### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Prepares the 0.1.1 release. **Base is `main`.**

## What 0.1.1 contains
Two changes merged after v0.1.0 and unreleased since:

| commit | issue | effect |
|---|---|---|
| Speak the console-script form in everything a user reads | closes #2 | `--help` usage lines now print the command actually typed; the doctrine and stubs `init` writes say `bunnyforge review checkup` rather than `python3 -m bunnyforge.review checkup` |
| Fail a release whose tag disagrees with pyproject's version | closes #3 | CI guard; no user-visible change |

The invocation sweep is the reason to release: those strings live in packaged `data/`, so they reach nobody until a version ships.

## Why patch, not minor
No interface added, removed, or renamed. Every subcommand, flag, and config key is unchanged; what changes is the text the tool prints and the doctrine it writes into new workspaces.

## Verification
- Suite **436** OK.
- The new guard dry-run against this version: `v0.1.1` passes, `v0.1.0` and `v0.2.0` both fail — so the tag it is about to gate is correct, and a mismatched one would be caught.

## Next steps after merge
Tag `v0.1.1` and push it (fires `publish.yml` → PyPI via trusted publishing), then smoke-test in a clean venv, then bump the pin in the consuming campaign — where its drift guard will report the changed `AGENTS.md` for adoption.

## Provenance
- Agent: Claude Code (VS Code extension)
- Model / version: transcript set Opus 5 (`/model opus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)