### PR TITLE
Fail a release whose tag disagrees with pyproject's version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,21 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+      # The tag and pyproject's version are edited at different times, so
+      # they drift. Unchecked, that fails in two unhelpful ways: a tag ahead
+      # of the version builds the OLD version and PyPI rejects it as
+      # already-existing (safe, but the error names the wrong problem), and a
+      # version ahead of the tag simply never publishes, with no signal at
+      # all. Fail here instead, naming both values.
+      - name: Tag must match the version in pyproject.toml
+        run: |
+          v=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "v$v" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject version $v"
+            echo "Bump version in pyproject.toml, or retag to v$v."
+            exit 1
+          fi
+          echo "tag ${GITHUB_REF_NAME} matches pyproject version $v"
       - name: Build sdist and wheel
         run: |
           pip install build

--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ to.
 
 Design history lives in [docs/superpowers/specs/](docs/superpowers/specs/).
 
+## Releasing
+
+Releases are triggered by pushing a tag, and published to PyPI by
+[trusted publishing](https://docs.pypi.org/trusted-publishers/) — there is
+no API token stored anywhere.
+
+1. Land the changes on `main` in the usual way (branch, PR, review).
+2. Bump `version` in `pyproject.toml`. **This is a separate step from the
+   tag, which is why they drift** — CI refuses a tag that disagrees with it.
+3. Tag and push:
+
+       git tag vX.Y.Z && git push origin vX.Y.Z
+
+4. Watch `publish.yml`. It verifies the tag against `pyproject.toml`, builds
+   the sdist and wheel, and uploads.
+5. Bump the pin in any campaign that depends on this package, in its own
+   commit, so the upgrade is deliberate and its drift guard can report what
+   changed underneath it.
+
+Note that PyPI never releases a name and never lets a version number be
+reused, even after deletion — so step 2 is the one to get right.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Closes #3.

**Base is `main`.** First PR in this repository.

## The problem
The tag and `pyproject.toml`'s version are edited at different moments, so they drift. Nothing checked that they agreed, which failed two unhelpful ways:

- **Tag ahead of the version** — builds the *old* version; PyPI rejects it as already-existing. Safe, but the error names a file conflict rather than the actual mistake.
- **Version ahead of the tag** — nothing fires at all. No signal, and the repo looks like it shipped. This is the worse one: a silent no-op is harder to notice than a red workflow.

## The fix
A guard before the build that names both values:

```yaml
      - name: Tag must match the version in pyproject.toml
        run: |
          v=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
          if [ "v$v" != "${GITHUB_REF_NAME}" ]; then
            echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject version $v"
            echo "Bump version in pyproject.toml, or retag to v$v."
            exit 1
          fi
```

`tomllib` is stdlib on the workflow's Python 3.13, so no dependency is added — consistent with the package's zero-runtime-dependency rule.

**Verified in all four cases** (logic run locally against the real `pyproject.toml`):

| tag | version | result |
|---|---|---|
| `v0.1.0` | 0.1.0 | pass |
| `v0.2.0` | 0.1.0 | fail |
| `v0.0.9` | 0.1.0 | fail |
| `0.1.0` (no `v`) | 0.1.0 | fail |

## Also: the release checklist
The issue noted that a guard catches the mismatch but a checklist is what stops it happening. Added a **Releasing** section to the README covering the full sequence — land, bump, tag, watch, then bump the pin in any consuming campaign — and recording that PyPI never releases a name or permits reuse of a version number, even after deletion.

## Test expectations
None. Suite **436** OK; the workflow change cannot be exercised until the next tag, by design.

## Provenance
- Agent: Claude Code (VS Code extension)
- Model / version: transcript set Opus 5 (`/model opus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)