### PR TITLE
Release checklist: warn about PyPI index lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,44 @@ no API token stored anywhere.
 
 4. Watch `publish.yml`. It verifies the tag against `pyproject.toml`, builds
    the sdist and wheel, and uploads.
-5. Bump the pin in any campaign that depends on this package, in its own
+5. Confirm the release is actually **installable**, in a clean virtualenv on
+   a path holding no checkout:
+
+       pip install bunnyforge==X.Y.Z
+       pip show bunnyforge          # check the version it really installed
+
+   Check the version it reports rather than trusting the workflow's green
+   tick — see the note on index lag below.
+6. Bump the pin in any campaign that depends on this package, in its own
    commit, so the upgrade is deliberate and its drift guard can report what
    changed underneath it.
 
 Note that PyPI never releases a name and never lets a version number be
 reused, even after deletion — so step 2 is the one to get right.
+
+### Index lag, right after a release
+
+For a few minutes after a successful publish, PyPI may still serve the
+*previous* version to some clients. Expect any of these, and do not go
+looking for a bug:
+
+- `pip install bunnyforge` quietly installs the older version — which is why
+  step 5 checks what actually landed rather than assuming;
+- a consuming project's CI fails with
+
+      ERROR: Could not find a version that satisfies the requirement
+      bunnyforge==X.Y.Z (from versions: <older>)
+
+  on a clean runner with no cache involved.
+
+The fix is to wait a few minutes and re-run. Two things that mislead here:
+`https://pypi.org/pypi/bunnyforge/json` can report the new version while the
+simple index a given client reaches has not caught up, and `--no-cache-dir`
+does not help, because the staleness is not local. Different machines
+disagree at the same moment.
+
+All three of these were observed within minutes of one release; each
+resolved on its own with no change.
 
 ## License
 


### PR DESCRIPTION
Closes #8. **Base is `main`.** Documentation only.

## Why
Publishing a version and immediately bumping a consumer's pin races PyPI's index propagation. During the 0.1.1 release this bit **three times within minutes** of a green publish workflow:

1. A plain `pip install bunnyforge` in a clean venv installed **0.1.0** — the release was nearly reported as verified when the new content had not shipped.
2. The local pin install in the consuming campaign failed outright.
3. The consumer's **CI** failed on a clean runner, no cache involved:

   ```
   ERROR: Could not find a version that satisfies the requirement
   bunnyforge==0.1.1 (from versions: 0.1.0)
   ```

All three cleared on their own within minutes. Nothing was wrong; a re-run passed unchanged.

The third is the expensive one — a red check on a pin-bump PR reads as a broken PR, and *"no matching distribution"* names a missing package rather than a timing problem. It invites debugging something that is not there.

## What changed
- **New step 5**: verify the release is actually installable in a clean venv, and **check the version pip really installed** rather than trusting the workflow's green tick. (Pin-bumping moves to step 6.)
- **New subsection, "Index lag, right after a release"**: names both symptoms and the fix (wait, re-run), plus the two things that actively mislead —
  - `https://pypi.org/pypi/bunnyforge/json` can report the new version while the simple index a given client reaches has not propagated;
  - `--no-cache-dir` does not help, because the staleness is not local. Different machines disagree at the same moment.

## Deliberately not doing
Retry logic in CI — a `pip install` retry loop or a wait-for-index step. That trades a clear transient failure for a slower, mushier one, for an event that is rare and self-correcting. Worth revisiting only if releases become frequent enough that manual re-runs are a burden.

## Test expectations
None. Suite **436** OK.

## Provenance
- Agent: Claude Code (VS Code extension)
- Model / version: transcript set Opus 5 (`/model opus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)