### PR TITLE
deploy-export: JSON-RPC transport, dry-run/--go convention, wiki-remote check (#7)

### DIFF
--- a/.github/workflows/live-wiki-canary.yml
+++ b/.github/workflows/live-wiki-canary.yml
@@ -1,0 +1,81 @@
+name: live-wiki-canary
+
+# WHAT THIS IS. A weekly canary that runs tests/live_wiki_check.py --go
+# against a REAL DokuWiki install, over the network, using repo secrets. It
+# exists to catch WIKI-SIDE drift that no unit test can ever see, because the
+# rest of this suite is offline by design (see live_wiki_check.py's module
+# docstring) and never touches a socket: a DokuWiki upgrade changing how
+# core.getPage reports a missing page, or a host changing how it handles the
+# Authorization header (some run PHP as CGI/FastCGI and strip it). Both bugs
+# have happened for real; both are why this script -- and this canary -- exist.
+#
+# WHAT THIS IS NOT. A substitute for the unit suite in tests.yml. That suite
+# is the real correctness gate and runs on every push and pull request; this
+# canary only proves the live install still behaves the way that suite
+# assumes. It is deliberately NOT wired to `push` or `pull_request`: GitHub
+# withholds secrets from a forked pull request's workflow runs, so a
+# secrets-requiring check on `pull_request` would be permanently red on every
+# outside contribution with no way for the contributor to fix it.
+#
+# NON-BLOCKING, ON PURPOSE. This repo has no branch protection today, so
+# nothing here blocks a merge either way. The job is written to genuinely
+# fail (not continue-on-error) when the live check fails, so a real failure
+# shows red and is visible -- silencing it would defeat the point of a
+# canary. The only thing allowed to make this NOT fail is missing
+# configuration (see below), never a check that actually ran and failed.
+on:
+  schedule:
+    # Sundays 06:00 UTC -- a quiet time, chosen only to avoid contention with
+    # any other scheduled activity; there is nothing campaign-specific about
+    # the choice.
+    - cron: "0 6 * * 0"
+  workflow_dispatch: {}
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      # Secrets cannot be tested in a job-level `if:`, so gate every
+      # meaningful step on this step's output instead. Missing secrets are
+      # a configuration state (a fork, or before the owner sets them up),
+      # not a failure -- printing a notice and exiting 0 here is what keeps
+      # this canary from going red on absent configuration, which would be
+      # noise that erodes trust in a genuine failure later.
+      - name: Check required secrets
+        id: check
+        env:
+          WIKI_URL: ${{ secrets.WIKI_URL }}
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+          WIKI_NAMESPACE: ${{ secrets.WIKI_NAMESPACE }}
+        run: |
+          if [ -z "$WIKI_URL" ] || [ -z "$WIKI_TOKEN" ] || [ -z "$WIKI_NAMESPACE" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=live-wiki-canary skipped::One or more of the WIKI_URL, WIKI_TOKEN, WIKI_NAMESPACE repository secrets is not set, so this canary has nothing to run against. Configure all three in the repo's Settings -> Secrets and variables -> Actions to enable it. Skipping (not failing) is deliberate: absent configuration is not a check failure."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@v7
+        if: steps.check.outputs.configured == 'true'
+      - uses: actions/setup-python@v7
+        if: steps.check.outputs.configured == 'true'
+        with:
+          # One pinned version: this canary checks a live install's
+          # behaviour, not this package's compatibility across interpreters
+          # -- that matrix already lives in tests.yml.
+          python-version: "3.13"
+      # Stdlib only at runtime; the install is the package itself (editable).
+      - name: Install bunnyforge
+        if: steps.check.outputs.configured == 'true'
+        run: pip install -e .
+      # --go runs the full battery (1-11), not just the read-only subset
+      # (1-3): the write, drift-holdback, --overwrite, and adopt checks are
+      # what would actually catch the wiki-side regressions this canary
+      # exists for, and the read-only checks alone would not exercise them.
+      - name: Live-wiki check (--go)
+        if: steps.check.outputs.configured == 'true'
+        env:
+          WIKI_URL: ${{ secrets.WIKI_URL }}
+          WIKI_NAMESPACE: ${{ secrets.WIKI_NAMESPACE }}
+          BUNNYFORGE_WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+        run: |
+          python3 tests/live_wiki_check.py --wiki-url "$WIKI_URL" --namespace "$WIKI_NAMESPACE" --go

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Your campaign is a directory of Markdown files with front matter: NPCs,
 factions, places, sessions, mechanics. bunnyforge gives that directory a
 skeleton, reviews its integrity, generates names from culture inventories
 you define, and exports the player-visible slice to DokuWiki. Everything
-is a text file; everything works offline; the only state is your git
-history.
+is a text file; the only state is your git history. Every command works
+offline except the wiki deploy itself — and even that keeps a fully
+offline path via `deploy-export --render-only`.
 
 - **Python ≥ 3.11, zero runtime dependencies.**
 - **Agent-first doctrine.** `init` writes an `AGENTS.md` contract that

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ entity files from the templates in `_Templates/`.
 | `init` | scaffold a new campaign workspace |
 | `review` | run a named workspace review suite (`checkup`, `wiki`) |
 | `export-player` | write player-safe copies of content files to `Export/` |
-| `deploy-export` | render `Export/` into a DokuWiki staging tree |
+| `deploy-export` | render `Export/` and deploy it to the wiki (dry run by default) |
 | `import-perceptions` | import player-authored wiki pages into `Perceptions/` |
 | `build-sheets` | build one-page HTML reference sheets for a session |
 | `names` | generate culture-appropriate names |
@@ -80,11 +80,22 @@ registers and spelling variants.
 
 ## DokuWiki export
 
-`export-player` renders the player-visible slice; `deploy-export` pushes
-it into a DokuWiki staging tree. Sync is strictly one-way: the wiki is a
-published artifact, never a source of truth. `import-perceptions` brings
-player-authored pages back as *perceptions* — recorded belief, explicitly
-not canon.
+`export-player` renders the player-visible slice; `deploy-export` renders it
+into DokuWiki markup and deploys it to the wiki over its JSON-RPC API. Sync
+is strictly one-way: the wiki is a published artifact, never a source of
+truth. `import-perceptions` brings player-authored pages back as
+*perceptions* — recorded belief, explicitly not canon.
+
+## Dry runs and --go
+
+Every mutating command follows one convention: **the default run is a dry
+run; `--go` performs the writes.** A bare `bunnyforge deploy-export` fetches
+and prints the full deploy plan without writing anything; a bare
+`bunnyforge import-perceptions` reports what it would import. Re-run with
+`--go` to act. (`deploy-export --render-only` is not a rehearsal — it is a
+different, offline deliverable, and needs no wiki config at all.)
+
+Future mutating commands inherit this convention.
 
 ## Development
 

--- a/docs/superpowers/specs/2026-07-27-player-wiki-export-design.md
+++ b/docs/superpowers/specs/2026-07-27-player-wiki-export-design.md
@@ -1,5 +1,15 @@
 # Player-facing wiki export (design)
 
+> **Partially superseded (2026-08-05):** the transport half of this design
+> (sequencing steps 6–8: rsync, `receive_export.sh`, `indexer.php`, the
+> server-side `manifest.json`) is superseded by
+> [2026-08-05-deploy-export-rpc-transport-design.md](2026-08-05-deploy-export-rpc-transport-design.md),
+> which replaces it with DokuWiki's JSON-RPC API. The render half — namespace
+> layout, wrapper format, ACL design, wikilink rewriting, leak-test posture —
+> is shipped and untouched. The drift guarantee carries over verbatim; the
+> open absolute-link verification item carries into the new spec's
+> first-deploy checklist.
+
 > **Provenance:** a scrubbed copy of a development record from the
 > private campaign repository where this tool was first built. Campaign
 > identifiers are neutralised throughout; the verbatim original stays in

--- a/docs/superpowers/specs/2026-07-27-player-wiki-export-design.md
+++ b/docs/superpowers/specs/2026-07-27-player-wiki-export-design.md
@@ -18,8 +18,11 @@
 **Date:** 2026-07-27
 **Status:** **render half implemented and shipped** (Plan A `ecdabe4`; wikilink
 rewriting `a10f3a8`, issue #17; markdown-link policy #23, issue #21). Transport
-(sequencing steps 6–8) is **not built** — `deploy_export` still refuses anything
-but `--render-only`. See "Sequencing" for what is done and what is not.
+(sequencing steps 6–8) as designed in this document was never built. See the
+supersession note above: `deploy_export` shipped a different transport in its
+place (DokuWiki's JSON-RPC API), so `--render-only` is no longer the only
+supported mode. See "Sequencing" for what this document's own plan completed
+and what it did not.
 
 ## Purpose
 

--- a/docs/superpowers/specs/2026-08-05-deploy-export-rpc-transport-design.md
+++ b/docs/superpowers/specs/2026-08-05-deploy-export-rpc-transport-design.md
@@ -64,6 +64,32 @@ Facts this design builds on, verified on a real `2026-07-14a "Mort"` install
   right shape for a deploy tool: scopable, revocable without a password
   change, never the owner's login.
 
+**Verified against a live deploy attempt (2026-08-05), JSON-RPC API version
+14** — the first real run surfaced three assumptions above that did not
+survive contact:
+
+- **`core.getAPIVersion()` returns 14** on the target install.
+- **A missing page returns `""` with a *success* error object** —
+  `{"code": 0, "message": "success"}` — never error 121. 121 does not occur on
+  this build at all. `get_page` now treats an empty result the same as 121
+  (see the client section below); the "First-live-deploy checklist" item this
+  answered is recorded there.
+- **`Authorization: Bearer <token>` alone is unusable on hosts where PHP runs
+  as CGI/FastCGI** — Apache strips the header before PHP sees it. On the
+  target host, DokuWiki's `getallheaders()` returned every other header but
+  no `Authorization`, so its `$_SERVER` fallback (which only runs when
+  `getallheaders()` itself is empty) never triggered either — no `.htaccess`
+  or `preload.php` normalisation fixes this from this side.
+  **`X-DokuWiki-Token: <token>` is not special-cased by Apache and arrives
+  intact**, and DokuWiki's `auth_tokenlogin()` prefers it over `Authorization`
+  when both are present. The client now sends both headers.
+- **The two authentication failure modes are distinguishable and both
+  reachable over JSON-RPC**: no credential at all is HTTP 401 / RPC code
+  `-32603` (`AccessDeniedException` with no `REMOTE_USER`); a credential that
+  is valid but lacks permission for the method is HTTP 403 / RPC code
+  `-32604` (`REMOTE_USER` present). The error table now gives both their own
+  entry instead of leaving `-32603` to the "unrecognised code" fallback.
+
 ## Scope
 
 **In:** transport in `deploy_export.py`; a new `_dokuwiki_rpc.py` client; a
@@ -106,7 +132,11 @@ Missing both → instructional error naming both sources and where a token
 comes from (the wiki user's profile → API token). A rejected credential is a
 server-side answer and is translated per the error table (`-32604`).
 
-Sent as `Authorization: Bearer <token>`. HTTP Basic is deliberately not
+Sent as both `Authorization: Bearer <token>` and `X-DokuWiki-Token: <token>`
+(verified live, 2026-08-05 — see above: some hosts strip `Authorization`
+before PHP ever sees it, and `X-DokuWiki-Token` is what survives there).
+Sending both is strictly more compatible than either alone and costs nothing
+on a host where `Authorization` already works. HTTP Basic is deliberately not
 supported: one auth path is one to test, and a token is strictly better for
 this job. Plain `http://` URLs are refused — the token would cross the wire
 in clear — except for localhost, which keeps a local test install usable.
@@ -164,12 +194,17 @@ install over the wire. Stdlib only; imports nothing from `_config` — it takes
   bookkeeping.
 - **Success test:** `error` absent, `null`, or `code == 0` — never
   key-presence.
-- Headers: `Authorization: Bearer <token>`, `Content-Type: application/json`,
-  `User-Agent: bunnyforge/<version>`. One timeout (default 30s). Standard TLS
-  verification, no knob to disable it.
+- Headers: `Authorization: Bearer <token>` **and** `X-DokuWiki-Token: <token>`
+  (both, verified live — some hosts strip `Authorization` before PHP ever
+  sees it; `X-DokuWiki-Token` is what survives there), `Content-Type:
+  application/json`, `User-Agent: bunnyforge/<version>`. One timeout (default
+  30s). Standard TLS verification, no knob to disable it.
 - Surface: `call(method, params)` plus three typed wrappers:
-  - `get_page(id) -> str | None` — `None` for "does not exist" (error 121
-    translated internally; it is a state, not a failure);
+  - `get_page(id) -> str | None` — `None` for "does not exist": an empty
+    result (verified live — the missing-page response on API 14) or error
+    121 (older builds; kept, costs nothing). Safe rather than a heuristic:
+    `core.savePage` refuses to create an empty page (error 132), so a page
+    cannot simultaneously be empty and exist;
   - `save_page(id, text, summary)` — every save carries the change summary
     `bunnyforge deploy-export`, so wiki history shows provenance.
 
@@ -285,17 +320,21 @@ design; `-32605` and `-32606` verified live.
 | DNS failure / connection refused / timeout (`URLError`) | the URL from `[wiki]`, and that it is a connectivity or config problem, not a wiki fault |
 | HTTP 404 at the endpoint | no JSON-RPC endpoint — DokuWiki too old (the minimum release, pinned during implementation) or wrong base URL |
 | `-32605` | "your wiki's remote API is disabled; set `$conf['remote'] = 1` in `conf/local.php`, not `conf/dokuwiki.php`" — on the critical path: `remote` defaults to 0, so every new user hits this on their first deploy |
-| `-32604` | not authorized: check the token (`BUNNYFORGE_WIKI_TOKEN` / `.bunnyforge/wiki-token`) and that the API user is within `$conf['remoteuser']` |
+| `-32603` | not authenticated — the wiki received no usable credential (HTTP 401, `AccessDeniedException` with no `REMOTE_USER`); names the common non-obvious cause — some hosts strip `Authorization` when PHP runs as CGI/FastCGI, and bunnyforge also sends `X-DokuWiki-Token` for exactly that reason — and points at the token (`BUNNYFORGE_WIKI_TOKEN` / `.bunnyforge/wiki-token`) and `$conf['remoteuser']` |
+| `-32604` | authenticated but forbidden — the credential was accepted but this user may not call the method (HTTP 403, `AccessDeniedException` with `REMOTE_USER` set); points at `$conf['remoteuser']` and the wiki's ACL |
 | `111` | the wiki's ACL denies this user on `<page-id>` — grant the deploy user edit on the campaign namespace |
 | `133` | page locked by an editing session — retry after the lock expires (default 15 minutes) |
 | `134` | content blocked by the wiki's wordblock blacklist, naming the page |
 | `-32606`, `-32700`, `-32602`, `131`, `132` | "bug in bunnyforge, please report" — client-side defects a user should never see |
 | anything else | method, code, raw message, "unrecognised code — please report" |
 
-`121` never reaches the user — it is the internal "does not exist" signal.
-`-32603`'s meaning differs between DokuWiki's layers (method-not-found at the
-API layer, internal error in the standard), which is exactly why unknown
-codes print raw rather than guessing.
+`121` never reaches the user — it is the internal "does not exist" signal,
+alongside an empty `core.getPage` result (verified live, see above). The
+spec had deferred `-32603` as ambiguous between DokuWiki's layers; the
+JSON-RPC server's own source (`inc/Remote/JsonRpcServer.php`) resolves that
+ambiguity at this layer — `-32603` is unauthenticated, `-32604` is
+authenticated-but-forbidden — so both now get a named entry instead of
+falling through to "unrecognised code, please report it."
 
 ## `review wiki` gains `wiki-remote`
 
@@ -321,8 +360,10 @@ from prose — green on 3.11, 3.12, and 3.13.
 
 - **Client** — injected transport; all three success shapes (`error` absent /
   `null` / `code 0` — the key-presence trap pinned by a test), each
-  translated error code, Bearer and Content-Type headers on the request,
-  `121 → None` in `get_page`, timeout and `URLError` translation,
+  translated error code (including `-32603` vs `-32604`, distinguished per
+  the live source), Bearer, `X-DokuWiki-Token`, and Content-Type headers on
+  the request (both credential headers unredirected), `121 → None` and
+  `"" → None` in `get_page`, timeout and `URLError` translation,
   non-localhost `http://` refusal.
 - **Planner** — the classification is a pure function
   `(target_bytes, wiki_text, manifest_hash) → action`; one table-driven test
@@ -365,27 +406,22 @@ mismatch), expecting PyPI index lag before the campaign repo can re-pin.
 ## First-live-deploy checklist
 
 Named here because no test can cover them; each is checked on the first real
-deploy before being trusted:
+deploy before being trusted. One item originally on this list — whether
+`core.getPage` on a missing page returns error 121 or `""` — is answered and
+removed from the open list below; the finding is recorded under "Verified
+against a live deploy attempt (2026-08-05)" above, and `get_page` and its
+tests were updated accordingly. Renumbered:
 
-1. `core.getPage` on a page ID that does not exist returns error **121**, not
-   an empty string. "Verified against the live target" only recorded that
-   `core.getPage` exists, never what it returns for a missing page; `get_page`
-   treats only error 121 as "no page", and three of the eight
-   classification-matrix rows depend on that. If the live install returns
-   `""` instead, `new` becomes `drift-manual-era` (the first deploy writes
-   nothing and holds every page back), `deleted-on-wiki` becomes `drift`, and
-   resolved orphans never resolve. Loud and non-destructive, but it is the
-   very first thing a user hits.
-2. `~~NOTOC~~` placeholder pages render blank and count as existing.
-3. The exact named-parameter spelling `core.savePage` expects in the
+1. `~~NOTOC~~` placeholder pages render blank and count as existing.
+2. The exact named-parameter spelling `core.savePage` expects in the
    simplified `PATH_INFO` form (verified against the live wiki, then pinned
    in the client's tests).
-4. The old spec's carried-forward item: a rewritten absolute link
+3. The old spec's carried-forward item: a rewritten absolute link
    (`[[<ns>:<dir>:<stem>|label]]`, no leading colon) resolves from the root
    when followed from *inside* an included page. First publication finally
    creates the wiki state needed to check it. Bounded risk: a navigation
    defect, not a leak — the link policy's refusals do not depend on it.
-5. The read-back hash equals a re-fetch a minute later (i.e. `get_page` is
+4. The read-back hash equals a re-fetch a minute later (i.e. `get_page` is
    stable after save; no lazy normalization on later reads).
 
 ## Out of scope, on the record

--- a/docs/superpowers/specs/2026-08-05-deploy-export-rpc-transport-design.md
+++ b/docs/superpowers/specs/2026-08-05-deploy-export-rpc-transport-design.md
@@ -307,6 +307,7 @@ copy and CI never needs a live wiki. Universal rules, naming no campaign:
 |---|---|
 | `remote` enabled but `remoteuser` unset or empty — every wiki account can call the API | error |
 | `remote` enabled from `conf/dokuwiki.php` — one upgrade from silently reverting | error (mirrors the `useacl` provenance rule) |
+| `remoteuser` set to a real value but from `conf/dokuwiki.php` — one upgrade from reverting to the stock placeholder, handing every account the API back | error (the same provenance rule, applied to the setting that actually holds the security boundary; the placeholder case above wins when `!!not set!!` itself lives in `dokuwiki.php`) |
 | `remote` disabled | no finding — a disabled API is a legitimate secure state; the deploy's `-32605` translation owns that path |
 
 `remoteuser`'s stock value is the placeholder `!!not set!!`, which DokuWiki
@@ -366,16 +367,25 @@ mismatch), expecting PyPI index lag before the campaign repo can re-pin.
 Named here because no test can cover them; each is checked on the first real
 deploy before being trusted:
 
-1. `~~NOTOC~~` placeholder pages render blank and count as existing.
-2. The exact named-parameter spelling `core.savePage` expects in the
+1. `core.getPage` on a page ID that does not exist returns error **121**, not
+   an empty string. "Verified against the live target" only recorded that
+   `core.getPage` exists, never what it returns for a missing page; `get_page`
+   treats only error 121 as "no page", and three of the eight
+   classification-matrix rows depend on that. If the live install returns
+   `""` instead, `new` becomes `drift-manual-era` (the first deploy writes
+   nothing and holds every page back), `deleted-on-wiki` becomes `drift`, and
+   resolved orphans never resolve. Loud and non-destructive, but it is the
+   very first thing a user hits.
+2. `~~NOTOC~~` placeholder pages render blank and count as existing.
+3. The exact named-parameter spelling `core.savePage` expects in the
    simplified `PATH_INFO` form (verified against the live wiki, then pinned
    in the client's tests).
-3. The old spec's carried-forward item: a rewritten absolute link
+4. The old spec's carried-forward item: a rewritten absolute link
    (`[[<ns>:<dir>:<stem>|label]]`, no leading colon) resolves from the root
    when followed from *inside* an included page. First publication finally
    creates the wiki state needed to check it. Bounded risk: a navigation
    defect, not a leak — the link policy's refusals do not depend on it.
-4. The read-back hash equals a re-fetch a minute later (i.e. `get_page` is
+5. The read-back hash equals a re-fetch a minute later (i.e. `get_page` is
    stable after save; no lazy normalization on later reads).
 
 ## Out of scope, on the record

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.1.1"
+version = "0.2.0"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -180,10 +180,17 @@ Exports player-authored wiki pages into `Perceptions/`, marked
 Reads DokuWiki's flat files rather than its API, because `data/attic/` keeps
 every historical revision — which makes exact session-boundary snapshots free.
 
+Follows the package-wide dry-run convention: the default run only reports what
+it would write; pass `--go` to actually write. **Breaking, pre-1.0:** earlier
+versions took a `--dry-run` flag with the opposite default (writing unless
+`--dry-run` was passed). `--dry-run` no longer exists — a bare invocation is
+now the rehearsal, and `--go` is what writes.
+
 ```sh
-python3 -m bunnyforge.import_perceptions --wiki-data /path/to/dokuwiki/data
-python3 -m bunnyforge.import_perceptions --wiki-data ... --namespace party
-python3 -m bunnyforge.import_perceptions --wiki-data ... --as-of 2026-03-14
+python3 -m bunnyforge.import_perceptions --wiki-data /path/to/dokuwiki/data          # dry run
+python3 -m bunnyforge.import_perceptions --wiki-data ... --go
+python3 -m bunnyforge.import_perceptions --wiki-data ... --namespace party --go
+python3 -m bunnyforge.import_perceptions --wiki-data ... --as-of 2026-03-14 --go
 ```
 
 `--as-of YYYY-MM-DD` captures each page as it stood on that date, suffixing the
@@ -219,10 +226,32 @@ wikilink policy. There is no separate handout publisher.
 ## deploy_export.py
 
 Renders `Export/` into a DokuWiki page tree — content pages in DokuWiki markup
-plus include-wrappers — ready to be copied onto the wiki.
+plus include-wrappers — and deploys it to the wiki over DokuWiki's JSON-RPC
+API. Three invocations:
+
+| invocation | what it does |
+|---|---|
+| `deploy_export.py` | **Dry run (the default).** Render, fetch the wiki's current state, print the full deploy plan — including pages held back for drift. Writes nothing to the wiki, makes no manifest change. |
+| `deploy_export.py --go` | Same plan, then perform the writes it calls for and update the manifest. |
+| `deploy_export.py --render-only --staging PATH` | Render only, offline. No `[wiki]` config and no token needed; unchanged from before this pipeline could deploy at all. |
 
     python3 -m bunnyforge.export_player
+    python3 -m bunnyforge.deploy_export                          # dry run
+    python3 -m bunnyforge.deploy_export --go                     # deploy
     python3 -m bunnyforge.deploy_export --render-only --staging /tmp/stage
+    python3 -m bunnyforge.deploy_export --go --overwrite <ns>:npcs:<stem>
+
+`--staging` is optional in the default and `--go` modes — a temporary
+directory is used and removed at exit, so a stale tree can never be pushed —
+and required with `--render-only`, where the staged tree is the deliverable.
+Whenever `--staging` is given, it must be a fresh or empty directory: a
+pre-existing, non-empty staging tree is refused rather than rendered into,
+since a page dropped from this run (e.g. flipped to `gm-only` since the last
+run) would otherwise survive untouched from the previous run while this run
+still reports success.
+
+`--overwrite <page-id>` (repeatable) writes a held-back page anyway and
+re-baselines it; see "Drift" below. It only takes effect with `--go`.
 
 Each exported file becomes two pages: `<ns>:export:<dir>:<stem>` holding the
 converted content, and `<ns>:<dir>:<stem>` holding two Include directives —
@@ -231,13 +260,62 @@ and this pipeline never writes. `<ns>:main` is hand-written on the wiki and
 is never wrapped or overwritten. `<ns>` is `campaign.namespace` from
 `campaign.toml`.
 
-Transport to the server is not implemented yet; `--render-only` is currently
-required.
+### Connecting to the wiki
 
-`--staging` must be a fresh or empty directory. A pre-existing, non-empty
-staging tree is refused rather than rendered into, since a page dropped from
-this run (e.g. flipped to `gm-only` since the last run) would otherwise
-survive untouched from the previous run while this run still reports success.
+Any mode but `--render-only` needs a `[wiki]` table in `campaign.toml` naming
+the wiki's **base URL** — the client appends `lib/exe/jsonrpc.php` itself, so
+do not include it:
+
+```toml
+[wiki]
+url = "https://<wiki>"
+```
+
+`https://` is required. A plain `http://` URL is refused — the token would
+cross the wire in clear — except for `localhost`, `127.0.0.1`, or `::1`,
+where a local test install has nothing to leak.
+
+It also needs a DokuWiki API token, resolved in order:
+
+1. the `BUNNYFORGE_WIKI_TOKEN` environment variable, or
+2. a single line in `<workspace>/.bunnyforge/wiki-token`.
+
+The token file is refused, with a `chmod 600 <path>` instruction, if it is
+readable by group or world — a wiki credential must be private. Create the
+token on the wiki itself: log in as the deploy user, open its profile, and
+generate an API token there.
+
+### The manifest
+
+`<workspace>/.bunnyforge/wiki-manifest.json` records the hash of what this
+tool last wrote for every page it deployed. It is **committed** to the
+campaign repo, not gitignored: deploying from a second machine then sees the
+true baseline, and the post-deploy diff is reviewable in the repo's own git
+history like any other change.
+
+### Drift
+
+A page changed on the wiki since the last deploy is **held back**, never
+silently overwritten: the plan reports it with a unified diff against the
+staged target, and its current wiki text is written to
+`<workspace>/.bunnyforge/wiki-drift/` for manual merge (recreated from empty
+on every planning run, so a page that stops drifting leaves no stale copy
+behind). Resolve a held-back page either by pulling the wiki edit into the
+workspace source — the next render then matches and the drift disappears —
+or by re-running with `--overwrite <page-id> --go` to clobber it and
+re-baseline.
+
+### Orphans
+
+A manifest entry no longer staged (the source file was deleted, or flipped
+to `gm-only`) is **reported as an orphan, never deleted** — removing the wiki
+page is a manual act this tool does not automate. If the page was already
+deleted on the wiki by hand, it is reported as resolved instead and drops
+from the manifest on `--go`.
+
+The exit code is non-zero if anything was held back or any orphan was
+reported, in both dry-run and `--go` modes — a clean plan is the only way to
+see exit 0.
 
 **Known limitations.** `to_dokuwiki`'s emphasis handling (`*text*`, `**text**`)
 is line-scoped: an emphasis span crossing a line break is left as literal
@@ -347,6 +425,12 @@ unit test could have caught:
   page design is composed of its directives.
 - `useheading` must be set to something truthy, or wrapper pages display raw
   page IDs instead of their included heading.
+- If the remote (JSON-RPC) API is enabled, it must be **scoped**: `remote`
+  itself must be set in `conf/local.php`, not the upgrade-overwritten
+  `conf/dokuwiki.php`, and `remoteuser` must name the deploy user rather than
+  being left unset — an unset `remoteuser` lets every wiki account call the
+  API. A disabled remote API is a legitimate secure state and raises nothing;
+  this only fires once `deploy-export` is meant to be usable.
 
 `checkup` never includes these checks, so CI — which has no wiki — is
 unaffected. Everything is read from the install's files directly; there is no

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -436,6 +436,34 @@ any form, not even their filename appears". The run summary therefore lists
 every placeholder page ID it wrote; read that list before copying the staging
 tree onto the wiki.
 
+### Live wiki check
+
+`tests/live_wiki_check.py` is an opt-in, human-invoked script that exercises
+this transport against a **real** DokuWiki install — the same kind of
+confidence `tests/check_portability.py` gives a culture author, but for the
+deploy transport. It is not a `unittest` test: `unittest discover`'s default
+pattern is `test*.py`, so this file is never collected, and it **never runs
+in CI or the normal test suite** — every other test in this suite is
+offline by design, and that posture never changes.
+
+```sh
+PYTHONPATH=src python3 tests/live_wiki_check.py --workspace PATH            # read-only checks
+PYTHONPATH=src python3 tests/live_wiki_check.py --workspace PATH --go       # full battery, writes to the wiki
+```
+
+Without `--go` it runs three read-only checks (the auth handshake, the
+missing-page contract, and the protected-page guard) and writes nothing.
+With `--go` it also deploys, edits, drift-tests, `--overwrite`s, and
+resume-after-crash-tests a small probe page under `<ns>:live-wiki-check:` —
+using its own temporary workspace and manifest, never the real
+`<workspace>/.bunnyforge/wiki-manifest.json` — and probes two RPC edge
+cases (`core.savePage` refusing an empty page; the `~~NOTOC~~` placeholder
+body saving as non-empty). Every write check reuses the same handful of
+stable page IDs, so running it repeatedly updates those same pages in place
+rather than piling up new ones. **This tool cannot delete wiki pages**, so
+neither can this script — it prints the page IDs it touched at the end, and
+removing them, if ever wanted, is a manual act on the wiki itself.
+
 ## review.py
 
 Runs a named suite of workspace checks on demand.

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -295,15 +295,35 @@ history like any other change.
 
 ### Drift
 
-A page changed on the wiki since the last deploy is **held back**, never
-silently overwritten: the plan reports it with a unified diff against the
-staged target, and its current wiki text is written to
+A staged page is **held back**, never silently overwritten, for any of three
+reasons:
+
+- **drift** — the page changed on the wiki since the last deploy: the wiki's
+  current text no longer matches the hash this tool recorded, and it also
+  differs from what would now be deployed.
+- **drift-manual-era** — this page has no baseline in the manifest at all,
+  yet the wiki's current text differs from what would be deployed. This is
+  what fires on the **first** deploy against a wiki that already has content
+  from the old manual-copy workflow, or against any page edited by hand
+  outside this tool: with no recorded baseline the tool cannot tell what
+  changed, so it refuses to guess and holds the page back rather than
+  overwriting a page it never wrote itself.
+- **deleted-on-wiki** — the page is still staged (its source file is still
+  exported), but a human deleted the wiki page since the last deploy.
+  Recreating it would clobber that deletion decision, so it is held back
+  instead. This is distinct from an **orphan** (below): an orphan is a
+  manifest entry that has dropped *out of* the staged set — the source file
+  was removed, or its visibility changed — whereas `deleted-on-wiki` is a
+  page still being staged whose *wiki* copy is the one that's gone.
+
+For `drift` and `drift-manual-era` the plan reports a unified diff against
+the staged target, and the wiki's current text is written to
 `<workspace>/.bunnyforge/wiki-drift/` for manual merge (recreated from empty
 on every planning run, so a page that stops drifting leaves no stale copy
-behind). Resolve a held-back page either by pulling the wiki edit into the
-workspace source — the next render then matches and the drift disappears —
-or by re-running with `--overwrite <page-id> --go` to clobber it and
-re-baseline.
+behind); `deleted-on-wiki` has no wiki text to diff or copy. The resolution
+is the same for all three: either pull the wiki edit into the workspace
+source — the next render then matches and the drift disappears — or re-run
+with `--overwrite <page-id> --go` to clobber it and re-baseline.
 
 ### Orphans
 

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -282,6 +282,14 @@ too**, rather than followed. A wiki whose canonical URL redirects (apex to
 across a host change. Point `[wiki] url` at the wiki's canonical base URL —
 the JSON-RPC endpoint has no legitimate reason to redirect.
 
+Both credential headers are sent on every call: `Authorization: Bearer
+<token>` and `X-DokuWiki-Token: <token>`. Some hosts run PHP as CGI/FastCGI,
+which makes Apache strip `Authorization` before PHP ever sees it;
+`X-DokuWiki-Token` is not special-cased that way and is what actually works
+on such hosts, while keeping `Authorization` preserves compatibility with any
+build that only honours that one. See the troubleshooting note below if
+every call fails with `-32603`.
+
 It also needs a DokuWiki API token, resolved in order:
 
 1. the `BUNNYFORGE_WIKI_TOKEN` environment variable, or
@@ -293,6 +301,14 @@ directory is checked too: a `.bunnyforge/` writable by group or world is
 refused with `chmod 700 <path>`, because anyone who can write the directory
 can replace the credential inside it. Create the token on the wiki itself:
 log in as the deploy user, open its profile, and generate an API token there.
+
+**Troubleshooting: every call fails with `-32603`.** The wiki received no
+usable credential at all. The likely cause is the host running PHP as
+CGI/FastCGI, which makes Apache strip the `Authorization` header before PHP
+ever sees it — a hosting-config problem, not a bunnyforge bug. bunnyforge
+already sends `X-DokuWiki-Token` alongside `Authorization`, which usually
+survives on such hosts; if `-32603` persists, check the token itself and that
+the API user is within `$conf['remoteuser']`.
 
 ### The manifest
 

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -275,15 +275,24 @@ url = "https://<wiki>"
 cross the wire in clear — except for `localhost`, `127.0.0.1`, or `::1`,
 where a local test install has nothing to leak.
 
+That check can only vet the URL you configured, so **redirects are refused
+too**, rather than followed. A wiki whose canonical URL redirects (apex to
+`www`, or an `https` vhost that `301`s to `http`) would otherwise carry the
+`Authorization` header onto the redirect target: `urllib` forwards it even
+across a host change. Point `[wiki] url` at the wiki's canonical base URL —
+the JSON-RPC endpoint has no legitimate reason to redirect.
+
 It also needs a DokuWiki API token, resolved in order:
 
 1. the `BUNNYFORGE_WIKI_TOKEN` environment variable, or
 2. a single line in `<workspace>/.bunnyforge/wiki-token`.
 
 The token file is refused, with a `chmod 600 <path>` instruction, if it is
-readable by group or world — a wiki credential must be private. Create the
-token on the wiki itself: log in as the deploy user, open its profile, and
-generate an API token there.
+readable by group or world — a wiki credential must be private. Its
+directory is checked too: a `.bunnyforge/` writable by group or world is
+refused with `chmod 700 <path>`, because anyone who can write the directory
+can replace the credential inside it. Create the token on the wiki itself:
+log in as the deploy user, open its profile, and generate an API token there.
 
 ### The manifest
 
@@ -324,6 +333,15 @@ behind); `deleted-on-wiki` has no wiki text to diff or copy. The resolution
 is the same for all three: either pull the wiki edit into the workspace
 source — the next render then matches and the drift disappears — or re-run
 with `--overwrite <page-id> --go` to clobber it and re-baseline.
+
+The same guarantee holds **within** a single `--go` run. The plan fetches
+every page up front, so on a large campaign tens of seconds pass between a
+page being read and being written. Each page is therefore re-read immediately
+before its save, and a page whose wiki text changed in that window is
+reported `SKIPPED` and left alone — the run exits non-zero and the next plan
+reports it as ordinary drift, with a diff. This applies to `--overwrite`
+pages too: `--overwrite` consents to clobbering the diff the plan printed,
+and an edit that landed after that diff was never reviewed.
 
 ### Orphans
 

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -464,6 +464,45 @@ rather than piling up new ones. **This tool cannot delete wiki pages**, so
 neither can this script — it prints the page IDs it touched at the end, and
 removing them, if ever wanted, is a manual act on the wiki itself.
 
+`--workspace` is optional: `--wiki-url URL --namespace NS`, given together,
+run the same checks with no campaign workspace and no `campaign.toml` at
+all — this is how CI runs it (see below). The two must be given together;
+either alone is refused with an instructional error. The credential still
+resolves the same way as everywhere else in this package —
+`BUNNYFORGE_WIKI_TOKEN` first, else `<workspace>/.bunnyforge/wiki-token` —
+except that with no `--workspace` there is no token file to fall back to,
+so the environment variable is the only option; if it is unset, the script
+fails naming it.
+
+```sh
+BUNNYFORGE_WIKI_TOKEN=... PYTHONPATH=src python3 tests/live_wiki_check.py \
+    --wiki-url https://<wiki> --namespace <ns>            # read-only checks
+BUNNYFORGE_WIKI_TOKEN=... PYTHONPATH=src python3 tests/live_wiki_check.py \
+    --wiki-url https://<wiki> --namespace <ns> --go       # full battery
+```
+
+#### CI canary
+
+`.github/workflows/live-wiki-canary.yml` runs this script's full battery
+(`--go`) weekly against a real wiki, using three repository secrets:
+`WIKI_URL`, `WIKI_TOKEN` (passed to the script as `BUNNYFORGE_WIKI_TOKEN`),
+and `WIKI_NAMESPACE`. It is triggered by `schedule` and `workflow_dispatch`
+only — never `push` or `pull_request`, since GitHub withholds secrets from
+forked pull requests, which would make a secrets-requiring check
+permanently red on outside contributions. If any of the three secrets is
+unset, the job prints a notice naming them and exits successfully — a red
+check caused by missing configuration would be noise, not signal. The repo
+has no branch protection, so this job is deliberately not a required check
+either way: it is a canary, meant to fail loudly when it fails, not a merge
+gate, and it is not a substitute for the unit suite above, which is.
+
+Security notes for whoever configures the secrets: issue a **separate**
+DokuWiki API token for CI rather than reusing a human's local one, so it
+can be revoked independently without disturbing anyone's own setup, and
+keep the deploy user's ACL as narrow as this job actually needs (write
+access to its own `live-wiki-check` sub-path is enough — it never touches
+anything else).
+
 ## review.py
 
 Runs a named suite of workspace checks on demand.

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -16,6 +16,8 @@ Stdlib only. tomllib requires Python 3.11+.
 
 from __future__ import annotations
 
+import os
+import stat
 import tomllib
 from collections import namedtuple
 from pathlib import Path
@@ -33,11 +35,44 @@ Config = namedtuple(
     "Config",
     "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
     "exclude_dirs names_cultures names_official_culture names_spelling "
-    "briefs_dir sheets_dir perceptions_dir type_dirs")
+    "briefs_dir sheets_dir perceptions_dir type_dirs wiki_url",
+    defaults=[None])  # wiki_url only — [wiki] is optional and network-only
 
 
 class ConfigError(Exception):
     """campaign.toml is missing, malformed, or incomplete."""
+
+
+TOKEN_ENV = "BUNNYFORGE_WIKI_TOKEN"
+TOKEN_FILE = ".bunnyforge/wiki-token"
+
+
+def resolve_wiki_token(workspace_root: Path) -> str:
+    """The deploy credential, in resolution order: env var, then token file.
+
+    A DokuWiki API token, never a password — scopable, revocable without a
+    password change. A rejected credential is a server-side answer and is
+    translated by the RPC error table, not here.
+    """
+    env = os.environ.get(TOKEN_ENV, "").strip()
+    if env:
+        return env
+    path = workspace_root / TOKEN_FILE
+    if path.is_file():
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode & 0o077:
+            raise ConfigError(
+                f"{path} is readable by group or world (mode {mode:03o}) — "
+                f"a wiki credential must be private:\n  chmod 600 {path}")
+        token = path.read_text(encoding="utf-8").strip()
+        if token:
+            return token
+    raise ConfigError(
+        "no wiki API token found. Provide one via either:\n"
+        f"  - the {TOKEN_ENV} environment variable, or\n"
+        f"  - a single line in <workspace>/{TOKEN_FILE} (chmod 600)\n"
+        "Create one on the wiki: log in as the deploy user, open its "
+        "profile, and generate an API token.")
 
 
 # The three entity types build_sheets understands, and nothing else — an
@@ -140,6 +175,13 @@ def load(workspace: Path) -> Config:
     if not isinstance(spelling, dict):
         raise ConfigError(f"{path}: [names.spelling] must be a table")
 
+    wiki = raw.get("wiki", {})
+    if not isinstance(wiki, dict):
+        raise ConfigError(f"{path}: [wiki] must be a table")
+    wiki_url = wiki.get("url")
+    if wiki_url is not None and not isinstance(wiki_url, str):
+        raise ConfigError(f"{path}: wiki.url must be a string")
+
     entity_dirs = _str_tuple(ws, "entity_dirs")
     inherit_dirs = _str_tuple(ws, "inherit_dirs")
     # iter_content_files walks entity_dirs and then inherit_dirs, so a
@@ -170,6 +212,7 @@ def load(workspace: Path) -> Config:
         sheets_dir=_str(ws, "sheets_dir"),
         perceptions_dir=_str(ws, "perceptions_dir"),
         type_dirs=_type_dirs(ws),
+        wiki_url=wiki_url,
     )
 
 

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -59,6 +59,19 @@ def resolve_wiki_token(workspace_root: Path) -> str:
         return env
     path = workspace_root / TOKEN_FILE
     if path.is_file():
+        # The directory first: a token file nobody else can read is still not
+        # private if anyone can write the directory holding it — they can
+        # unlink it and leave their own credential in its place, and the next
+        # deploy authenticates with a token it did not choose. Group/world
+        # *readable* is fine and stays fine (mkdir under a normal umask leaves
+        # 0o755); only the write bits are refused.
+        parent_mode = stat.S_IMODE(path.parent.stat().st_mode)
+        if parent_mode & 0o022:
+            raise ConfigError(
+                f"{path.parent} is writable by group or world (mode "
+                f"{parent_mode:03o}) — anyone who can write that directory "
+                f"can replace the wiki credential in it:\n"
+                f"  chmod 700 {path.parent}")
         mode = stat.S_IMODE(path.stat().st_mode)
         if mode & 0o077:
             raise ConfigError(

--- a/src/bunnyforge/_dokuwiki_rpc.py
+++ b/src/bunnyforge/_dokuwiki_rpc.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+_dokuwiki_rpc.py — talk to a DokuWiki install over its JSON-RPC API.
+
+Third sibling in the DokuWiki family: _dokuwiki.py knows markup,
+_dokuwiki_install.py knows an install on disk, this module knows an install
+over the wire. Stdlib only; imports nothing from _config — it takes
+(base_url, token) and knows nothing about workspaces.
+
+Speaks only the simplified PATH_INFO form, verified live (#7):
+
+    POST <base_url>/lib/exe/jsonrpc.php/<method>
+
+with a JSON object of named params — no JSON-RPC 2.0 envelope, no id
+bookkeeping. Success responses may still carry an `error` object of
+{"code": 0, "message": "success"}, so the success test is: `error` absent,
+null, or code == 0 — never key presence.
+
+The transport is injectable so tests never construct a socket.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ENDPOINT = "lib/exe/jsonrpc.php"
+SAVE_SUMMARY = "bunnyforge deploy-export"
+# First DokuWiki release with the core.* JSON-RPC methods: PR #4134
+# "Complete API Refactoring" consolidated wiki.*/dokuwiki.* calls into
+# core.* calls, landing in this release. Verified against
+# https://github.com/dokuwiki/dokuwiki/pull/4134 and the Fossies diff of
+# inc/Remote/ApiCore.php between release-2023-04-04a and release-2024-02-06.
+MIN_RELEASE = '2024-02-06 "Kaos"'
+
+# http:// is refused everywhere else — the token would cross the wire in
+# clear — but a local test install has nothing to leak to.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+try:
+    _VERSION = importlib.metadata.version("bunnyforge")
+except importlib.metadata.PackageNotFoundError:  # uninstalled checkout
+    _VERSION = "unknown"
+
+
+class RpcError(Exception):
+    """A failed RPC call. `code` is the wiki's JSON-RPC error code, or one
+    of the transport sentinels 'unreachable' (DNS / refused / timeout) and
+    'no-endpoint' (HTTP 404, or a body that is not JSON)."""
+
+    def __init__(self, code, message, method):
+        super().__init__(f"{method}: [{code}] {message}")
+        self.code = code
+        self.message = message
+        self.method = method
+
+
+def _default_transport(request: urllib.request.Request, timeout: float) -> bytes:
+    method = request.full_url.rsplit("/", 1)[-1]
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise RpcError("no-endpoint", "HTTP 404", method) from exc
+        # JSON-RPC errors can ride a non-200 status; the JSON body wins.
+        return exc.read()
+    except urllib.error.URLError as exc:
+        raise RpcError("unreachable", str(exc.reason), method) from exc
+    except TimeoutError as exc:
+        raise RpcError("unreachable", "timed out", method) from exc
+
+
+class RpcClient:
+    def __init__(self, base_url: str, token: str, timeout: float = 30.0,
+                 transport=None):
+        parts = urllib.parse.urlsplit(base_url)
+        if parts.scheme == "http" and parts.hostname not in _LOCAL_HOSTS:
+            raise ValueError(
+                f"[wiki] url {base_url} uses http:// — the API token would "
+                "cross the wire in clear. Use https:// (http is allowed only "
+                "for localhost test installs).")
+        if parts.scheme not in ("http", "https"):
+            raise ValueError(
+                f"[wiki] url {base_url} is not an http(s) URL — expected "
+                "the wiki's base URL, e.g. https://<wiki>")
+        self._endpoint = base_url.rstrip("/") + "/" + ENDPOINT
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": f"bunnyforge/{_VERSION}",
+        }
+        self._timeout = timeout
+        self._transport = transport or _default_transport
+
+    def call(self, method: str, params: dict):
+        request = urllib.request.Request(
+            f"{self._endpoint}/{method}",
+            data=json.dumps(params).encode("utf-8"),
+            headers=self._headers, method="POST")
+        raw = self._transport(request, self._timeout)
+        try:
+            obj = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise RpcError("no-endpoint",
+                           "response is not JSON — wrong base URL?",
+                           method) from exc
+        error = obj.get("error") if isinstance(obj, dict) else None
+        if error and error.get("code", 0) != 0:
+            raise RpcError(error.get("code"), error.get("message", ""), method)
+        return obj.get("result") if isinstance(obj, dict) else obj
+
+    def get_page(self, page_id: str) -> str | None:
+        """Current wiki text, or None for a page that does not exist.
+        Error 121 is a state, not a failure — translated here, never shown."""
+        try:
+            return self.call("core.getPage", {"page": page_id})
+        except RpcError as exc:
+            if exc.code == 121:
+                return None
+            raise
+
+    def save_page(self, page_id: str, text: str,
+                  summary: str = SAVE_SUMMARY) -> None:
+        """Every save carries the summary, so wiki history shows provenance."""
+        self.call("core.savePage", {"page": page_id, "text": text,
+                                    "summary": summary, "isminor": False})
+
+
+# One table, applied by deploy_export at the run level — call sites raise
+# RpcError and never compose prose themselves. Codes from the DokuWiki
+# source; -32605 and -32606 verified live (#7).
+_CLIENT_DEFECTS = frozenset({-32606, -32700, -32602, 131, 132})
+
+
+def translate_error(err: RpcError, wiki_url: str) -> str:
+    code = err.code
+    if code == "unreachable":
+        return (f"cannot reach {wiki_url}: {err.message}. This is a "
+                "connectivity or [wiki] url problem, not a wiki fault — "
+                "check the URL in campaign.toml and your network.")
+    if code == "no-endpoint":
+        return (f"no JSON-RPC endpoint at {wiki_url} ({err.message}) — the "
+                f"DokuWiki release is older than {MIN_RELEASE}, or [wiki] "
+                "url is not the wiki's base URL.")
+    if code == -32605:
+        return ("your wiki's remote API is disabled; set "
+                "$conf['remote'] = 1 in conf/local.php, not "
+                "conf/dokuwiki.php (which upgrades overwrite).")
+    if code == -32604:
+        return ("not authorized: check the token (BUNNYFORGE_WIKI_TOKEN or "
+                "<workspace>/.bunnyforge/wiki-token) and that the API user "
+                "is within $conf['remoteuser'].")
+    if code == 111:
+        return ("the wiki's ACL denies this user here — grant the deploy "
+                "user edit on the campaign namespace.")
+    if code == 133:
+        return ("page locked by an editing session — retry after the lock "
+                "expires (default 15 minutes).")
+    if code == 134:
+        return "content blocked by the wiki's wordblock blacklist."
+    if code in _CLIENT_DEFECTS:
+        return (f"{err.method} failed with code {code} ({err.message}) — "
+                "bug in bunnyforge, please report it.")
+    return (f"{err.method} failed with code {code}: {err.message} — "
+            "unrecognised code, please report it.")

--- a/src/bunnyforge/_dokuwiki_rpc.py
+++ b/src/bunnyforge/_dokuwiki_rpc.py
@@ -155,7 +155,19 @@ class RpcClient:
         # machinery never copies it onto a redirected request — so the
         # credential cannot follow a redirect even if this module were one
         # day reached through the default opener.
+        #
+        # Both credential headers are sent, verified live (2026-08-05)
+        # against a host running PHP as CGI/FastCGI: Apache strips the
+        # Authorization header there before PHP ever runs, so a Bearer-only
+        # client is silently treated as anonymous — not a wiki config
+        # problem, and no amount of .htaccess or preload.php tuning fixes it
+        # from this side. X-DokuWiki-Token is not special-cased by Apache and
+        # arrives intact; DokuWiki's auth_tokenlogin() also prefers it over
+        # Authorization when both are present. Sending both is strictly more
+        # compatible than either alone, and costs nothing on a host where
+        # Authorization already works fine.
         request.add_unredirected_header("Authorization", f"Bearer {self._token}")
+        request.add_unredirected_header("X-DokuWiki-Token", self._token)
         raw = self._transport(request, self._timeout)
         try:
             obj = json.loads(raw.decode("utf-8"))
@@ -170,13 +182,26 @@ class RpcClient:
 
     def get_page(self, page_id: str) -> str | None:
         """Current wiki text, or None for a page that does not exist.
-        Error 121 is a state, not a failure — translated here, never shown."""
+
+        Verified live (2026-08-05) against a real 2026-07-14a "Mort" install,
+        JSON-RPC API version 14: a missing page returns "" with a *success*
+        error object — {"code": 0, "message": "success"} — and error 121
+        never occurs at all on that build. The 121 branch is kept for older
+        builds that may still raise it; it costs nothing to keep.
+
+        Treating "" as "does not exist" is safe, not a heuristic:
+        core.savePage refuses to create an empty page (error 132) — the
+        exact reason the render half translates a zero-byte placeholder to
+        ~~NOTOC~~ before upload. A page cannot simultaneously be empty and
+        exist, so "" unambiguously means "does not exist".
+        """
         try:
-            return self.call("core.getPage", {"page": page_id})
+            text = self.call("core.getPage", {"page": page_id})
         except RpcError as exc:
             if exc.code == 121:
                 return None
             raise
+        return text if text else None
 
     def save_page(self, page_id: str, text: str,
                   summary: str = SAVE_SUMMARY) -> None:
@@ -205,10 +230,28 @@ def translate_error(err: RpcError, wiki_url: str) -> str:
         return ("your wiki's remote API is disabled; set "
                 "$conf['remote'] = 1 in conf/local.php, not "
                 "conf/dokuwiki.php (which upgrades overwrite).")
+    if code == -32603:
+        # Not authenticated: DokuWiki's JsonRpcServer.php raises this (HTTP
+        # 401) when the request carried no usable credential at all —
+        # $INPUT->server has no REMOTE_USER. Verified live (2026-08-05): a
+        # host running PHP as CGI/FastCGI strips the Authorization header
+        # before PHP ever sees it, so a Bearer-only client is silently
+        # anonymous there — common and non-obvious enough to name outright.
+        return ("not authenticated: the wiki received no usable credential — "
+                "some hosts strip the Authorization header when PHP runs as "
+                "CGI/FastCGI (bunnyforge also sends X-DokuWiki-Token, which "
+                "usually survives that). Check the token "
+                "(BUNNYFORGE_WIKI_TOKEN or <workspace>/.bunnyforge/wiki-token) "
+                "and that the API user is within $conf['remoteuser'].")
     if code == -32604:
-        return ("not authorized: check the token (BUNNYFORGE_WIKI_TOKEN or "
-                "<workspace>/.bunnyforge/wiki-token) and that the API user "
-                "is within $conf['remoteuser'].")
+        # Authenticated but forbidden: JsonRpcServer.php raises this (HTTP
+        # 403) when $INPUT->server *does* have REMOTE_USER — the credential
+        # was accepted, this user just may not call the method. Previously
+        # mapped to "check the token", which named the wrong layer; the live
+        # source above resolves the ambiguity the spec had deferred.
+        return ("authenticated but forbidden: this user may not call this "
+                "method — check $conf['remoteuser'] and the wiki's ACL for "
+                "the deploy user.")
     if code == 111:
         return ("the wiki's ACL denies this user here — grant the deploy "
                 "user edit on the campaign namespace.")

--- a/src/bunnyforge/_dokuwiki_rpc.py
+++ b/src/bunnyforge/_dokuwiki_rpc.py
@@ -21,6 +21,7 @@ The transport is injectable so tests never construct a socket.
 
 from __future__ import annotations
 
+import http.client
 import importlib.metadata
 import json
 import urllib.error
@@ -48,8 +49,9 @@ except importlib.metadata.PackageNotFoundError:  # uninstalled checkout
 
 class RpcError(Exception):
     """A failed RPC call. `code` is the wiki's JSON-RPC error code, or one
-    of the transport sentinels 'unreachable' (DNS / refused / timeout) and
-    'no-endpoint' (HTTP 404, or a body that is not JSON)."""
+    of the transport sentinels 'unreachable' (DNS / refused / timeout /
+    connection dropped mid-response) and 'no-endpoint' (HTTP 404, a redirect,
+    or a body that is not JSON)."""
 
     def __init__(self, code, message, method):
         super().__init__(f"{method}: [{code}] {message}")
@@ -58,10 +60,43 @@ class RpcError(Exception):
         self.method = method
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse every redirect rather than following it.
+
+    urllib's stock HTTPRedirectHandler copies each header except
+    content-length/content-type onto the redirected request — Authorization
+    included — and, unlike `requests`, does *not* drop it when the host
+    changes. It also downgrades a 301/302/303 POST to GET. So a wiki whose
+    canonical URL redirects (apex -> www, or an https vhost that 301s to
+    http) would send a live campaign's API token in clear, or to a host the
+    user never configured in [wiki] url. The https-only check in RpcClient
+    guards the configured base URL only; it can say nothing about a redirect
+    target, so the token's guarantee has to be enforced here.
+
+    A JSON-RPC POST to lib/exe/jsonrpc.php/<method> has no legitimate reason
+    to redirect, so refusing costs nothing and the message points at the fix.
+    (Following it would not work anyway: the endpoint is POST-only and
+    answers a GET with -32606, which the error table reports as a bunnyforge
+    bug — a URL misconfiguration misdiagnosed as a tool defect.)
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise RpcError(
+            "no-endpoint",
+            f"redirected to {newurl} — point [wiki] url at the wiki's "
+            "canonical base URL; the API token is never sent to a redirect "
+            "target",
+            req.full_url.rsplit("/", 1)[-1])
+
+
+# Never urlopen(): that uses the default opener, which follows redirects.
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
 def _default_transport(request: urllib.request.Request, timeout: float) -> bytes:
     method = request.full_url.rsplit("/", 1)[-1]
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as resp:
+        with _OPENER.open(request, timeout=timeout) as resp:
             return resp.read()
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -72,27 +107,40 @@ def _default_transport(request: urllib.request.Request, timeout: float) -> bytes
         raise RpcError("unreachable", str(exc.reason), method) from exc
     except TimeoutError as exc:
         raise RpcError("unreachable", "timed out", method) from exc
+    except (OSError, http.client.HTTPException) as exc:
+        # urlopen wraps only the OSError raised inside h.request(); anything
+        # from getresponse() or resp.read() arrives unwrapped —
+        # RemoteDisconnected, ConnectionResetError, IncompleteRead, a
+        # mid-stream ssl.SSLError. Unhandled they become a traceback, and
+        # inside apply_deploy they would also skip the written / not-yet-
+        # written / re-run report a partial deploy owes the user. Ordering
+        # matters: HTTPError and URLError are both OSError subclasses and
+        # carry better detail, so they are caught above.
+        raise RpcError("unreachable", str(exc) or type(exc).__name__,
+                       method) from exc
 
 
 class RpcClient:
     def __init__(self, base_url: str, token: str, timeout: float = 30.0,
                  transport=None):
         parts = urllib.parse.urlsplit(base_url)
+        # Is it a web URL at all, then is it a safe one — the general check
+        # before the specific, so the pair reads in the order it decides in.
+        if parts.scheme not in ("http", "https"):
+            raise ValueError(
+                f"[wiki] url {base_url} is not an http(s) URL — expected "
+                "the wiki's base URL, e.g. https://<wiki>")
         if parts.scheme == "http" and parts.hostname not in _LOCAL_HOSTS:
             raise ValueError(
                 f"[wiki] url {base_url} uses http:// — the API token would "
                 "cross the wire in clear. Use https:// (http is allowed only "
                 "for localhost test installs).")
-        if parts.scheme not in ("http", "https"):
-            raise ValueError(
-                f"[wiki] url {base_url} is not an http(s) URL — expected "
-                "the wiki's base URL, e.g. https://<wiki>")
         self._endpoint = base_url.rstrip("/") + "/" + ENDPOINT
         self._headers = {
-            "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
             "User-Agent": f"bunnyforge/{_VERSION}",
         }
+        self._token = token
         self._timeout = timeout
         self._transport = transport or _default_transport
 
@@ -101,6 +149,13 @@ class RpcClient:
             f"{self._endpoint}/{method}",
             data=json.dumps(params).encode("utf-8"),
             headers=self._headers, method="POST")
+        # Second layer under _NoRedirect, and the reason the token is not in
+        # `headers` above. An unredirected header goes on the wire exactly
+        # like any other (do_open merges both dicts), but urllib's redirect
+        # machinery never copies it onto a redirected request — so the
+        # credential cannot follow a redirect even if this module were one
+        # day reached through the default opener.
+        request.add_unredirected_header("Authorization", f"Bearer {self._token}")
         raw = self._transport(request, self._timeout)
         try:
             obj = json.loads(raw.decode("utf-8"))

--- a/src/bunnyforge/cli.py
+++ b/src/bunnyforge/cli.py
@@ -57,7 +57,7 @@ _SUMMARIES = {
     "init": "scaffold a new campaign workspace",
     "review": "run a named workspace review suite",
     "export-player": "write player-safe copies of content files to Export/",
-    "deploy-export": "render Export/ into a DokuWiki staging tree",
+    "deploy-export": "render Export/ and deploy it to the wiki (dry run by default)",
     "import-perceptions": "import player-authored wiki pages into Perceptions/",
     "build-sheets": "build one-page HTML reference sheets for a session",
     "names": "generate culture-appropriate names",

--- a/src/bunnyforge/data/root/gitignore
+++ b/src/bunnyforge/data/root/gitignore
@@ -7,3 +7,9 @@ _Ignore/
 
 # Python
 __pycache__/
+
+# Wiki deploy: the credential and the tool-owned drift copies. The deploy
+# manifest (.bunnyforge/wiki-manifest.json) is deliberately NOT ignored —
+# it is the committed baseline.
+.bunnyforge/wiki-token
+.bunnyforge/wiki-drift/

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -555,11 +555,48 @@ def write_order(page_ids, base: str) -> list[str]:
     return order
 
 
-ApplyResult = namedtuple("ApplyResult", "written adopted failure remaining")
+ApplyResult = namedtuple("ApplyResult", "written adopted failure remaining skipped")
 
 # Held-back actions: written only when named in --overwrite, and always
 # re-baselined when written.
 _HELD = ("drift", "drift-manual-era", "deleted-on-wiki")
+
+
+def held_page_ids(plan: DeployPlan, overwrite=frozenset()) -> list[str]:
+    """Page IDs this run holds back: a held-back action, not named in
+    --overwrite. Sorted.
+
+    This is the predicate deciding whether someone's wiki edit gets clobbered,
+    so it has exactly one definition. Called with the default empty
+    `overwrite` it is instead the set of pages --overwrite may legitimately
+    name — the same predicate before the escape hatch is applied, which is
+    precisely what validating --overwrite needs.
+    """
+    return sorted(pid for pid, p in plan.pages.items()
+                  if p.action in _HELD and pid not in overwrite)
+
+
+def pages_to_write(plan: DeployPlan, overwrite: set[str]) -> list[str]:
+    """Page IDs this run writes: new or update, plus anything --overwrite
+    named. Shared by apply_deploy and the dry run's count, so the rehearsal
+    cannot drift from the run it rehearses."""
+    return [pid for pid, p in plan.pages.items()
+            if p.action in ("new", "update") or pid in overwrite]
+
+
+def check_overwrite(plan: DeployPlan, overwrite: set[str]) -> None:
+    """Refuse an --overwrite naming a page this run did not hold back — a
+    typo'd page ID, or one that stopped drifting since the last run.
+
+    Called from run_deploy so a dry run refuses exactly what --go refuses; a
+    rehearsal that disagreed with the real run is worse than no rehearsal.
+    apply_deploy calls it again, because it is independently reachable.
+    """
+    unknown = sorted(set(overwrite) - set(held_page_ids(plan)))
+    if unknown:
+        raise DeployError(
+            f"--overwrite names page(s) not held back this run: "
+            f"{', '.join(unknown)} — nothing to clobber.")
 
 
 def apply_deploy(plan: DeployPlan, staged: dict[str, str], client,
@@ -569,17 +606,19 @@ def apply_deploy(plan: DeployPlan, staged: dict[str, str], client,
     through to disk after each successful save, so a run that dies mid-way
     needs no resume machinery — re-running converges (unchanged / adopt).
     """
-    held = {pid for pid, p in plan.pages.items() if p.action in _HELD}
-    unknown = sorted(overwrite - held)
-    if unknown:
-        raise DeployError(
-            f"--overwrite names page(s) not held back this run: "
-            f"{', '.join(unknown)} — nothing to clobber.")
+    check_overwrite(plan, overwrite)
 
-    to_write = [pid for pid, p in plan.pages.items()
-                if p.action in ("new", "update") or pid in overwrite]
+    to_write = pages_to_write(plan, overwrite)
+    order = write_order(to_write, base)
     written: list[str] = []
     adopted: list[str] = []
+    skipped: list[str] = []
+
+    def _remaining():
+        # A skipped page was decided on, not left undone, and is reported on
+        # its own line — listing it as "not yet written" would read as work
+        # the re-run must still do.
+        return [i for i in order if i not in written and i not in skipped]
 
     for pid, p in plan.pages.items():
         if p.action == "adopt":
@@ -590,21 +629,45 @@ def apply_deploy(plan: DeployPlan, staged: dict[str, str], client,
     if adopted or plan.resolved_orphans:
         save_manifest(manifest_path, manifest)
 
-    for pid in write_order(to_write, base):
+    for pid in order:
         try:
+            # Re-read immediately before writing. plan_deploy fetched every
+            # page up front, so on a real campaign the gap between a page's
+            # fetch and its save is the whole fetch loop plus the report —
+            # tens of seconds in which the spec's guarantee ("a quick wiki
+            # edit made mid-run survives, rather than being silently
+            # clobbered") would otherwise hold only *between* runs. The run
+            # already pays one get_page per written page for the read-back
+            # baseline; a second is affordable at campaign scale.
+            #
+            # This applies to --overwrite pages too: --overwrite consents to
+            # clobbering the diff the plan printed, and an edit that landed
+            # after that diff was never reviewed.
+            if client.get_page(pid) != plan.pages[pid].wiki_text:
+                skipped.append(pid)
+                continue
             client.save_page(pid, staged[pid])
             readback = client.get_page(pid)
         except RpcError as exc:
-            remaining = [i for i in write_order(to_write, base)
-                         if i not in written]
             return ApplyResult(
                 written, sorted(adopted),
-                f"{pid}: {translate_error(exc, wiki_url)}", remaining)
-        manifest[pid] = page_hash(readback or "")
+                f"{pid}: {translate_error(exc, wiki_url)}", _remaining(),
+                skipped)
+        if readback is None:
+            # The wiki accepted the save and then says the page does not
+            # exist. Whatever happened, there is no baseline to record:
+            # page_hash("") would be a knowingly-wrong entry that makes the
+            # page look drifted forever. Treat it as a failed save.
+            return ApplyResult(
+                written, sorted(adopted),
+                f"{pid}: saved, but reading the page back found nothing — the "
+                "wiki did not keep the write. Check the deploy user's ACL on "
+                "this page and re-run.", _remaining(), skipped)
+        manifest[pid] = page_hash(readback)
         save_manifest(manifest_path, manifest)
         written.append(pid)
 
-    return ApplyResult(written, sorted(adopted), None, [])
+    return ApplyResult(written, sorted(adopted), None, [], skipped)
 
 
 _HELD_REASONS = {
@@ -632,13 +695,12 @@ def write_drift_copies(held: dict[str, str], drift_dir: Path) -> None:
 def format_deploy_report(plan: DeployPlan, staged: dict[str, str],
                          overwrite: set[str], go: bool) -> tuple[list[str], bool]:
     lines: list[str] = []
-    held_pages = []
+    held_pages = held_page_ids(plan, overwrite)
+    held_set = set(held_pages)
     for pid in sorted(plan.pages):
-        p = plan.pages[pid]
-        if p.action in _HELD and pid not in overwrite:
-            held_pages.append(pid)
+        if pid in held_set:
             continue
-        word = "overwrite" if pid in overwrite else p.action
+        word = "overwrite" if pid in overwrite else plan.pages[pid].action
         lines.append(f"  {word:<12} {pid}")
     for pid in plan.refused:
         lines.append(f"  refused      {pid}  (protected page — never written)")
@@ -691,20 +753,34 @@ def run_deploy(ws, staging: Path, client, go: bool, overwrite: set[str],
         print(f"error: {translate_error(exc, wiki_url)}", file=sys.stderr)
         return 1
 
-    held = {pid: p.wiki_text for pid, p in plan.pages.items()
-            if p.action in _HELD and pid not in overwrite
-            and p.wiki_text is not None}
+    # Validated here, before any reporting, so a dry run refuses exactly what
+    # --go would refuse rather than printing a plan the real run rejects.
+    check_overwrite(plan, overwrite)
+
+    # deleted-on-wiki is held back too but has no wiki text to copy, hence
+    # the extra filter here and nowhere else.
+    held = {pid: plan.pages[pid].wiki_text
+            for pid in held_page_ids(plan, overwrite)
+            if plan.pages[pid].wiki_text is not None}
     # Copies are part of reporting, not deployment: written in both modes.
     write_drift_copies(held, ws.root / DRIFT_DIR)
 
     lines, held_or_orphaned = format_deploy_report(plan, staged, overwrite, go)
     print("\n".join(lines))
 
+    skipped: list[str] = []
     if go:
         result = apply_deploy(plan, staged, client, manifest, manifest_path,
                               overwrite, base, wiki_url)
+        skipped = result.skipped
         for pid in result.written:
             print(f"  saved        {pid}")
+        for pid in skipped:
+            # Loud, and on stderr: a silently skipped page would be worse
+            # than the clobber this check exists to prevent.
+            print(f"  SKIPPED      {pid} — changed on the wiki between this "
+                  "run's plan and its write; not written. Re-run: the next "
+                  "plan reports it as drift, with a diff.", file=sys.stderr)
         if result.failure:
             print(f"\nerror: {result.failure}", file=sys.stderr)
             print(f"Written before the failure: "
@@ -714,14 +790,13 @@ def run_deploy(ws, staging: Path, client, go: bool, overwrite: set[str],
                   "unchanged or adopt.", file=sys.stderr)
             return 1
         print(f"\nDeployed {len(result.written)} page(s), "
-              f"adopted {len(result.adopted)}.")
+              f"adopted {len(result.adopted)}."
+              + (f" Skipped {len(skipped)} changed mid-run." if skipped else ""))
     else:
-        writes = sum(1 for pid, p in plan.pages.items()
-                     if p.action in ("new", "update") or pid in overwrite)
-        print(f"\nDry run: {writes} page(s) would be written. "
-              "Re-run with --go to deploy.")
+        print(f"\nDry run: {len(pages_to_write(plan, overwrite))} page(s) "
+              "would be written. Re-run with --go to deploy.")
 
-    return 1 if held_or_orphaned else 0
+    return 1 if held_or_orphaned or skipped else 0
 
 
 if __name__ == "__main__":

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -27,8 +27,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import difflib
 import hashlib
 import json
+import shutil
 import sys
 from collections import namedtuple
 from pathlib import Path
@@ -531,6 +533,123 @@ def apply_deploy(plan: DeployPlan, staged: dict[str, str], client,
         written.append(pid)
 
     return ApplyResult(written, sorted(adopted), None, [])
+
+
+_HELD_REASONS = {
+    "drift": "changed on the wiki since the last deploy",
+    "drift-manual-era": "no baseline for it — could be hand-edits from the "
+                        "manual era",
+    "deleted-on-wiki": "a human deleted it on the wiki; recreating it would "
+                       "clobber that decision",
+}
+
+
+def write_drift_copies(held: dict[str, str], drift_dir: Path) -> None:
+    """Each drifted page's current wiki text, laid out like data/pages/, for
+    manual merge. The tool owns this directory outright: recreated from empty
+    every planning run, so a page that stops drifting leaves no stale copy."""
+    if drift_dir.exists():
+        shutil.rmtree(drift_dir)
+    drift_dir.mkdir(parents=True)
+    for pid, wiki_text in held.items():
+        dest = page_path(pid, drift_dir)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(wiki_text, encoding="utf-8")
+
+
+def format_deploy_report(plan: DeployPlan, staged: dict[str, str],
+                         overwrite: set[str], go: bool) -> tuple[list[str], bool]:
+    lines: list[str] = []
+    held_pages = []
+    for pid in sorted(plan.pages):
+        p = plan.pages[pid]
+        if p.action in _HELD and pid not in overwrite:
+            held_pages.append(pid)
+            continue
+        word = "overwrite" if pid in overwrite else p.action
+        lines.append(f"  {word:<12} {pid}")
+    for pid in plan.refused:
+        lines.append(f"  refused      {pid}  (protected page — never written)")
+
+    for pid in held_pages:
+        p = plan.pages[pid]
+        lines.append(f"\n  HELD  {pid} — {_HELD_REASONS[p.action]}")
+        if p.wiki_text is not None:
+            diff = difflib.unified_diff(
+                p.wiki_text.splitlines(keepends=True),
+                staged[pid].splitlines(keepends=True),
+                fromfile="wiki (current)", tofile="deploy (target)")
+            lines.extend("    " + line.rstrip("\n") for line in diff)
+    if held_pages:
+        lines.append(
+            "\nHeld-back pages: pull the wiki edit into the workspace source "
+            "(the next render then matches and the drift disappears), or "
+            "re-run with --overwrite <page-id> --go to clobber that page "
+            "and re-baseline it. Current wiki text saved under "
+            f"{DRIFT_DIR}/ for manual merge.")
+
+    for pid in plan.orphans:
+        lines.append(
+            f"  orphan       {pid} — in the manifest but no longer staged; "
+            "removing the wiki page is a manual act, this tool never "
+            "deletes.")
+    for pid in plan.resolved_orphans:
+        lines.append(
+            f"  resolved     {pid} — deleted on the wiki; "
+            + ("dropped from the manifest." if go else
+               "will drop from the manifest on --go."))
+
+    held_or_orphaned = bool(held_pages or plan.orphans)
+    return lines, held_or_orphaned
+
+
+def run_deploy(ws, staging: Path, client, go: bool, overwrite: set[str],
+               wiki_url: str) -> int:
+    """Plan, report, copy drift, and (with go) apply. Exit-code contract:
+    non-zero if anything was held back or any orphan was reported, in both
+    modes — matching the render half's fail-loudly posture."""
+    base = ws.config.namespace
+    manifest_path = ws.root / MANIFEST_FILE
+    manifest = load_manifest(manifest_path)
+    staged = staged_pages(staging)
+
+    try:
+        plan = plan_deploy(staged, manifest, client.get_page, base)
+    except RpcError as exc:
+        print(f"error: {translate_error(exc, wiki_url)}", file=sys.stderr)
+        return 1
+
+    held = {pid: p.wiki_text for pid, p in plan.pages.items()
+            if p.action in _HELD and pid not in overwrite
+            and p.wiki_text is not None}
+    # Copies are part of reporting, not deployment: written in both modes.
+    write_drift_copies(held, ws.root / DRIFT_DIR)
+
+    lines, held_or_orphaned = format_deploy_report(plan, staged, overwrite, go)
+    print("\n".join(lines))
+
+    if go:
+        result = apply_deploy(plan, staged, client, manifest, manifest_path,
+                              overwrite, base, wiki_url)
+        for pid in result.written:
+            print(f"  saved        {pid}")
+        if result.failure:
+            print(f"\nerror: {result.failure}", file=sys.stderr)
+            print(f"Written before the failure: "
+                  f"{', '.join(result.written) or 'nothing'}.\n"
+                  f"Not yet written: {', '.join(result.remaining)}.\n"
+                  "Re-run to converge — already-written pages classify as "
+                  "unchanged or adopt.", file=sys.stderr)
+            return 1
+        print(f"\nDeployed {len(result.written)} page(s), "
+              f"adopted {len(result.adopted)}.")
+    else:
+        writes = sum(1 for pid, p in plan.pages.items()
+                     if p.action in ("new", "update") or pid in overwrite)
+        print(f"\nDry run: {writes} page(s) would be written. "
+              "Re-run with --go to deploy.")
+
+    return 1 if held_or_orphaned else 0
 
 
 if __name__ == "__main__":

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-deploy_export.py — render Export/ into a DokuWiki staging tree.
+deploy_export.py — render Export/ and deploy it to the wiki over JSON-RPC.
 
 Direction: Export/ -> staging tree -> wiki. This script never writes to the
 workspace itself; the wiki is read to plan on every run except --render-only,

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -49,6 +49,7 @@ from bunnyforge._common import (
     target_index,
 )
 from bunnyforge._config import ConfigError, Workspace, resolve_workspace
+from bunnyforge._dokuwiki_rpc import RpcError, translate_error
 from bunnyforge._workspace import WorkspaceError
 
 # Hand-written on the wiki and owned by nobody in this repo. Never wrapped,
@@ -478,6 +479,58 @@ def write_order(page_ids, base: str) -> list[str]:
             order.append(mate)
         order.append(pid)
     return order
+
+
+ApplyResult = namedtuple("ApplyResult", "written adopted failure remaining")
+
+# Held-back actions: written only when named in --overwrite, and always
+# re-baselined when written.
+_HELD = ("drift", "drift-manual-era", "deleted-on-wiki")
+
+
+def apply_deploy(plan: DeployPlan, staged: dict[str, str], client,
+                 manifest: dict[str, str], manifest_path: Path,
+                 overwrite: set[str], base: str, wiki_url: str) -> ApplyResult:
+    """Perform the writes a plan calls for. Mutates `manifest` and writes it
+    through to disk after each successful save, so a run that dies mid-way
+    needs no resume machinery — re-running converges (unchanged / adopt).
+    """
+    held = {pid for pid, p in plan.pages.items() if p.action in _HELD}
+    unknown = sorted(overwrite - held)
+    if unknown:
+        raise DeployError(
+            f"--overwrite names page(s) not held back this run: "
+            f"{', '.join(unknown)} — nothing to clobber.")
+
+    to_write = [pid for pid, p in plan.pages.items()
+                if p.action in ("new", "update") or pid in overwrite]
+    written: list[str] = []
+    adopted: list[str] = []
+
+    for pid, p in plan.pages.items():
+        if p.action == "adopt":
+            manifest[pid] = page_hash(p.wiki_text)
+            adopted.append(pid)
+    for pid in plan.resolved_orphans:
+        manifest.pop(pid, None)
+    if adopted or plan.resolved_orphans:
+        save_manifest(manifest_path, manifest)
+
+    for pid in write_order(to_write, base):
+        try:
+            client.save_page(pid, staged[pid])
+            readback = client.get_page(pid)
+        except RpcError as exc:
+            remaining = [i for i in write_order(to_write, base)
+                         if i not in written]
+            return ApplyResult(
+                written, sorted(adopted),
+                f"{pid}: {translate_error(exc, wiki_url)}", remaining)
+        manifest[pid] = page_hash(readback or "")
+        save_manifest(manifest_path, manifest)
+        written.append(pid)
+
+    return ApplyResult(written, sorted(adopted), None, [])
 
 
 if __name__ == "__main__":

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -458,7 +458,11 @@ def write_order(page_ids, base: str) -> list[str]:
     """Sorted page order, except each content page lands immediately before
     its wrapper — so a wrapper never points at a not-yet-written include for
     longer than one call."""
-    ids = sorted(page_ids)
+    # Dedupe up front: `present` is a set regardless, but the loop below
+    # drives off `ids` — an un-deduped list would re-trigger "mate present ->
+    # emit mate + self" once per repeat, breaking the exactly-once guarantee
+    # this function exists to provide.
+    ids = sorted(set(page_ids))
     present = set(ids)
     export_prefix = f"{base}:export:"
 

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -27,6 +27,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import sys
 from collections import namedtuple
 from pathlib import Path
@@ -319,6 +321,71 @@ def main(argv: list[str] | None = None) -> int:
         for pid in sorted(result.placeholder_ids):
             print(f"  {pid}")
     return 0
+
+
+# ---------------------------------------------------------------------------
+# Transport half: manifest, classification, plan/apply. The render code above
+# is untouched — a deploy always uploads what it just rendered.
+# ---------------------------------------------------------------------------
+
+MANIFEST_VERSION = 1
+MANIFEST_FILE = ".bunnyforge/wiki-manifest.json"
+DRIFT_DIR = ".bunnyforge/wiki-drift"
+
+
+class DeployError(Exception):
+    """The deploy phase cannot proceed; message is user-facing."""
+
+
+def page_hash(text: str) -> str:
+    """Hash of what the wiki returns from get_page after a save — never of
+    the bytes we sent: DokuWiki normalizes on save, and hashing our own
+    bytes would make every page look self-drifted on the next run."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def classify_page(target_text: str, wiki_text: str | None,
+                  manifest_hash: str | None) -> str:
+    """The spec's eight-row state matrix as a pure function.
+
+    (staged target text, current wiki text or None, manifest hash or None)
+    -> one of: new, deleted-on-wiki, unchanged, update, adopt, drift,
+    drift-manual-era. 'adopt' covers both resume-after-crash and the
+    manual-era exact match; the two drift labels differ only in how the
+    report explains them.
+    """
+    if wiki_text is None:
+        return "new" if manifest_hash is None else "deleted-on-wiki"
+    if manifest_hash is None:
+        return "adopt" if target_text == wiki_text else "drift-manual-era"
+    if page_hash(wiki_text) == manifest_hash:
+        return "unchanged" if target_text == wiki_text else "update"
+    return "adopt" if target_text == wiki_text else "drift"
+
+
+def load_manifest(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise DeployError(
+            f"{path} is not valid JSON: {exc}. It is the deploy baseline — "
+            "restore it from git rather than deleting it.") from exc
+    if not isinstance(raw, dict) or raw.get("version") != MANIFEST_VERSION:
+        raise DeployError(
+            f"{path} has manifest version {raw.get('version')!r}; this "
+            f"bunnyforge understands version {MANIFEST_VERSION}. Upgrade "
+            "bunnyforge, or restore the manifest from git.")
+    return dict(raw.get("pages", {}))
+
+
+def save_manifest(path: Path, pages: dict[str, str]) -> None:
+    """Sorted keys so the committed manifest diffs cleanly in git."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps({"version": MANIFEST_VERSION,
+                       "pages": dict(sorted(pages.items()))}, indent=1)
+    path.write_text(body + "\n", encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -372,12 +372,26 @@ def load_manifest(path: Path) -> dict[str, str]:
         raise DeployError(
             f"{path} is not valid JSON: {exc}. It is the deploy baseline — "
             "restore it from git rather than deleting it.") from exc
-    if not isinstance(raw, dict) or raw.get("version") != MANIFEST_VERSION:
+    if not isinstance(raw, dict):
+        raise DeployError(
+            f"{path} is not a JSON object — it is the deploy baseline. "
+            "Restore it from git rather than deleting it.")
+    if raw.get("version") != MANIFEST_VERSION:
         raise DeployError(
             f"{path} has manifest version {raw.get('version')!r}; this "
             f"bunnyforge understands version {MANIFEST_VERSION}. Upgrade "
             "bunnyforge, or restore the manifest from git.")
-    return dict(raw.get("pages", {}))
+    pages = raw.get("pages", {})
+    if not isinstance(pages, dict):
+        # dict() of a non-dict iterable doesn't reliably fail loudly: a list
+        # of two-character strings (e.g. ["ab", "cd"]) silently becomes
+        # {"a": "b", "c": "d"} instead of raising, which would corrupt the
+        # manifest read rather than refuse it. Reject the shape outright.
+        raise DeployError(
+            f"{path} has a non-object 'pages' field "
+            f"({type(pages).__name__}) — it is the deploy baseline. "
+            "Restore it from git rather than deleting it.")
+    return dict(pages)
 
 
 def save_manifest(path: Path, pages: dict[str, str]) -> None:

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -2,8 +2,9 @@
 """
 deploy_export.py — render Export/ into a DokuWiki staging tree.
 
-Direction: Export/ -> staging tree. This script never writes to the workspace
-and never reads the wiki.
+Direction: Export/ -> staging tree -> wiki. This script never writes to the
+workspace itself; the wiki is read to plan on every run except --render-only,
+and written only with --go.
 
 Each exported Markdown file produces two staged pages:
 
@@ -16,22 +17,38 @@ The player half, <ns>:players:<dir>:<stem>, is never written here — it
 belongs to the players, and the wrapper's include renders a create-link while
 it does not exist.
 
-This is the render half of the pipeline. Transport, the content manifest, and
-drift detection arrive in a later change; --render-only is currently the only
-supported mode.
+This is the render half of the pipeline, feeding the transport half below it
+(manifest, drift detection, plan/apply) that main() drives. Three invocations:
+
+    bunnyforge deploy-export
+        Dry run (the default): render, fetch the wiki's current state, print
+        the full plan. Reads the network, writes nothing to the wiki.
+
+    bunnyforge deploy-export --go
+        Same plan, then perform the writes it calls for and update the
+        manifest.
+
+    bunnyforge deploy-export --render-only --staging PATH
+        Render only, offline: no [wiki] config and no token needed. PATH is
+        the deliverable, so it is required (dry run and --go accept it too,
+        optionally; a temp directory is used and removed otherwise).
 
 Usage:
+    python3 -m bunnyforge.deploy_export
+    python3 -m bunnyforge.deploy_export --go
     python3 -m bunnyforge.deploy_export --render-only --staging /tmp/stage
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import difflib
 import hashlib
 import json
 import shutil
 import sys
+import tempfile
 from collections import namedtuple
 from pathlib import Path
 
@@ -50,8 +67,9 @@ from bunnyforge._common import (
     markdown_links_to_wikilinks,
     target_index,
 )
-from bunnyforge._config import ConfigError, Workspace, resolve_workspace
-from bunnyforge._dokuwiki_rpc import RpcError, translate_error
+from bunnyforge._config import (
+    ConfigError, Workspace, resolve_workspace, resolve_wiki_token)
+from bunnyforge._dokuwiki_rpc import RpcClient, RpcError, translate_error
 from bunnyforge._workspace import WorkspaceError
 
 # Hand-written on the wiki and owned by nobody in this repo. Never wrapped,
@@ -223,11 +241,29 @@ def render_tree(export_dir: Path, staging: Path, base: str,
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="bunnyforge deploy-export",
-        description="Render Export/ into a DokuWiki staging tree.")
-    parser.add_argument("--render-only", action="store_true",
-                        help="Render to --staging and stop (currently required)")
-    parser.add_argument("--staging", required=True,
-                        help="Directory to write the staged page tree into")
+        description="Render Export/ and deploy it to the wiki over "
+                    "JSON-RPC. The default run is a dry run: it renders, "
+                    "fetches the wiki's current state, and prints the full "
+                    "plan, writing nothing to the wiki.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--go", action="store_true",
+                      help="Perform the writes the plan calls for, and "
+                           "update the manifest")
+    mode.add_argument("--render-only", action="store_true",
+                      help="Render to --staging and stop; no network, no "
+                           "[wiki] config, no token needed")
+    parser.add_argument("--staging", default=None,
+                        help="Directory for the staged page tree. Optional "
+                             "in the default and --go modes (a temp "
+                             "directory is used and removed at exit "
+                             "otherwise, so a stale tree can never be "
+                             "pushed); required with --render-only, where "
+                             "the tree is the deliverable")
+    parser.add_argument("--overwrite", action="append", default=[],
+                        metavar="PAGE_ID",
+                        help="Write this drifted/held-back page anyway and "
+                             "re-baseline it (repeatable; takes effect with "
+                             "--go)")
     parser.add_argument("--export-dir", default=None,
                         help="Source directory (default: the resolved "
                              "workspace's Export/, so it follows --workspace)")
@@ -245,9 +281,9 @@ def main(argv: list[str] | None = None) -> int:
              "the nearest campaign.toml above the current directory)")
     args = parser.parse_args(argv)
 
-    if not args.render_only:
-        print("error: only --render-only is implemented; transport lands in a "
-              "later change", file=sys.stderr)
+    if args.render_only and not args.staging:
+        print("error: --render-only needs --staging PATH — the staged tree "
+              "is the deliverable of a render-only run", file=sys.stderr)
         return 1
 
     try:
@@ -268,62 +304,98 @@ def main(argv: list[str] | None = None) -> int:
               file=sys.stderr)
         return 1
 
-    staging = Path(args.staging).expanduser().resolve()
-    if staging.exists():
-        if not staging.is_dir():
-            print(f"error: --staging {staging} exists and is not a directory",
+    # Network needs are gated up front, before any rendering, so a config
+    # problem is reported in one second, not after a full render.
+    client = None
+    if not args.render_only:
+        wiki_url = ws.config.wiki_url
+        if not wiki_url:
+            print("error: campaign.toml has no [wiki] url — deploying needs "
+                  "to know where the wiki is. Add:\n\n"
+                  "  [wiki]\n"
+                  '  url = "https://<wiki>"\n\n'
+                  "(--render-only needs no [wiki] and no token.)",
                   file=sys.stderr)
             return 1
-        if any(staging.iterdir()):
-            print(
-                f"error: --staging {staging} already exists and is not empty. "
-                "Rendering into it could leave a retired page on disk from a "
-                "prior run while this run still reports success — remove the "
-                "directory or pick a fresh one and re-run.",
-                file=sys.stderr)
+        try:
+            token = resolve_wiki_token(ws.root)
+            client = RpcClient(wiki_url, token)
+        except (ConfigError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
             return 1
 
-    rels = sorted(p.relative_to(export_dir).as_posix()
-                  for p in export_dir.rglob("*.md"))
-    # render_tree writes any placeholder pages itself (it holds `staging`);
-    # build_link_resolver only ever sees the workspace, so it cannot write.
-    resolver = build_link_resolver(
-        ws, rels, base, args.create_empty_placeholders)
-    result, log = render_tree(export_dir, staging, base, link_resolver=resolver)
+    # When --staging is omitted the tree goes to a temp directory removed at
+    # exit — a deploy always uploads what it just rendered, so a stale tree
+    # can never be pushed.
+    with contextlib.ExitStack() as stack:
+        if args.staging:
+            staging = Path(args.staging).expanduser().resolve()
+            if staging.exists():
+                if not staging.is_dir():
+                    print(f"error: --staging {staging} exists and is not a directory",
+                          file=sys.stderr)
+                    return 1
+                if any(staging.iterdir()):
+                    print(
+                        f"error: --staging {staging} already exists and is not empty. "
+                        "Rendering into it could leave a retired page on disk from a "
+                        "prior run while this run still reports success — remove the "
+                        "directory or pick a fresh one and re-run.",
+                        file=sys.stderr)
+                    return 1
+        else:
+            staging = Path(stack.enter_context(tempfile.TemporaryDirectory()))
 
-    fatal = [i for i in result.link_issues
-             if i.case in ("unresolved", "ambiguous")
-             or (i.case == "unexported" and not args.create_empty_placeholders)]
+        rels = sorted(p.relative_to(export_dir).as_posix()
+                      for p in export_dir.rglob("*.md"))
+        # render_tree writes any placeholder pages itself (it holds `staging`);
+        # build_link_resolver only ever sees the workspace, so it cannot write.
+        resolver = build_link_resolver(
+            ws, rels, base, args.create_empty_placeholders)
+        result, log = render_tree(export_dir, staging, base, link_resolver=resolver)
 
-    for line in log:
-        print(line, file=sys.stderr if "REFUSED" in line else sys.stdout)
+        fatal = [i for i in result.link_issues
+                 if i.case in ("unresolved", "ambiguous")
+                 or (i.case == "unexported" and not args.create_empty_placeholders)]
 
-    if result.collisions:
-        print(f"\nRefused: {len(result.collisions)} reserved-namespace "
-              f"collision(s).", file=sys.stderr)
-        return 1
+        for line in log:
+            print(line, file=sys.stderr if "REFUSED" in line else sys.stdout)
 
-    if fatal:
-        print(f"\n{len(fatal)} link(s) refused. Fix the source text, or pass "
-              "--create-empty-placeholders for links to real but unexported "
-              "files (typos and ambiguous targets are never placeholdered).",
-              file=sys.stderr)
-        return 1
+        if result.collisions:
+            print(f"\nRefused: {len(result.collisions)} reserved-namespace "
+                  f"collision(s).", file=sys.stderr)
+            return 1
 
-    print(f"\n{result.pages} page(s), {result.wrappers} wrapper(s), "
-          f"{result.skipped} skipped, "
-          f"{len(result.placeholder_ids)} placeholder(s).")
+        if fatal:
+            print(f"\n{len(fatal)} link(s) refused. Fix the source text, or pass "
+                  "--create-empty-placeholders for links to real but unexported "
+                  "files (typos and ambiguous targets are never placeholdered).",
+                  file=sys.stderr)
+            return 1
 
-    if result.placeholder_ids:
-        # A placeholder page is empty, but its ID is not: it spells out the
-        # unexported file's path, which for a gm-only doc means publishing
-        # that filename to the player wiki's index and search. Name them all,
-        # so the operator sees exactly what is about to become visible.
-        print("\nPlaceholder page IDs — these names become visible in the "
-              "player wiki's index and search:")
-        for pid in sorted(result.placeholder_ids):
-            print(f"  {pid}")
-    return 0
+        print(f"\n{result.pages} page(s), {result.wrappers} wrapper(s), "
+              f"{result.skipped} skipped, "
+              f"{len(result.placeholder_ids)} placeholder(s).")
+
+        if result.placeholder_ids:
+            # A placeholder page is empty, but its ID is not: it spells out the
+            # unexported file's path, which for a gm-only doc means publishing
+            # that filename to the player wiki's index and search. Name them all,
+            # so the operator sees exactly what is about to become visible.
+            print("\nPlaceholder page IDs — these names become visible in the "
+                  "player wiki's index and search:")
+            for pid in sorted(result.placeholder_ids):
+                print(f"  {pid}")
+
+        if args.render_only:
+            return 0
+
+        try:
+            return run_deploy(ws, staging, client, args.go,
+                              set(args.overwrite), ws.config.wiki_url)
+        except DeployError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/bunnyforge/deploy_export.py
+++ b/src/bunnyforge/deploy_export.py
@@ -402,6 +402,80 @@ def save_manifest(path: Path, pages: dict[str, str]) -> None:
     path.write_text(body + "\n", encoding="utf-8")
 
 
+# core.savePage refuses to create an empty page (error 132), so the render
+# half's zero-byte placeholder cannot cross RPC as-is. ~~NOTOC~~ renders
+# nothing, so the page displays blank while being non-empty and existing —
+# which is all a placeholder is for. The one place staged bytes are not sent
+# verbatim, and it carries no content.
+PLACEHOLDER_BODY = "~~NOTOC~~\n"
+
+PagePlan = namedtuple("PagePlan", "action wiki_text")
+DeployPlan = namedtuple("DeployPlan", "pages orphans resolved_orphans refused")
+
+
+def staged_pages(staging: Path) -> dict[str, str]:
+    """Page ID -> text for every staged page, placeholder translation applied."""
+    out: dict[str, str] = {}
+    for path in sorted(staging.rglob("*.txt")):
+        rel = path.relative_to(staging)
+        pid = ":".join((*rel.parts[:-1], rel.stem))
+        text = path.read_text(encoding="utf-8")
+        out[pid] = text if text else PLACEHOLDER_BODY
+    return out
+
+
+def _protected(staged_ids, base: str) -> list[str]:
+    """Belt and braces: the render half never generates these, but a render
+    bug must not become a wiki write. Never fetched, never written."""
+    names = {f"{base}:{name}" for name in PROTECTED_PAGE_NAMES}
+    prefix = f"{base}:players:"
+    return sorted(pid for pid in staged_ids
+                  if pid in names or pid.startswith(prefix))
+
+
+def plan_deploy(staged: dict[str, str], manifest: dict[str, str],
+                fetch, base: str) -> DeployPlan:
+    refused = _protected(staged, base)
+    pages: dict[str, PagePlan] = {}
+    for pid in sorted(staged):
+        if pid in refused:
+            continue
+        wiki_text = fetch(pid)
+        pages[pid] = PagePlan(
+            classify_page(staged[pid], wiki_text, manifest.get(pid)),
+            wiki_text)
+    orphans: list[str] = []
+    resolved: list[str] = []
+    for pid in sorted(set(manifest) - set(staged)):
+        # An orphan whose wiki page a human has since deleted resolves
+        # itself: it drops from the manifest (in --go) instead of being
+        # reported forever.
+        (orphans if fetch(pid) is not None else resolved).append(pid)
+    return DeployPlan(pages, orphans, resolved, refused)
+
+
+def write_order(page_ids, base: str) -> list[str]:
+    """Sorted page order, except each content page lands immediately before
+    its wrapper — so a wrapper never points at a not-yet-written include for
+    longer than one call."""
+    ids = sorted(page_ids)
+    present = set(ids)
+    export_prefix = f"{base}:export:"
+
+    def wrapper_of(pid: str) -> str:
+        return f"{base}:{pid[len(export_prefix):]}"
+
+    order: list[str] = []
+    for pid in ids:
+        if pid.startswith(export_prefix) and wrapper_of(pid) in present:
+            continue  # emitted just before its wrapper below
+        mate = f"{export_prefix}{pid[len(base) + 1:]}"
+        if mate in present:
+            order.append(mate)
+        order.append(pid)
+    return order
+
+
 if __name__ == "__main__":
     try:
         raise SystemExit(main())

--- a/src/bunnyforge/import_perceptions.py
+++ b/src/bunnyforge/import_perceptions.py
@@ -15,10 +15,10 @@ every historical revision in data/attic/ as `page.<unixtime>.txt.gz`. That gives
 exact session-boundary snapshots for free.
 
 Usage:
-    python3 -m bunnyforge.import_perceptions --wiki-data /path/to/dokuwiki/data
+    python3 -m bunnyforge.import_perceptions --wiki-data /path/to/dokuwiki/data  # dry run — default
+    python3 -m bunnyforge.import_perceptions --wiki-data ... --go
     python3 -m bunnyforge.import_perceptions --wiki-data ... --namespace party
     python3 -m bunnyforge.import_perceptions --wiki-data ... --as-of 2026-03-14
-    python3 -m bunnyforge.import_perceptions --wiki-data ... --dry-run
     python3 -m bunnyforge.import_perceptions --wiki-data ... --workspace /path/to/campaign
 """
 
@@ -192,7 +192,8 @@ def build_file(page_id: str, raw: str, mtime: int, as_of_label: str | None) -> s
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="bunnyforge import-perceptions",
-        description="Export player-authored DokuWiki pages into Perceptions/ (one-way).",
+        description="Export player-authored DokuWiki pages into Perceptions/ (one-way). "
+                    "The default is a dry run; pass --go to write.",
     )
     parser.add_argument(
         "--wiki-data",
@@ -213,7 +214,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Replace existing files in Perceptions/ (default: skip existing)",
     )
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be written")
+    parser.add_argument(
+        "--go", action="store_true",
+        help="Write the files. Without it this is a dry run that only "
+             "reports what would be written (the package-wide convention).")
     parser.add_argument(
         "--workspace", metavar="PATH",
         help="Campaign workspace root (default: $BUNNYFORGE_WORKSPACE, else "
@@ -262,7 +266,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No pages found in namespace '{args.namespace}'.")
         return 0
 
-    if not args.dry_run:
+    if args.go:
         perceptions_dir.mkdir(parents=True, exist_ok=True)
 
     written = skipped = missing = blank = 0
@@ -294,7 +298,7 @@ def main(argv: list[str] | None = None) -> int:
             continue
 
         content = build_file(page_id, raw, mtime, args.as_of)
-        if args.dry_run:
+        if not args.go:
             print(f"  [dry-run] would write     {dest.name}  ({len(content)} bytes)")
         else:
             dest.write_text(content, encoding="utf-8")
@@ -305,6 +309,8 @@ def main(argv: list[str] | None = None) -> int:
           f"{missing} unavailable.")
     if skipped and not args.overwrite:
         print("Use --overwrite to refresh existing captures.")
+    if not args.go and written:
+        print("Dry run: re-run with --go to write.")
     return 0
 
 

--- a/src/bunnyforge/review.py
+++ b/src/bunnyforge/review.py
@@ -351,6 +351,40 @@ def check_wiki_plugins(files: list[FileRec], wiki_root: Path) -> list[Finding]:
     return []
 
 
+# remoteuser's stock value is a placeholder DokuWiki treats as
+# not-configured; the check must treat it as unset, not as a scoping.
+_REMOTEUSER_UNSET = "!!not set!!"
+
+
+def check_wiki_remote(files: list[FileRec], wiki_root: Path) -> list[Finding]:
+    """The deploy transport's preconditions, stated as universal rules.
+
+    A disabled API is a legitimate secure state and yields no finding — the
+    deploy's own -32605 translation owns that path. Built on read_conf: no
+    network, so the suite stays runnable against a filesystem copy and CI
+    never needs a live wiki.
+    """
+    conf = dwi.read_conf(wiki_root)
+    remote = conf.get("remote")
+    if remote is None or not remote.value:
+        return []
+    out: list[Finding] = []
+    if remote.source not in _UPGRADE_SAFE_CONF:
+        out.append(Finding(
+            "error", "wiki-remote", f"conf/{remote.source}",
+            f"remote is enabled but set in {remote.source}, which DokuWiki "
+            f"upgrades overwrite — move it to conf/local.php"))
+    ru = conf.get("remoteuser")
+    value = str(ru.value).strip() if ru and ru.value is not None else ""
+    if not value or value == _REMOTEUSER_UNSET:
+        out.append(Finding(
+            "error", "wiki-remote", "conf/",
+            "remote is enabled but remoteuser is unset or empty — every "
+            "wiki account can call the API; scope it to the deploy user in "
+            "conf/local.php"))
+    return out
+
+
 CHECKS = {
     "visibility-audit": check_visibility_audit,
     "front-matter": check_front_matter,
@@ -360,6 +394,7 @@ CHECKS = {
     "wiki-conf": check_wiki_conf,
     "wiki-acl": check_wiki_acl,
     "wiki-plugins": check_wiki_plugins,
+    "wiki-remote": check_wiki_remote,
 }
 
 SUITES = {
@@ -368,7 +403,7 @@ SUITES = {
     # Deliberately not part of checkup: it needs a live install, which CI does
     # not have. Keeping it a separate suite is the whole skippability
     # mechanism — checkup never reaches off the local machine.
-    "wiki": ["wiki-conf", "wiki-acl", "wiki-plugins"],
+    "wiki": ["wiki-conf", "wiki-acl", "wiki-plugins", "wiki-remote"],
 }
 
 # Checks that need the full Workspace (its config), rather than just the
@@ -377,7 +412,7 @@ SUITES = {
 _NEEDS_WORKSPACE = frozenset({"wikilinks", "compendium"})
 # Checks taking a DokuWiki install root instead of anything from the
 # workspace — a third argument shape, alongside Workspace and workspace root.
-_NEEDS_WIKI = frozenset({"wiki-conf", "wiki-acl", "wiki-plugins"})
+_NEEDS_WIKI = frozenset({"wiki-conf", "wiki-acl", "wiki-plugins", "wiki-remote"})
 
 
 def run_suite(suite: str, ws: Workspace,

--- a/src/bunnyforge/review.py
+++ b/src/bunnyforge/review.py
@@ -382,6 +382,17 @@ def check_wiki_remote(files: list[FileRec], wiki_root: Path) -> list[Finding]:
             "remote is enabled but remoteuser is unset or empty — every "
             "wiki account can call the API; scope it to the deploy user in "
             "conf/local.php"))
+    elif ru.source not in _UPGRADE_SAFE_CONF:
+        # remoteuser holds the actual security boundary — remote merely
+        # turns the API on. A scoped value that lives outside local.php is
+        # one upgrade away from reverting to the stock placeholder, at
+        # which point every account regains API access, unremarked. Same
+        # failure the `remote` provenance rule above exists to prevent, on
+        # the more dangerous of the two settings.
+        out.append(Finding(
+            "error", "wiki-remote", f"conf/{ru.source}",
+            f"remoteuser is set but from {ru.source}, which DokuWiki "
+            f"upgrades overwrite — move it to conf/local.php"))
     return out
 
 

--- a/tests/live_wiki_check.py
+++ b/tests/live_wiki_check.py
@@ -74,6 +74,15 @@ Usage:
         --overwrite, adopt, and empty-page/placeholder checks. Writes to
         the live wiki named in PATH/campaign.toml's [wiki] url.
 
+    python3 tests/live_wiki_check.py --wiki-url URL --namespace NS [--go]
+        Same checks, run with no campaign workspace at all -- for CI, or
+        anywhere a campaign.toml is unavailable or beside the point.
+        --wiki-url and --namespace must be given together; each requires
+        the other. With no --workspace, the wiki token can only come from
+        the BUNNYFORGE_WIKI_TOKEN environment variable (there is no
+        workspace root to look for a token file under) -- if it is unset,
+        the script fails with an instructional error naming it.
+
 PYTHONPATH=src is required, exactly as for the rest of the suite — a
 published bunnyforge in site-packages otherwise shadows this working tree.
 """
@@ -574,7 +583,19 @@ def main(argv: list[str] | None = None) -> int:
         help="Campaign workspace root (default: $BUNNYFORGE_WORKSPACE, else "
              "the nearest campaign.toml above the current directory) -- "
              "the REAL workspace, read only for its [wiki] url, namespace, "
-             "and token; never written to")
+             "and token; never written to. Optional if --wiki-url and "
+             "--namespace are both given instead.")
+    parser.add_argument(
+        "--wiki-url", metavar="URL", default=None,
+        help="Wiki base URL, used instead of campaign.toml's [wiki] url. "
+             "Must be paired with --namespace; together they let this "
+             "script run with no --workspace and no campaign.toml at all "
+             "(e.g. in CI). With no --workspace, the wiki token can only "
+             "come from BUNNYFORGE_WIKI_TOKEN.")
+    parser.add_argument(
+        "--namespace", metavar="NS", default=None,
+        help="Wiki namespace, used instead of campaign.toml's "
+             "campaign.namespace. Must be paired with --wiki-url.")
     parser.add_argument(
         "--go", action="store_true",
         help="Also run the write checks (4-11): create/update a probe page "
@@ -583,26 +604,56 @@ def main(argv: list[str] | None = None) -> int:
              "read-only checks (1-3) run and nothing is written.")
     args = parser.parse_args(argv)
 
-    try:
-        real_ws = _config.resolve_workspace(args.workspace)
-    except Exception as exc:  # ConfigError / WorkspaceError, both user-facing
-        print(f"error: {exc}", file=sys.stderr)
+    if bool(args.wiki_url) != bool(args.namespace):
+        print(
+            "error: --wiki-url and --namespace must be given together "
+            "(both, or neither) -- pass both to run with no --workspace, "
+            "or drop both to fall back to --workspace / campaign.toml.",
+            file=sys.stderr)
         return 1
 
-    ns = real_ws.config.namespace
-    wiki_url = real_ws.config.wiki_url
-    if not wiki_url:
-        print("error: campaign.toml has no [wiki] url -- this check needs a "
-              "real wiki to talk to. Add:\n\n"
-              "  [wiki]\n"
-              '  url = "https://<wiki>"\n', file=sys.stderr)
-        return 1
+    # token_root is where a token FILE could live, if one is allowed at all.
+    # It is None exactly when there is no workspace to look under, which is
+    # the only case that collapses token resolution to the environment
+    # variable alone.
+    if args.wiki_url and args.namespace:
+        ns = args.namespace
+        wiki_url = args.wiki_url
+        token_root = Path(args.workspace).resolve() if args.workspace else None
+    else:
+        try:
+            real_ws = _config.resolve_workspace(args.workspace)
+        except Exception as exc:  # ConfigError / WorkspaceError, both user-facing
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
 
-    try:
-        token = _config.resolve_wiki_token(real_ws.root)
-    except Exception as exc:  # ConfigError
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
+        ns = real_ws.config.namespace
+        wiki_url = real_ws.config.wiki_url
+        token_root = real_ws.root
+        if not wiki_url:
+            print("error: campaign.toml has no [wiki] url -- this check needs a "
+                  "real wiki to talk to. Add:\n\n"
+                  "  [wiki]\n"
+                  '  url = "https://<wiki>"\n\n'
+                  "or pass --wiki-url URL --namespace NS to run without "
+                  "campaign.toml at all.", file=sys.stderr)
+            return 1
+
+    if token_root is not None:
+        try:
+            token = _config.resolve_wiki_token(token_root)
+        except Exception as exc:  # ConfigError
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    else:
+        token = os.environ.get(_config.TOKEN_ENV, "").strip()
+        if not token:
+            print(
+                "error: no wiki API token found. With no --workspace, the "
+                f"token can only come from the {_config.TOKEN_ENV} "
+                "environment variable, and it is not set. Export it, e.g.:\n"
+                f"  export {_config.TOKEN_ENV}=<token>", file=sys.stderr)
+            return 1
 
     try:
         client = RpcClient(wiki_url, token)

--- a/tests/live_wiki_check.py
+++ b/tests/live_wiki_check.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""
+live_wiki_check.py — an opt-in, human-invoked check of the JSON-RPC deploy
+transport against a REAL DokuWiki install.
+
+WHY THIS FILE EXISTS AND IS NOT A unittest.TestCase: every other test in this
+suite is offline by design — `_dokuwiki_rpc.RpcClient` takes an injectable
+transport precisely so nothing here ever opens a socket, and the design spec
+this pipeline implements says so explicitly: "no test touches the network;
+CI never needs a live wiki." That posture is deliberately never broken. This
+script is the escape hatch for the one thing a fake transport cannot prove:
+that a *real* DokuWiki, with its own quirks (see the two bugs this script
+was written to prevent from recurring, below), actually accepts what
+bunnyforge sends it. It is discovered by nobody: `unittest discover`'s
+default pattern is `test*.py`, and this file is named so it never matches —
+verified by running the full suite before and after adding it and confirming
+the count does not move.
+
+WHAT IT PROVES. A first-time deployer configures `[wiki] url` and a token,
+then runs this script to gain confidence *before* pointing the real
+`deploy-export --go` at their campaign — the same way `check_portability.py`
+lets a culture author gain confidence before publishing a name file. Two
+genuine bugs were found this way during this feature's first live deploy
+(both fixed, both now permanent assertions here so they can never silently
+regress):
+
+  1. `get_page()` on a missing page must return None. On the API v14 install
+     this was verified against, a missing page comes back as an EMPTY STRING
+     with a success error object, never the error code the original design
+     assumed — see check 2 below.
+  2. The credential must go out as `X-DokuWiki-Token`, not just
+     `Authorization: Bearer` — some hosts run PHP as CGI/FastCGI and Apache
+     strips the Authorization header before PHP ever sees it. This script
+     does not re-test that directly (it is a header the client always sends,
+     not something observable from here), but the very fact that check 1's
+     handshake succeeds at all is live proof the credential got through.
+
+WHAT IT DOES NOT PROVE. This tool cannot delete wiki pages, so this script
+cannot either — it never claims to. It cannot check that the `~~NOTOC~~`
+placeholder body actually *renders* blank; that needs a browser (see check
+11). It is not exhaustive: it is the specific battery the human asked for,
+built around one property that makes it safe to run repeatedly — see below.
+
+SAFETY. Three separate guarantees, each load-bearing:
+
+  - **Never runs by accident.** Checks 1-3 are read-only and always run.
+    Checks 4-11 write to the wiki and run ONLY with the explicit --go flag,
+    matching this package's dry-run/--go convention everywhere else.
+  - **Never touches the operator's real deploy state.** The real
+    `<workspace>/.bunnyforge/wiki-manifest.json` is a committed baseline for
+    a real campaign; this script never opens it. Every write check builds
+    its OWN temporary workspace — a throwaway `campaign.toml` copying only
+    `namespace` and `[wiki] url` from the real one, and its own manifest —
+    so nothing this script does can perturb the operator's real baseline.
+    The credential travels via the `BUNNYFORGE_WIKI_TOKEN` environment
+    variable, so the real token file is read once (to get the value) and
+    never copied anywhere.
+  - **Bounded, reusable footprint.** The tool cannot delete pages, so
+    proliferation would be a real cost of re-running this script. Every
+    write check uses a small number of STABLE page IDs under a
+    `live-wiki-check` sub-path of the operator's own namespace, and running
+    the whole script ten times in a row updates those same IDs in place
+    rather than minting new ones each time — this is what makes checks 4-9
+    (create, idempotent, edit, drift, overwrite, adopt) a coherent story
+    instead of a pile of one-off pages. See the module-level PROBE_* names.
+
+Usage:
+    python3 tests/live_wiki_check.py --workspace PATH
+        Read-only checks only (1-3): handshake, missing-page contract,
+        protected-page guard. Writes nothing to the wiki.
+
+    python3 tests/live_wiki_check.py --workspace PATH --go
+        All checks (1-11), including the roundtrip-edit, drift-holdback,
+        --overwrite, adopt, and empty-page/placeholder checks. Writes to
+        the live wiki named in PATH/campaign.toml's [wiki] url.
+
+PYTHONPATH=src is required, exactly as for the rest of the suite — a
+published bunnyforge in site-packages otherwise shadows this working tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import os
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from bunnyforge import _config
+from bunnyforge import deploy_export
+from bunnyforge._dokuwiki import page_id as _page_id
+from bunnyforge._dokuwiki_rpc import RpcClient, RpcError
+
+# ---------------------------------------------------------------------------
+# Stable probe identity. Everything this script writes lives under this one
+# sub-path of the operator's own namespace, so a human who wants to clean up
+# afterwards (this tool cannot: see the module docstring) knows exactly
+# where to look, and re-running the script never mints a new page.
+# ---------------------------------------------------------------------------
+
+PROBE_DIR = "live-wiki-check"
+PROBE_STEM = "probe"
+PROBE_REL_PATH = f"{PROBE_DIR}/{PROBE_STEM}.md"
+
+# Two source bodies for the same probe page. V1 is what checks 4/5 deploy and
+# confirm; V2 is what check 6 (the roundtrip *edit*, as opposed to check 4's
+# create) changes to and confirms again. Both are deliberately inert prose —
+# nothing here should ever look like real campaign content to a passerby.
+PROBE_BODY_V1 = (
+    "# bunnyforge live-wiki-check probe\n\n"
+    "This page is maintained by an opt-in diagnostic script "
+    "(tests/live_wiki_check.py in the bunnyforge repository) that exercises "
+    "the JSON-RPC deploy transport against this wiki installation. It is "
+    "safe to ignore. Edits made directly on this page will be reported as "
+    "drift the next time the script runs with --go.\n\n"
+    "State marker: v1\n"
+)
+PROBE_BODY_V2 = (
+    "# bunnyforge live-wiki-check probe\n\n"
+    "This page is maintained by an opt-in diagnostic script "
+    "(tests/live_wiki_check.py in the bunnyforge repository) that exercises "
+    "the JSON-RPC deploy transport against this wiki installation. It is "
+    "safe to ignore. Edits made directly on this page will be reported as "
+    "drift the next time the script runs with --go.\n\n"
+    "State marker: v2 -- this text proves the roundtrip EDIT path, not just "
+    "the initial create.\n"
+)
+
+# What a human editing the probe directly on the wiki looks like, for the
+# drift-holdback check (7). Deliberately unlike either body above, so a
+# comparison failure is unambiguous about which text won.
+MANUAL_EDIT_BODY = (
+    "====== drifted ======\n\n"
+    "Someone edited this page directly on the wiki, bypassing bunnyforge. "
+    "If bunnyforge is working, this text survives the next deploy and is "
+    "reported as held-back drift instead of being silently overwritten.\n"
+)
+
+# Actions plan_deploy can report that mean "held back, not written". Mirrors
+# deploy_export's own private _HELD tuple; kept as a local literal rather than
+# reaching into that module's underscore-prefixed name, since it is not part
+# of the interface this script was asked to use.
+_HELD_ACTIONS = frozenset({"drift", "drift-manual-era", "deleted-on-wiki"})
+
+_DEPLOY_SUMMARY_RE = re.compile(r"Deployed (\d+) page\(s\), adopted (\d+)\.")
+
+
+# ---------------------------------------------------------------------------
+# Small helpers shared by the write checks
+# ---------------------------------------------------------------------------
+
+def _norm(text: str) -> str:
+    """Compare wiki text against rendered text ignoring only a trailing
+    newline: DokuWiki normalizes that much on save (see deploy_export's own
+    page_hash docstring), and comparing on anything more forgiving would
+    risk masking a real content mismatch."""
+    return text.rstrip("\n")
+
+
+def _write_probe(export_dir: Path, body: str) -> None:
+    dest = export_dir / PROBE_REL_PATH
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(body, encoding="utf-8")
+
+
+def _render_expected(export_dir: Path, ns: str) -> dict[str, str]:
+    """What deploy_export would stage right now, computed independently of
+    any actual deploy run. Used both to know what to compare live wiki
+    content against, and (via plan_deploy below) to inspect a classification
+    before ever invoking main()."""
+    staging = Path(tempfile.mkdtemp(prefix="live-wiki-check-render-"))
+    try:
+        deploy_export.render_tree(export_dir, staging, base=ns)
+        return deploy_export.staged_pages(staging)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _plan_now(export_dir: Path, ns: str, manifest_path: Path, client):
+    """The plan deploy_export.main() would compute right now, without
+    running it -- lets each check assert on a structured DeployPlan.action
+    rather than scraping the CLI's printed report."""
+    staged = _render_expected(export_dir, ns)
+    manifest = deploy_export.load_manifest(manifest_path)
+    plan = deploy_export.plan_deploy(staged, manifest, client.get_page, ns)
+    return staged, plan
+
+
+def _run_main(ws_root: Path, export_dir: Path, go: bool, overwrite=()):
+    """Drive the real deploy_export CLI in-process, capturing its stdout and
+    stderr so this script controls its own report and can surface the
+    captured text when a check fails."""
+    argv = ["--workspace", str(ws_root), "--export-dir", str(export_dir)]
+    if go:
+        argv.append("--go")
+    for pid in overwrite:
+        argv += ["--overwrite", pid]
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = deploy_export.main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+class Ctx:
+    """Bag of values every write check needs. A plain object rather than a
+    namedtuple -- nothing here is ever reconstructed positionally."""
+
+    def __init__(self, client, ns, ws_root, export_dir, manifest_path):
+        self.client = client
+        self.ns = ns
+        self.ws_root = ws_root
+        self.export_dir = export_dir
+        self.manifest_path = manifest_path
+        self.content_id = _page_id(PROBE_REL_PATH, f"{ns}:export")
+        self.wrapper_id = _page_id(PROBE_REL_PATH, ns)
+        self.players_id = _page_id(PROBE_REL_PATH, f"{ns}:players")
+
+
+# ---------------------------------------------------------------------------
+# Read-only checks (1-3) -- always run, never write to the wiki
+# ---------------------------------------------------------------------------
+
+def check_handshake(client: RpcClient) -> str:
+    """1. Endpoint and auth handshake: core.getAPIVersion must succeed at
+    all, which proves the URL is reachable, the endpoint exists, and both
+    credential headers were accepted."""
+    version = client.call("core.getAPIVersion", {})
+    return f"core.getAPIVersion() -> {version!r}"
+
+
+def check_missing_page_returns_none(client: RpcClient, ns: str) -> str:
+    """2. get_page() on a page that cannot exist must return None. This is
+    the exact assumption that was WRONG on the live install this transport
+    was verified against (API v14 returns "" with a success error object,
+    never error 121) -- worth asserting on every install, not just the one
+    that first surfaced it."""
+    missing_id = f"{ns}:{PROBE_DIR}:__this-page-must-never-exist__"
+    result = client.get_page(missing_id)
+    assert result is None, (
+        f"get_page({missing_id!r}) returned {result!r}, not None. Either "
+        "this page id has genuinely been created on the wiki (rename the "
+        "check), or get_page's 'missing page' contract has regressed -- see "
+        "_dokuwiki_rpc.RpcClient.get_page's docstring for the two shapes "
+        "(error 121, or a success response whose result is empty) it must "
+        "both treat as 'does not exist'.")
+    return f"get_page({missing_id!r}) -> None, as expected"
+
+
+def check_protected_guard(ns: str) -> str:
+    """3. The protected-page guard: a staged page id equal to <ns>:main or
+    under <ns>:players: must never be fetched and never be written, even if
+    something upstream of plan_deploy staged it by mistake. Exercised
+    entirely offline with a fake fetch that records every id it is called
+    with -- no network needed, so this check runs even without --go."""
+    calls: list[str] = []
+
+    def fake_fetch(pid: str):
+        calls.append(pid)
+        return None
+
+    protected_main = f"{ns}:main"
+    protected_player_page = f"{ns}:players:some-players-page"
+    ordinary = f"{ns}:{PROBE_DIR}:guard-contrast"
+    staged = {
+        protected_main: "must never be fetched or written",
+        protected_player_page: "must never be fetched or written",
+        ordinary: "an ordinary staged page, for contrast",
+    }
+    plan = deploy_export.plan_deploy(staged, {}, fake_fetch, ns)
+
+    for pid in (protected_main, protected_player_page):
+        assert pid not in calls, (
+            f"the protected-page guard fetched {pid!r} -- it must never be "
+            "fetched, let alone written")
+        assert pid not in plan.pages, (
+            f"{pid!r} appears in plan.pages -- the protected-page guard "
+            "must exclude it entirely, not merely skip writing it")
+        assert pid in plan.refused, (
+            f"{pid!r} was not reported in plan.refused")
+    assert ordinary in calls, (
+        "the guard's contrast page was never fetched either -- this check "
+        "would pass even if plan_deploy fetched nothing at all, so it "
+        "proves nothing about the guard specifically")
+    return (f"plan_deploy() never fetched or staged {protected_main!r} or "
+            f"{protected_player_page!r} (both reported refused); an "
+            f"ordinary page ({ordinary!r}) staged alongside them WAS "
+            "fetched, ruling out a guard that simply fetches nothing")
+
+
+# ---------------------------------------------------------------------------
+# Write checks (4-11) -- only with --go
+# ---------------------------------------------------------------------------
+
+def check_create_or_update(ctx: Ctx) -> str:
+    """4. Create or update the probe page -- the roundtrip the human
+    specifically asked for. This script's temp manifest starts empty on
+    EVERY invocation (by design: it must never persist across runs), so if
+    the wiki already carries a probe page from an earlier invocation of this
+    script, plan_deploy sees "no baseline, content differs" -- the same
+    shape as manual-era drift. That is reconciled here with --overwrite
+    (this script's own leftover test data, not a real editor's drift) so the
+    check is robust to any starting state; the genuine day-to-day 'update'
+    path is exercised for real by check 6 below, within a manifest this run
+    itself created."""
+    _write_probe(ctx.export_dir, PROBE_BODY_V1)
+    staged, plan = _plan_now(ctx.export_dir, ctx.ns, ctx.manifest_path, ctx.client)
+    content_action = plan.pages[ctx.content_id].action
+    overwrite = [ctx.content_id] if content_action in _HELD_ACTIONS else []
+    verb = ("reconciled (leftover content from an earlier run of this "
+            "script)" if overwrite else content_action)
+
+    rc, out, err = _run_main(ctx.ws_root, ctx.export_dir, go=True, overwrite=overwrite)
+    assert rc == 0, (
+        f"deploying the probe page failed unexpectedly (rc={rc}).\n"
+        f"--- stdout ---\n{out}--- stderr ---\n{err}")
+
+    wiki_text = ctx.client.get_page(ctx.content_id)
+    expected = staged[ctx.content_id]
+    assert wiki_text is not None and _norm(wiki_text) == _norm(expected), (
+        f"after deploying the probe page ({verb}), the wiki content does "
+        f"not match what was rendered.\nexpected:\n{expected!r}\n"
+        f"wiki:\n{wiki_text!r}\n--- stdout ---\n{out}")
+    return (f"probe page {verb} at {ctx.content_id}; wiki content matches "
+            f"the rendered source ({len(expected)} bytes)")
+
+
+def check_idempotent(ctx: Ctx) -> str:
+    """5. Idempotency: deploying again immediately, with nothing changed,
+    must write zero pages and classify every page 'unchanged'. This is also
+    what proves the read-back-hash discipline (page_hash() hashes what
+    get_page returns, never the bytes sent) -- hashing sent bytes instead
+    would make every page look self-drifted on exactly this check."""
+    _staged, plan_before = _plan_now(
+        ctx.export_dir, ctx.ns, ctx.manifest_path, ctx.client)
+    for pid in (ctx.content_id, ctx.wrapper_id):
+        action = plan_before.pages[pid].action
+        assert action == "unchanged", (
+            f"expected {pid} to classify 'unchanged' before the idempotency "
+            f"redeploy, got {action!r} -- either check 4 did not leave a "
+            "clean baseline, or the wiki page changed between checks")
+
+    rc, out, err = _run_main(ctx.ws_root, ctx.export_dir, go=True)
+    assert rc == 0, (
+        f"the idempotent redeploy failed (rc={rc}).\n"
+        f"--- stdout ---\n{out}--- stderr ---\n{err}")
+    m = _DEPLOY_SUMMARY_RE.search(out)
+    assert m, f"could not find the deploy summary line in stdout:\n{out}"
+    written, adopted = int(m.group(1)), int(m.group(2))
+    assert written == 0, (
+        f"a redeploy with no source change wrote {written} page(s); a "
+        "second consecutive run should write zero, or the read-back hash "
+        f"discipline has regressed.\n--- stdout ---\n{out}")
+    return (f"redeploy with no source change wrote 0 page(s) (adopted "
+            f"{adopted}); both probe pages classified 'unchanged' beforehand")
+
+
+def check_roundtrip_edit(ctx: Ctx) -> str:
+    """6. Roundtrip edit: change the probe's source and redeploy. This is
+    the literal 'update an existing test page' case the human asked for,
+    distinct from check 4's first-run create -- here the manifest this run
+    itself built has a real baseline, so the classification is genuinely
+    'update', not the reconciliation check 4 sometimes needs."""
+    _write_probe(ctx.export_dir, PROBE_BODY_V2)
+    staged, plan = _plan_now(ctx.export_dir, ctx.ns, ctx.manifest_path, ctx.client)
+    action = plan.pages[ctx.content_id].action
+    assert action == "update", (
+        f"expected the content page to classify 'update' after changing its "
+        f"source text, got {action!r}")
+
+    rc, out, err = _run_main(ctx.ws_root, ctx.export_dir, go=True)
+    assert rc == 0, (
+        f"the roundtrip-edit redeploy failed (rc={rc}).\n"
+        f"--- stdout ---\n{out}--- stderr ---\n{err}")
+    wiki_text = ctx.client.get_page(ctx.content_id)
+    expected = staged[ctx.content_id]
+    assert wiki_text is not None and _norm(wiki_text) == _norm(expected), (
+        "after redeploying with changed source, the wiki content does not "
+        f"match the new render.\nexpected:\n{expected!r}\n"
+        f"wiki:\n{wiki_text!r}\n--- stdout ---\n{out}")
+    return ("changed the probe's source text and redeployed: classified "
+            "'update'; wiki content now matches the new text")
+
+
+def check_drift_holdback(ctx: Ctx) -> str:
+    """7. Drift hold-back: edit the page directly on the wiki (bypassing
+    bunnyforge entirely), then redeploy. Must hold the page back rather than
+    clobber the manual edit, report a unified diff, write an inbound copy
+    under wiki-drift/, and exit non-zero."""
+    ctx.client.save_page(ctx.content_id, MANUAL_EDIT_BODY)
+    assert ctx.client.get_page(ctx.content_id) is not None
+
+    rc, out, err = _run_main(ctx.ws_root, ctx.export_dir, go=True)
+    assert rc != 0, (
+        "redeploying after a manual wiki edit should exit non-zero (a page "
+        f"was held back), but rc=0.\n--- stdout ---\n{out}")
+    assert re.search(rf"HELD\s+{re.escape(ctx.content_id)}\b", out), (
+        f"expected a HELD report naming {ctx.content_id} in stdout:\n{out}")
+    assert "--- wiki (current)" in out and "+++ deploy (target)" in out, (
+        f"expected a unified diff in the deploy report:\n{out}")
+
+    survived = ctx.client.get_page(ctx.content_id)
+    assert survived is not None and _norm(survived) == _norm(MANUAL_EDIT_BODY), (
+        "the manual wiki edit did not survive the redeploy -- the held-back "
+        f"page was overwritten anyway.\nwiki now:\n{survived!r}")
+
+    drift_copy = deploy_export.page_path(
+        ctx.content_id, ctx.ws_root / deploy_export.DRIFT_DIR)
+    assert drift_copy.is_file(), (
+        f"expected an inbound drift copy at {drift_copy}, but it does not "
+        "exist")
+    copy_text = drift_copy.read_text(encoding="utf-8")
+    assert _norm(copy_text) == _norm(MANUAL_EDIT_BODY), (
+        f"the drift copy at {drift_copy} does not match the wiki's current "
+        f"text.\ncopy:\n{copy_text!r}")
+    return (f"manual edit to {ctx.content_id} survived the redeploy; held "
+            "back with a unified diff; inbound copy written under "
+            f"{drift_copy.relative_to(ctx.ws_root)}; exit code was non-zero")
+
+
+def check_overwrite(ctx: Ctx) -> str:
+    """8. --overwrite: rerun naming the drifted page. Must be written and
+    re-baselined, and the wiki edit from check 7 must be gone."""
+    staged, plan = _plan_now(ctx.export_dir, ctx.ns, ctx.manifest_path, ctx.client)
+    action = plan.pages[ctx.content_id].action
+    assert action == "drift", (
+        f"expected {ctx.content_id} to still classify 'drift' going into "
+        f"the --overwrite check, got {action!r}")
+
+    rc, out, err = _run_main(
+        ctx.ws_root, ctx.export_dir, go=True, overwrite=[ctx.content_id])
+    assert rc == 0, (
+        f"the --overwrite redeploy failed (rc={rc}).\n"
+        f"--- stdout ---\n{out}--- stderr ---\n{err}")
+
+    wiki_text = ctx.client.get_page(ctx.content_id)
+    expected = staged[ctx.content_id]
+    assert wiki_text is not None and _norm(wiki_text) == _norm(expected), (
+        "after --overwrite, the wiki content does not match the rendered "
+        f"source.\nexpected:\n{expected!r}\nwiki:\n{wiki_text!r}")
+
+    manifest = deploy_export.load_manifest(ctx.manifest_path)
+    assert manifest.get(ctx.content_id) == deploy_export.page_hash(wiki_text), (
+        "the manifest was not re-baselined to the new wiki content after "
+        "--overwrite")
+    return (f"--overwrite {ctx.content_id}: written and re-baselined; the "
+            "manual edit from the drift check is gone")
+
+
+def check_adopt_resume(ctx: Ctx) -> str:
+    """9. Adopt / resume-after-crash: clobber the manifest's recorded
+    hashes (simulating a run that saved a page but died before writing the
+    manifest), then redeploy. Must classify 'adopt', write zero pages
+    (the wiki already matches what would be sent), and re-baseline the
+    manifest to the real wiki hash."""
+    manifest = deploy_export.load_manifest(ctx.manifest_path)
+    for pid in (ctx.content_id, ctx.wrapper_id):
+        assert pid in manifest, (
+            f"expected {pid} to already be in the manifest before the "
+            "adopt check")
+    bogus = "0" * 64
+    clobbered = dict(manifest)
+    clobbered[ctx.content_id] = bogus
+    clobbered[ctx.wrapper_id] = bogus
+    deploy_export.save_manifest(ctx.manifest_path, clobbered)
+
+    _staged, plan = _plan_now(ctx.export_dir, ctx.ns, ctx.manifest_path, ctx.client)
+    for pid in (ctx.content_id, ctx.wrapper_id):
+        action = plan.pages[pid].action
+        assert action == "adopt", (
+            f"expected {pid} to classify 'adopt' after clobbering its "
+            f"manifest hash (wiki content unchanged), got {action!r}")
+
+    rc, out, err = _run_main(ctx.ws_root, ctx.export_dir, go=True)
+    assert rc == 0, (
+        f"the adopt redeploy failed (rc={rc}).\n"
+        f"--- stdout ---\n{out}--- stderr ---\n{err}")
+    m = _DEPLOY_SUMMARY_RE.search(out)
+    assert m, f"could not find the deploy summary line in stdout:\n{out}"
+    written, adopted = int(m.group(1)), int(m.group(2))
+    assert written == 0, (
+        f"the adopt redeploy wrote {written} page(s); expected 0.\n{out}")
+    assert adopted >= 2, (
+        f"expected at least 2 adopted pages, got {adopted}.\n{out}")
+
+    new_manifest = deploy_export.load_manifest(ctx.manifest_path)
+    for pid in (ctx.content_id, ctx.wrapper_id):
+        wiki_text = ctx.client.get_page(pid)
+        assert new_manifest.get(pid) == deploy_export.page_hash(wiki_text), (
+            f"the manifest entry for {pid} was not re-baselined to the "
+            "real wiki hash after adopt")
+    return (f"clobbered manifest hashes for {ctx.content_id} and "
+            f"{ctx.wrapper_id}; redeploy classified both 'adopt', wrote 0 "
+            "pages, and re-baselined the manifest to the real wiki hash")
+
+
+def check_empty_page_refused(ctx: Ctx) -> str:
+    """10. core.savePage must refuse an empty page with error 132 -- the
+    premise both the ~~NOTOC~~ placeholder design and get_page's empty-result
+    handling rest on. Uses a page id that has never been written by anything
+    in this script, so a refusal can never be misread as "deleted real
+    content"."""
+    probe_id = f"{ctx.ns}:{PROBE_DIR}:empty-page-refusal-probe"
+    pre = ctx.client.get_page(probe_id)
+    assert pre is None, (
+        f"{probe_id} already exists on the wiki -- this check needs a page "
+        "that has never existed, so a refused empty save can never be "
+        "misread as deleting real content. Delete it by hand, or pick a "
+        "different id, before re-running.")
+    try:
+        ctx.client.save_page(probe_id, "")
+    except RpcError as exc:
+        assert exc.code == 132, (
+            f"expected error 132 (empty page refused), got code "
+            f"{exc.code!r}: {exc.message}")
+    else:
+        raise AssertionError(
+            f"core.savePage accepted an empty body for {probe_id} instead "
+            "of refusing it with error 132 -- the ~~NOTOC~~ placeholder "
+            "design assumes this call always fails")
+    post = ctx.client.get_page(probe_id)
+    assert post is None, (
+        f"{probe_id} exists after the refused empty save -- expected it to "
+        "still not exist")
+    return f"core.savePage({probe_id!r}, '') refused with error 132, as expected"
+
+
+def check_notoc_placeholder(ctx: Ctx) -> str:
+    """11. The ~~NOTOC~~ placeholder body must save and count as existing.
+    Whether it actually *renders* blank cannot be checked programmatically
+    from here -- that needs a browser -- so this check only proves the
+    "exists" half and says so."""
+    probe_id = f"{ctx.ns}:{PROBE_DIR}:placeholder-probe"
+    ctx.client.save_page(probe_id, deploy_export.PLACEHOLDER_BODY)
+    result = ctx.client.get_page(probe_id)
+    assert result is not None, (
+        f"{probe_id} does not exist after saving the ~~NOTOC~~ placeholder "
+        "body -- get_page treats an empty result as 'does not exist', so a "
+        "wiki that renders ~~NOTOC~~ down to a truly empty stored page "
+        "would break the placeholder design")
+    return (f"saved the ~~NOTOC~~ placeholder body to {probe_id}; get_page "
+            "confirms it exists. Whether it RENDERS blank cannot be checked "
+            "from this script -- open the page in a browser to confirm.")
+
+
+# ---------------------------------------------------------------------------
+# Runner / report
+# ---------------------------------------------------------------------------
+
+def _run_one(name: str, fn, *args) -> tuple[bool, str]:
+    print(f"--- {name} ---")
+    try:
+        detail = fn(*args)
+    except AssertionError as exc:
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return False, str(exc)
+    except RpcError as exc:
+        print(f"FAILED (RPC error): {exc}", file=sys.stderr)
+        return False, str(exc)
+    print(f"PASSED: {detail}")
+    return True, detail
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Opt-in, human-invoked check of the JSON-RPC deploy "
+                    "transport against a real DokuWiki. Never runs in CI "
+                    "or the normal test suite.")
+    parser.add_argument(
+        "--workspace", metavar="PATH", default=None,
+        help="Campaign workspace root (default: $BUNNYFORGE_WORKSPACE, else "
+             "the nearest campaign.toml above the current directory) -- "
+             "the REAL workspace, read only for its [wiki] url, namespace, "
+             "and token; never written to")
+    parser.add_argument(
+        "--go", action="store_true",
+        help="Also run the write checks (4-11): create/update a probe page "
+             "on the live wiki, edit it, hold back drift, overwrite, adopt, "
+             "and probe two RPC edge cases. Without --go, only the "
+             "read-only checks (1-3) run and nothing is written.")
+    args = parser.parse_args(argv)
+
+    try:
+        real_ws = _config.resolve_workspace(args.workspace)
+    except Exception as exc:  # ConfigError / WorkspaceError, both user-facing
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    ns = real_ws.config.namespace
+    wiki_url = real_ws.config.wiki_url
+    if not wiki_url:
+        print("error: campaign.toml has no [wiki] url -- this check needs a "
+              "real wiki to talk to. Add:\n\n"
+              "  [wiki]\n"
+              '  url = "https://<wiki>"\n', file=sys.stderr)
+        return 1
+
+    try:
+        token = _config.resolve_wiki_token(real_ws.root)
+    except Exception as exc:  # ConfigError
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        client = RpcClient(wiki_url, token)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"live_wiki_check: namespace={ns!r}, --go={args.go}\n")
+
+    results: list[tuple[str, bool]] = []
+    ok, _ = _run_one("1. handshake", check_handshake, client)
+    results.append(("1. handshake", ok))
+    ok, _ = _run_one("2. missing-page contract", check_missing_page_returns_none,
+                     client, ns)
+    results.append(("2. missing-page contract", ok))
+    ok, _ = _run_one("3. protected-page guard", check_protected_guard, ns)
+    results.append(("3. protected-page guard", ok))
+
+    read_only_ok = all(ok for _, ok in results)
+
+    touched_pages: list[str] = []
+
+    if not args.go:
+        print("\nWrite checks (4-11) SKIPPED: pass --go to run them. Without "
+              "--go this script never writes to the wiki, matching the "
+              "package-wide dry-run/--go convention.")
+    elif not read_only_ok:
+        print("\nWrite checks (4-11) SKIPPED: a read-only check failed "
+              "above. Fixing the misconfiguration it reports is safer than "
+              "writing to a wiki this script cannot yet talk to correctly.",
+              file=sys.stderr)
+    else:
+        real_token_env = os.environ.get("BUNNYFORGE_WIKI_TOKEN")
+        os.environ["BUNNYFORGE_WIKI_TOKEN"] = token
+        tmp_root = Path(tempfile.mkdtemp(prefix="bunnyforge-live-wiki-check-"))
+        try:
+            (tmp_root / "campaign.toml").write_text(
+                f'[campaign]\nnamespace = "{ns}"\n\n'
+                f'[wiki]\nurl = "{wiki_url}"\n',
+                encoding="utf-8")
+            export_dir = tmp_root / "Export"
+            export_dir.mkdir()
+            manifest_path = tmp_root / deploy_export.MANIFEST_FILE
+            ctx = Ctx(client, ns, tmp_root, export_dir, manifest_path)
+
+            write_checks = [
+                ("4. create or update probe page", check_create_or_update),
+                ("5. idempotency", check_idempotent),
+                ("6. roundtrip edit", check_roundtrip_edit),
+                ("7. drift hold-back", check_drift_holdback),
+                ("8. --overwrite", check_overwrite),
+                ("9. adopt / resume-after-crash", check_adopt_resume),
+                ("10. savePage refuses empty page", check_empty_page_refused),
+                ("11. ~~NOTOC~~ placeholder", check_notoc_placeholder),
+            ]
+            for i, (name, fn) in enumerate(write_checks):
+                ok, _ = _run_one(name, fn, ctx)
+                results.append((name, ok))
+                if not ok:
+                    for skipped_name, _ in write_checks[i + 1:]:
+                        print(f"--- {skipped_name} ---\nSKIPPED: an earlier "
+                              "check failed and later checks assume its "
+                              "state.")
+                        results.append((skipped_name, False))
+                    break
+
+            touched_pages = [ctx.wrapper_id, ctx.content_id,
+                             f"{ns}:{PROBE_DIR}:placeholder-probe"]
+        finally:
+            shutil.rmtree(tmp_root, ignore_errors=True)
+            if real_token_env is None:
+                os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+            else:
+                os.environ["BUNNYFORGE_WIKI_TOKEN"] = real_token_env
+
+    print("\n--- summary ---")
+    for name, ok in results:
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+
+    if touched_pages:
+        print("\nPage(s) this run created or updated on the live wiki:")
+        for pid in touched_pages:
+            print(f"  {pid}")
+        print("This tool cannot delete wiki pages -- removing them, if "
+              "ever wanted, is a manual act on the wiki itself.")
+
+    passed = all(ok for _, ok in results)
+    print(f"\n{'PASSED' if passed else 'FAILED'}")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 from unittest import mock
 
@@ -374,6 +375,86 @@ class TestResolveWorkspace(unittest.TestCase):
                                return_value=root):
             ws = _config.resolve_workspace("")
         self.assertEqual(ws.root, root)
+
+
+class TestWikiConfig(unittest.TestCase):
+    def _load(self, toml_text):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "campaign.toml").write_text(toml_text, encoding="utf-8")
+            return _config.load(root)
+
+    def test_wiki_url_parsed(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n'
+                         '[wiki]\nurl = "https://wiki.example"\n')
+        self.assertEqual(cfg.wiki_url, "https://wiki.example")
+
+    def test_wiki_table_absent_is_none(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n')
+        self.assertIsNone(cfg.wiki_url)
+
+    def test_wiki_url_non_string_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n[wiki]\nurl = 7\n')
+
+    def test_wiki_non_table_refused(self):
+        # `wiki = "x"` must precede any table header, same TOML-scoping trap
+        # noted in TestConfigLoad.test_names_section_must_be_a_table: a bare
+        # key after [campaign] would be swallowed into campaign.wiki rather
+        # than staying a top-level `wiki` key, and this test would then
+        # assert nothing.
+        with self.assertRaises(_config.ConfigError):
+            self._load('wiki = "x"\n[campaign]\nnamespace = "test"\n')
+
+
+class TestWikiToken(unittest.TestCase):
+    def _token_file(self, root: Path, text, mode=0o600):
+        path = root / ".bunnyforge" / "wiki-token"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        path.chmod(mode)
+        return path
+
+    def test_env_wins(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._token_file(Path(d), "filetoken\n")
+            with unittest.mock.patch.dict(
+                    os.environ, {"BUNNYFORGE_WIKI_TOKEN": "envtoken"}):
+                self.assertEqual(_config.resolve_wiki_token(Path(d)), "envtoken")
+
+    def test_file_fallback_strips_trailing_whitespace(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._token_file(Path(d), "tok123\n")
+            with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+                self.assertEqual(_config.resolve_wiki_token(Path(d)), "tok123")
+
+    def test_group_readable_file_refused_with_chmod_instruction(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._token_file(Path(d), "tok123\n", mode=0o644)
+            # Wrapped in patch.dict so the pop below is undone on exit
+            # regardless of ambient state or test outcome — a bare pop with
+            # no restore would permanently delete a pre-existing
+            # BUNNYFORGE_WIKI_TOKEN from the test process for every test
+            # that runs after this one.
+            with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+                with self.assertRaises(_config.ConfigError) as ctx:
+                    _config.resolve_wiki_token(Path(d))
+                self.assertIn("chmod 600", str(ctx.exception))
+
+    def test_missing_both_names_both_sources(self):
+        with tempfile.TemporaryDirectory() as d:
+            # See test_group_readable_file_refused_with_chmod_instruction
+            # above for why the pop is wrapped rather than bare.
+            with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+                with self.assertRaises(_config.ConfigError) as ctx:
+                    _config.resolve_wiki_token(Path(d))
+                msg = str(ctx.exception)
+                self.assertIn("BUNNYFORGE_WIKI_TOKEN", msg)
+                self.assertIn(".bunnyforge/wiki-token", msg)
+                self.assertIn("API token", msg)  # says where a token comes from
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -443,6 +443,37 @@ class TestWikiToken(unittest.TestCase):
                     _config.resolve_wiki_token(Path(d))
                 self.assertIn("chmod 600", str(ctx.exception))
 
+    def test_world_writable_parent_dir_refused_with_chmod_instruction(self):
+        # A private token file inside a directory anyone can write is not
+        # private: whoever can write .bunnyforge/ can unlink the token and
+        # drop their own in its place, and the deploy would then authenticate
+        # to a wiki with a credential it did not choose. Checking the file's
+        # own mode says nothing about that.
+        with tempfile.TemporaryDirectory() as d:
+            path = self._token_file(Path(d), "tok123\n")
+            path.parent.chmod(0o777)
+            try:
+                with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+                    with self.assertRaises(_config.ConfigError) as ctx:
+                        _config.resolve_wiki_token(Path(d))
+                    msg = str(ctx.exception)
+                    self.assertIn("chmod 700", msg)
+                    self.assertIn(str(path.parent), msg)
+            finally:
+                # Leave the tree removable regardless of the assertions above.
+                path.parent.chmod(0o700)
+
+    def test_group_readable_parent_dir_is_fine(self):
+        # mkdir under a normal umask leaves 0o755. Readable is not writable,
+        # and refusing it would fail every ordinary workspace.
+        with tempfile.TemporaryDirectory() as d:
+            path = self._token_file(Path(d), "tok123\n")
+            path.parent.chmod(0o755)
+            with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+                self.assertEqual(_config.resolve_wiki_token(Path(d)), "tok123")
+
     def test_missing_both_names_both_sources(self):
         with tempfile.TemporaryDirectory() as d:
             # See test_group_readable_file_refused_with_chmod_instruction

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -352,8 +352,12 @@ class TestNewCliSurface(unittest.TestCase):
         return run_main(argv)
 
     def test_render_only_and_go_mutually_exclusive(self):
+        # Through self._run, not a bare main() call: redirect_stdout/stderr
+        # stay in effect across the SystemExit argparse raises, so argparse's
+        # usage banner and error line land in the captured buffers instead of
+        # the real stderr — test output must stay pristine.
         with self.assertRaises(SystemExit) as ctx:
-            deploy_export.main(["--render-only", "--go", "--staging", "/tmp/x"])
+            self._run(["--render-only", "--go", "--staging", "/tmp/x"])
         self.assertEqual(ctx.exception.code, 2)
 
     def test_render_only_still_requires_staging(self):
@@ -369,8 +373,15 @@ class TestNewCliSurface(unittest.TestCase):
                 '[campaign]\nnamespace = "test"\n'
                 '[wiki]\nurl = "https://wiki.invalid"\n', encoding="utf-8")
             make_export(Path(d) / "Export", {"Mechanics/a.md": "# A\n"})
-            os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
-            rc, _out, err = self._run(["--workspace", str(d)])
+            # Wrapped in patch.dict so the pop below is undone on exit
+            # regardless of ambient state or test outcome — a bare pop with
+            # no restore would permanently delete a pre-existing
+            # BUNNYFORGE_WIKI_TOKEN from the test process for every test that
+            # runs after this one (see test_config.py's
+            # test_group_readable_file_refused_with_chmod_instruction).
+            with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+                rc, _out, err = self._run(["--workspace", str(d)])
             self.assertEqual(rc, 1)
             self.assertIn("BUNNYFORGE_WIKI_TOKEN", err)
 

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -1,7 +1,9 @@
 import contextlib
 import io
+import os
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from bunnyforge import _config
@@ -223,10 +225,24 @@ class TestMainIntegration(unittest.TestCase):
     def _run(self, argv):
         return run_main(argv)
 
-    def test_missing_render_only_is_refused(self):
+    def test_default_run_without_wiki_config_is_instructional(self):
+        # Bare deploy-export is now a network dry run; with no [wiki] url it
+        # must say exactly what to add and where, and mention --render-only.
         with tempfile.TemporaryDirectory() as d:
-            rc, _out, err = self._run(["--staging", str(Path(d) / "stage")])
-            self.assertNotEqual(rc, 0)
+            # The brief's literal fixture pointed --workspace at `d` while
+            # only ever writing campaign.toml under d/Export -- resolving the
+            # workspace itself would fail before the wiki-url check this test
+            # exists to exercise. Give `d` its own campaign.toml (no [wiki]
+            # table) so resolve_workspace succeeds and the run reaches that
+            # check.
+            (Path(d) / "campaign.toml").write_text(
+                _MINIMAL_CAMPAIGN_TOML, encoding="utf-8")
+            export = make_export(Path(d) / "Export", {"Mechanics/a.md": "# A\n"})
+            rc, _out, err = self._run(
+                ["--workspace", str(d), "--export-dir", str(export)])
+            self.assertEqual(rc, 1)
+            self.assertIn("[wiki]", err)
+            self.assertIn('url = "https://<wiki>"', err)
             self.assertIn("--render-only", err)
 
     def test_missing_export_dir_is_refused(self):
@@ -329,6 +345,94 @@ class TestMainIntegration(unittest.TestCase):
                 "--export-dir", str(d / "Export"),
             ])
             self.assertEqual(rc, 0)
+
+
+class TestNewCliSurface(unittest.TestCase):
+    def _run(self, argv):
+        return run_main(argv)
+
+    def test_render_only_and_go_mutually_exclusive(self):
+        with self.assertRaises(SystemExit) as ctx:
+            deploy_export.main(["--render-only", "--go", "--staging", "/tmp/x"])
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_render_only_still_requires_staging(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_export(Path(d) / "Export", {"Mechanics/a.md": "# A\n"})
+            rc, _out, err = self._run(["--workspace", str(d), "--render-only"])
+            self.assertEqual(rc, 1)
+            self.assertIn("--staging", err)
+
+    def test_missing_token_is_instructional(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "campaign.toml").write_text(
+                '[campaign]\nnamespace = "test"\n'
+                '[wiki]\nurl = "https://wiki.invalid"\n', encoding="utf-8")
+            make_export(Path(d) / "Export", {"Mechanics/a.md": "# A\n"})
+            os.environ.pop("BUNNYFORGE_WIKI_TOKEN", None)
+            rc, _out, err = self._run(["--workspace", str(d)])
+            self.assertEqual(rc, 1)
+            self.assertIn("BUNNYFORGE_WIKI_TOKEN", err)
+
+    def test_http_url_refused_before_any_network(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "campaign.toml").write_text(
+                '[campaign]\nnamespace = "test"\n'
+                '[wiki]\nurl = "http://wiki.invalid"\n', encoding="utf-8")
+            make_export(Path(d) / "Export", {"Mechanics/a.md": "# A\n"})
+            with unittest.mock.patch.dict(
+                    os.environ, {"BUNNYFORGE_WIKI_TOKEN": "t"}):
+                rc, _out, err = self._run(["--workspace", str(d)])
+            self.assertEqual(rc, 1)
+            self.assertIn("http://", err)
+
+    def test_omitted_staging_renders_for_real_into_a_temp_dir_that_is_cleaned_up(self):
+        # No test may touch the network, so this drives a run that must
+        # render for real (proving the temp dir actually works as a staging
+        # target, not just that one gets created) while still never reaching
+        # run_deploy: an unresolved link fatally refuses the run from inside
+        # main() *after* render_tree has already written pages into the temp
+        # staging dir, but before any RPC call would be made.
+        real_temp_dir_cls = deploy_export.tempfile.TemporaryDirectory
+        captured = {}
+
+        class RecordingTempDir(real_temp_dir_cls):
+            def __enter__(self):
+                path = super().__enter__()
+                captured["path"] = path
+                return path
+
+            def __exit__(self, *exc_info):
+                # Snapshot what landed on disk immediately before cleanup —
+                # captured["path"] no longer exists once super().__exit__
+                # returns.
+                root = Path(captured["path"])
+                captured["files"] = sorted(
+                    p.relative_to(root).as_posix() for p in root.rglob("*.txt"))
+                return super().__exit__(*exc_info)
+
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "campaign.toml").write_text(
+                '[campaign]\nnamespace = "test"\n'
+                '[wiki]\nurl = "https://wiki.invalid"\n', encoding="utf-8")
+            make_export(Path(d) / "Export", {
+                "Mechanics/open.md": "# Open\n\nSee [[totally-nonexistent]].\n",
+            })
+            with unittest.mock.patch.dict(
+                    os.environ, {"BUNNYFORGE_WIKI_TOKEN": "t"}), \
+                unittest.mock.patch.object(
+                    deploy_export.tempfile, "TemporaryDirectory",
+                    RecordingTempDir):
+                rc, _out, err = self._run(["--workspace", str(d)])
+            self.assertEqual(rc, 1)
+            self.assertIn("unresolved", err)
+            # The content page was actually rendered into the temp dir before
+            # the fatal-link check refused the run.
+            self.assertTrue(
+                any(f.endswith("mechanics/open.txt")
+                    for f in captured["files"]),
+                captured["files"])
+            self.assertFalse(Path(captured["path"]).exists())
 
 
 class TestLinkPolicy(unittest.TestCase):

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -836,6 +836,30 @@ class TestManifest(unittest.TestCase):
                 deploy_export.load_manifest(path)
             self.assertIn(str(path), str(ctx.exception))
 
+    def test_non_object_json_refused_instructionally(self):
+        # Valid JSON but not an object at all (e.g. a bare array) must not
+        # reach `raw.get(...)` — that would raise AttributeError instead of
+        # the instructional DeployError every malformed manifest owes.
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "m.json"
+            path.write_text("[1, 2, 3]", encoding="utf-8")
+            with self.assertRaises(deploy_export.DeployError) as ctx:
+                deploy_export.load_manifest(path)
+            self.assertIn(str(path), str(ctx.exception))
+
+    def test_non_object_pages_refused_instructionally(self):
+        # A `pages` field that isn't a JSON object must be refused rather
+        # than silently misread — dict() of some non-dict shapes (e.g. a
+        # list of two-character strings) succeeds without error and would
+        # otherwise corrupt the read instead of refusing it.
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "m.json"
+            path.write_text('{"version": 1, "pages": ["ab", "cd"]}',
+                            encoding="utf-8")
+            with self.assertRaises(deploy_export.DeployError) as ctx:
+                deploy_export.load_manifest(path)
+            self.assertIn(str(path), str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from bunnyforge import _config
 from bunnyforge import deploy_export
 from bunnyforge import export_player
+from bunnyforge._dokuwiki_rpc import RpcError
 
 NS = "testwiki"   # tests own their namespace; never the campaign's
 
@@ -44,6 +45,26 @@ def namespace_of(root: Path) -> str:
     literal, so a main() that stopped consulting config would fail here.
     """
     return _config.open_workspace(root).config.namespace
+
+
+class FakeClient:
+    """In-memory wiki: a dict of pages. Mimics get_page/save_page, applies a
+    save normalization (strips trailing newlines, like DokuWiki) so
+    read-back hashing is exercised for real."""
+
+    def __init__(self, pages=None, fail_on=None):
+        self.pages = dict(pages or {})
+        self.saves = []
+        self.fail_on = fail_on
+
+    def get_page(self, pid):
+        return self.pages.get(pid)
+
+    def save_page(self, pid, text, summary=None):
+        if pid == self.fail_on:
+            raise RpcError(111, "denied", "core.savePage")
+        self.saves.append(pid)
+        self.pages[pid] = text.rstrip("\n") + "\n"
 
 
 class TestRenderTree(unittest.TestCase):
@@ -931,6 +952,96 @@ class TestWriteOrder(unittest.TestCase):
         ids = [f"{NS}:npcs:ana", f"{NS}:npcs:ana", f"{NS}:export:npcs:ana"]
         order = deploy_export.write_order(ids, NS)
         self.assertEqual(order, [f"{NS}:export:npcs:ana", f"{NS}:npcs:ana"])
+
+
+class TestApplyDeploy(unittest.TestCase):
+    def _apply(self, plan, staged, client, manifest, path, overwrite=()):
+        return deploy_export.apply_deploy(
+            plan, staged, client, manifest, path, set(overwrite), "w",
+            "https://<wiki>")
+
+    def test_clean_deploy_writes_and_baselines_readback(self):
+        client = FakeClient()
+        staged = {"w:export:npcs:ana": "body\n\n", "w:npcs:ana": "wrap\n"}
+        manifest = {}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            result = self._apply(plan, staged, client, manifest, mpath)
+            self.assertIsNone(result.failure)
+            # content before wrapper
+            self.assertEqual(client.saves,
+                             ["w:export:npcs:ana", "w:npcs:ana"])
+            # baseline is the hash of the READ-BACK text (normalized by the
+            # fake), not of the bytes sent
+            self.assertEqual(manifest["w:export:npcs:ana"],
+                             deploy_export.page_hash("body\n"))
+            # manifest written through to disk
+            self.assertEqual(deploy_export.load_manifest(mpath), manifest)
+
+    def test_adopt_rebaselines_without_writing(self):
+        client = FakeClient({"w:a": "same\n"})
+        staged = {"w:a": "same\n"}
+        manifest = {"w:a": "stale-hash"}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            result = self._apply(plan, staged, client, manifest, mpath)
+            self.assertEqual(client.saves, [])
+            self.assertEqual(result.adopted, ["w:a"])
+            self.assertEqual(manifest["w:a"], deploy_export.page_hash("same\n"))
+            self.assertEqual(deploy_export.load_manifest(mpath), manifest)
+
+    def test_drift_held_unless_overwritten(self):
+        client = FakeClient({"w:a": "wiki edit\n"})
+        staged = {"w:a": "ours\n"}
+        manifest = {"w:a": deploy_export.page_hash("older\n")}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            result = self._apply(plan, staged, client, manifest, mpath)
+            self.assertEqual(client.saves, [])
+            result = self._apply(plan, staged, client, manifest, mpath,
+                                 overwrite=["w:a"])
+            self.assertEqual(client.saves, ["w:a"])
+            self.assertEqual(manifest["w:a"], deploy_export.page_hash("ours\n"))
+
+    def test_overwrite_of_unheld_page_refused(self):
+        client = FakeClient()
+        staged = {"w:a": "x\n"}
+        with tempfile.TemporaryDirectory() as d:
+            plan = deploy_export.plan_deploy(staged, {}, client.get_page, "w")
+            with self.assertRaises(deploy_export.DeployError) as ctx:
+                self._apply(plan, staged, client, {}, Path(d) / "m.json",
+                            overwrite=["w:nope"])
+            self.assertIn("w:nope", str(ctx.exception))
+
+    def test_failed_save_aborts_reports_written_and_remaining(self):
+        client = FakeClient(fail_on="w:b")
+        staged = {"w:a": "1\n", "w:b": "2\n", "w:c": "3\n"}
+        manifest = {}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            result = self._apply(plan, staged, client, manifest, mpath)
+            self.assertIsNotNone(result.failure)
+            self.assertIn("ACL", result.failure)  # translated, not raw
+            self.assertEqual(result.written, ["w:a"])
+            self.assertEqual(result.remaining, ["w:b", "w:c"])
+            # the page that DID land is baselined — re-run converges
+            self.assertIn("w:a", deploy_export.load_manifest(mpath))
+            self.assertNotIn("w:b", deploy_export.load_manifest(mpath))
+
+    def test_resolved_orphans_dropped_from_manifest(self):
+        client = FakeClient({"w:a": "x\n"})
+        staged = {"w:a": "x\n"}
+        manifest = {"w:a": deploy_export.page_hash("x\n"), "w:gone": "h"}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            self._apply(plan, staged, client, manifest, mpath)
+            self.assertNotIn("w:gone", manifest)
+            self.assertNotIn("w:gone", deploy_export.load_manifest(mpath))
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -922,6 +922,16 @@ class TestWriteOrder(unittest.TestCase):
         ids = [f"{NS}:export:npcs:solo"]
         self.assertEqual(deploy_export.write_order(ids, NS), ids)
 
+    def test_duplicate_input_ids_yield_each_page_once(self):
+        # present = set(ids) dedupes for membership, but a loop driven off
+        # the raw (un-deduped) list would re-trigger "mate present -> emit
+        # mate + self" once per repeat. write_order's whole purpose is an
+        # exactly-once, content-before-wrapper order, so a duplicated input
+        # must not duplicate the output.
+        ids = [f"{NS}:npcs:ana", f"{NS}:npcs:ana", f"{NS}:export:npcs:ana"]
+        order = deploy_export.write_order(ids, NS)
+        self.assertEqual(order, [f"{NS}:export:npcs:ana", f"{NS}:npcs:ana"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -1044,5 +1044,141 @@ class TestApplyDeploy(unittest.TestCase):
             self.assertNotIn("w:gone", deploy_export.load_manifest(mpath))
 
 
+def make_workspace(d: Path) -> Path:
+    (d / "campaign.toml").write_text(_MINIMAL_CAMPAIGN_TOML, encoding="utf-8")
+    return d
+
+
+class TestDriftCopies(unittest.TestCase):
+    def test_copies_mirror_pages_layout_and_dir_recreated(self):
+        with tempfile.TemporaryDirectory() as d:
+            drift = Path(d) / "wiki-drift"
+            stale = drift / "old.txt"
+            stale.parent.mkdir(parents=True)
+            stale.write_text("stale", encoding="utf-8")
+            deploy_export.write_drift_copies(
+                {"w:npcs:ana": "wiki text\n"}, drift)
+            self.assertFalse(stale.exists())  # recreated from empty
+            copy = drift / "w" / "npcs" / "ana.txt"
+            self.assertEqual(copy.read_text(encoding="utf-8"), "wiki text\n")
+
+
+class TestRunDeploy(unittest.TestCase):
+    def _stage(self, d: Path, pages: dict) -> Path:
+        staging = d / "stage"
+        for pid, text in pages.items():
+            p = deploy_export.page_path(pid, staging)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(text, encoding="utf-8")
+        return staging
+
+    def _run(self, ws_root, staging, client, go=False, overwrite=()):
+        ws = _config.open_workspace(ws_root)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(out):
+            rc = deploy_export.run_deploy(
+                ws, staging, client, go, set(overwrite), "https://<wiki>")
+        return rc, out.getvalue()
+
+    def test_dry_run_is_default_shape_no_writes_no_manifest(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "hello\n"})
+            client = FakeClient()
+            rc, out = self._run(d, staging, client, go=False)
+            self.assertEqual(rc, 0)
+            self.assertEqual(client.saves, [])  # zero wiki writes
+            self.assertFalse(
+                (d / ".bunnyforge" / "wiki-manifest.json").exists())
+            self.assertIn("new", out)  # the full plan is printed
+
+    def test_go_writes_and_persists_manifest(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "hello\n"})
+            client = FakeClient()
+            rc, _ = self._run(d, staging, client, go=True)
+            self.assertEqual(rc, 0)
+            self.assertEqual(client.saves, ["test:npcs:ana"])
+            manifest = deploy_export.load_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json")
+            self.assertIn("test:npcs:ana", manifest)
+
+    def test_drift_held_diffed_copied_and_nonzero_in_both_modes(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "ours\n"})
+            client = FakeClient({"test:npcs:ana": "theirs\n"})
+            for go in (False, True):
+                with self.subTest(go=go):
+                    rc, out = self._run(d, staging, client, go=go)
+                    self.assertEqual(rc, 1)
+                    self.assertEqual(client.saves, [])
+                    self.assertIn("wiki (current)", out)   # unified diff sides
+                    self.assertIn("deploy (target)", out)
+                    self.assertIn("--overwrite", out)      # resolution path
+                    copy = (d / ".bunnyforge" / "wiki-drift" / "test" /
+                            "npcs" / "ana.txt")
+                    self.assertEqual(copy.read_text(encoding="utf-8"),
+                                     "theirs\n")
+
+    def test_deleted_on_wiki_held_and_reported(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "ours\n"})
+            deploy_export.save_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json",
+                {"test:npcs:ana": "somehash"})
+            client = FakeClient()  # page absent on wiki
+            rc, out = self._run(d, staging, client, go=True)
+            self.assertEqual(rc, 1)
+            self.assertEqual(client.saves, [])
+            self.assertIn("deleted", out)
+
+    def test_orphan_reported_never_deleted_nonzero(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "x\n"})
+            client = FakeClient({"test:npcs:ana": "x\n",
+                                 "test:npcs:retired": "old\n"})
+            deploy_export.save_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json",
+                {"test:npcs:ana": deploy_export.page_hash("x\n"),
+                 "test:npcs:retired": deploy_export.page_hash("old\n")})
+            rc, out = self._run(d, staging, client, go=True)
+            self.assertEqual(rc, 1)
+            self.assertIn("test:npcs:retired", out)
+            self.assertIn("manual", out)  # removal is a manual act
+            self.assertIn("test:npcs:retired", client.pages)  # never deleted
+
+    def test_resume_after_crash_adopts_and_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "same\n"})
+            client = FakeClient({"test:npcs:ana": "same\n"})
+            deploy_export.save_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json",
+                {"test:npcs:ana": "stale-pre-crash-hash"})
+            rc, out = self._run(d, staging, client, go=True)
+            self.assertEqual(rc, 0)
+            self.assertEqual(client.saves, [])
+            self.assertIn("adopt", out)
+
+    def test_drift_dir_recreated_each_planning_run(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            stale = d / ".bunnyforge" / "wiki-drift" / "stale.txt"
+            stale.parent.mkdir(parents=True)
+            stale.write_text("old", encoding="utf-8")
+            staging = self._stage(d, {"test:npcs:ana": "x\n"})
+            client = FakeClient({"test:npcs:ana": "x\n"})
+            deploy_export.save_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json",
+                {"test:npcs:ana": deploy_export.page_hash("x\n")})
+            rc, _ = self._run(d, staging, client)
+            self.assertEqual(rc, 0)
+            self.assertFalse(stale.exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -784,5 +784,58 @@ class TestExportDirComposesWithWorkspace(unittest.TestCase):
             self.assertIn("campaign.toml", err)
 
 
+class TestClassifyPage(unittest.TestCase):
+    """The spec's eight-row state matrix, walked as a table."""
+
+    def test_all_eight_rows(self):
+        h = deploy_export.page_hash
+        rows = [
+            # (target, wiki_text, manifest_hash) -> action
+            ("t\n", None, None, "new"),
+            ("t\n", None, h("old\n"), "deleted-on-wiki"),
+            ("t\n", "t\n", h("t\n"), "unchanged"),
+            ("t2\n", "t\n", h("t\n"), "update"),
+            ("t\n", "t\n", h("other\n"), "adopt"),      # resume-after-crash
+            ("t2\n", "t\n", h("other\n"), "drift"),
+            ("t\n", "t\n", None, "adopt"),               # manual-era match
+            ("t2\n", "t\n", None, "drift-manual-era"),
+        ]
+        for target, wiki, mh, expected in rows:
+            with self.subTest(expected=expected):
+                self.assertEqual(
+                    deploy_export.classify_page(target, wiki, mh), expected)
+
+
+class TestManifest(unittest.TestCase):
+    def test_missing_file_is_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(
+                deploy_export.load_manifest(Path(d) / "none.json"), {})
+
+    def test_round_trip_sorted(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / ".bunnyforge" / "wiki-manifest.json"
+            deploy_export.save_manifest(path, {"b:x": "2", "a:x": "1"})
+            raw = path.read_text(encoding="utf-8")
+            self.assertLess(raw.index('"a:x"'), raw.index('"b:x"'))
+            self.assertEqual(deploy_export.load_manifest(path),
+                             {"a:x": "1", "b:x": "2"})
+
+    def test_unknown_version_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "m.json"
+            path.write_text('{"version": 99, "pages": {}}', encoding="utf-8")
+            with self.assertRaises(deploy_export.DeployError):
+                deploy_export.load_manifest(path)
+
+    def test_bad_json_refused_instructionally(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "m.json"
+            path.write_text("{not json", encoding="utf-8")
+            with self.assertRaises(deploy_export.DeployError) as ctx:
+                deploy_export.load_manifest(path)
+            self.assertIn(str(path), str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -861,5 +861,67 @@ class TestManifest(unittest.TestCase):
             self.assertIn(str(path), str(ctx.exception))
 
 
+class TestStagedPages(unittest.TestCase):
+    def test_ids_and_placeholder_translation(self):
+        with tempfile.TemporaryDirectory() as d:
+            staging = Path(d)
+            page = staging / NS / "export" / "mechanics" / "rule.txt"
+            page.parent.mkdir(parents=True)
+            page.write_text("body\n", encoding="utf-8")
+            ph = staging / NS / "npcs" / "ghost.txt"
+            ph.parent.mkdir(parents=True)
+            ph.write_bytes(b"")  # zero-byte placeholder: savePage refuses
+            staged = deploy_export.staged_pages(staging)
+            self.assertEqual(staged[f"{NS}:export:mechanics:rule"], "body\n")
+            self.assertEqual(staged[f"{NS}:npcs:ghost"],
+                             deploy_export.PLACEHOLDER_BODY)
+
+
+class TestPlanDeploy(unittest.TestCase):
+    def test_classifies_and_finds_orphans(self):
+        wiki = {"w:a": "old\n", "w:gone-from-workspace": "still here\n"}
+        staged = {"w:a": "new\n", "w:b": "fresh\n"}
+        manifest = {"w:a": deploy_export.page_hash("old\n"),
+                    "w:gone-from-workspace": "x",
+                    "w:resolved": "y"}  # deleted on wiki by a human
+        plan = deploy_export.plan_deploy(staged, manifest, wiki.get, "w")
+        self.assertEqual(plan.pages["w:a"].action, "update")
+        self.assertEqual(plan.pages["w:b"].action, "new")
+        self.assertEqual(plan.orphans, ["w:gone-from-workspace"])
+        self.assertEqual(plan.resolved_orphans, ["w:resolved"])
+
+    def test_protected_pages_never_fetched_never_planned(self):
+        fetched = []
+
+        def fetch(pid):
+            fetched.append(pid)
+            return None
+
+        staged = {"w:main": "x\n", "w:players:notes": "x\n", "w:ok": "x\n"}
+        plan = deploy_export.plan_deploy(staged, {}, fetch, "w")
+        self.assertEqual(sorted(plan.refused), ["w:main", "w:players:notes"])
+        self.assertNotIn("w:main", plan.pages)
+        self.assertNotIn("w:main", fetched)
+        self.assertNotIn("w:players:notes", fetched)
+        self.assertIn("w:ok", plan.pages)
+
+
+class TestWriteOrder(unittest.TestCase):
+    def test_content_lands_immediately_before_its_wrapper(self):
+        ids = [f"{NS}:export:npcs:ana", f"{NS}:npcs:ana",
+               f"{NS}:export:npcs:bob", f"{NS}:npcs:bob",
+               f"{NS}:aaa-placeholder"]
+        order = deploy_export.write_order(ids, NS)
+        self.assertEqual(order, [
+            f"{NS}:aaa-placeholder",
+            f"{NS}:export:npcs:ana", f"{NS}:npcs:ana",
+            f"{NS}:export:npcs:bob", f"{NS}:npcs:bob",
+        ])
+
+    def test_unpaired_content_page_stays_sorted(self):
+        ids = [f"{NS}:export:npcs:solo"]
+        self.assertEqual(deploy_export.write_order(ids, NS), ids)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deploy_export.py
+++ b/tests/test_deploy_export.py
@@ -446,6 +446,89 @@ class TestNewCliSurface(unittest.TestCase):
             self.assertFalse(Path(captured["path"]).exists())
 
 
+class TestMainDrivesTheDeploy(unittest.TestCase):
+    """The main() -> run_deploy join, end to end.
+
+    Every other main() test either passes --render-only or bails before
+    run_deploy (no [wiki], no token, http:// url, unresolved link), so the one
+    seam no per-function test can see — that what render_tree wrote is what
+    the transport half then plans and writes — had no coverage at all.
+
+    deploy_export.RpcClient is patched rather than a new injection parameter
+    being added to main(): the seam is a composition detail, and widening
+    main()'s signature for a test would put a test-only argument on the
+    package's public CLI entry point.
+    """
+
+    def test_go_deploys_every_rendered_page_and_records_it(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "campaign.toml").write_text(
+                '[campaign]\nnamespace = "test"\n'
+                '[wiki]\nurl = "https://wiki.invalid"\n', encoding="utf-8")
+            make_export(d / "Export", {"Mechanics/open.md": "# Open\n",
+                                       "NPCs/ana.md": "# Ana\n"})
+            client = FakeClient()
+            with unittest.mock.patch.dict(
+                    os.environ, {"BUNNYFORGE_WIKI_TOKEN": "t"}), \
+                unittest.mock.patch.object(
+                    deploy_export, "RpcClient", return_value=client):
+                rc, out, err = run_main(["--workspace", str(d), "--go"])
+
+            self.assertEqual(rc, 0, err)
+            ns = namespace_of(d)
+            # Derived from the render half's own page_id, so this asserts the
+            # join rather than restating a hand-written literal.
+            expected = sorted(
+                [deploy_export.page_id(rel, ns) for rel in
+                 ("Mechanics/open.md", "NPCs/ana.md")] +
+                [deploy_export.page_id(rel, f"{ns}:export") for rel in
+                 ("Mechanics/open.md", "NPCs/ana.md")])
+            self.assertEqual(sorted(client.saves), expected)
+            manifest = deploy_export.load_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json")
+            self.assertEqual(sorted(manifest), expected)
+            self.assertIn("Deployed 4 page(s)", out)
+
+    def test_default_run_is_a_dry_run_that_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "campaign.toml").write_text(
+                '[campaign]\nnamespace = "test"\n'
+                '[wiki]\nurl = "https://wiki.invalid"\n', encoding="utf-8")
+            make_export(d / "Export", {"NPCs/ana.md": "# Ana\n"})
+            client = FakeClient()
+            with unittest.mock.patch.dict(
+                    os.environ, {"BUNNYFORGE_WIKI_TOKEN": "t"}), \
+                unittest.mock.patch.object(
+                    deploy_export, "RpcClient", return_value=client):
+                rc, out, err = run_main(["--workspace", str(d)])
+            self.assertEqual(rc, 0, err)
+            self.assertEqual(client.saves, [])
+            self.assertIn("2 page(s) would be written", out)
+            self.assertFalse((d / ".bunnyforge" / "wiki-manifest.json").exists())
+
+    def test_deploy_error_from_run_deploy_is_reported_not_raised(self):
+        # main()'s `except DeployError` arm — now reachable in a dry run too,
+        # since --overwrite is validated in both modes.
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "campaign.toml").write_text(
+                '[campaign]\nnamespace = "test"\n'
+                '[wiki]\nurl = "https://wiki.invalid"\n', encoding="utf-8")
+            make_export(d / "Export", {"NPCs/ana.md": "# Ana\n"})
+            client = FakeClient()
+            with unittest.mock.patch.dict(
+                    os.environ, {"BUNNYFORGE_WIKI_TOKEN": "t"}), \
+                unittest.mock.patch.object(
+                    deploy_export, "RpcClient", return_value=client):
+                rc, _out, err = run_main(
+                    ["--workspace", str(d), "--overwrite", "test:npcs:typo"])
+            self.assertEqual(rc, 1)
+            self.assertIn("test:npcs:typo", err)
+            self.assertEqual(client.saves, [])
+
+
 class TestLinkPolicy(unittest.TestCase):
     def _workspace(self, d):
         root = make_export(d / "ws", {
@@ -1147,6 +1230,66 @@ class TestApplyDeploy(unittest.TestCase):
             self.assertIn("w:a", deploy_export.load_manifest(mpath))
             self.assertNotIn("w:b", deploy_export.load_manifest(mpath))
 
+    def test_midrun_edit_is_skipped_not_clobbered(self):
+        # The spec's drift guarantee — "a quick wiki edit made mid-run
+        # survives, rather than being silently clobbered by the following
+        # deploy" — has to hold *within* one --go run too. plan_deploy fetches
+        # every page up front, so on a real campaign the window between a
+        # page's fetch and its save is the whole fetch loop plus the report.
+        client = FakeClient()
+        staged = {"w:a": "ours\n", "w:b": "ours\n"}
+        manifest = {}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            # A human edits w:b after it was planned as `new`.
+            client.pages["w:b"] = "human edit\n"
+            result = self._apply(plan, staged, client, manifest, mpath)
+            self.assertEqual(client.saves, ["w:a"])
+            self.assertEqual(result.written, ["w:a"])
+            self.assertEqual(result.skipped, ["w:b"])
+            self.assertIsNone(result.failure)   # a skip is not a save failure
+            self.assertNotIn("w:b", manifest)   # and never re-baselined
+            self.assertEqual(client.pages["w:b"], "human edit\n")
+
+    def test_overwrite_does_not_license_clobbering_an_unreviewed_edit(self):
+        # --overwrite consents to clobbering the diff the plan showed. An
+        # edit that landed *after* that diff was printed was never reviewed,
+        # so it gets the same mid-run protection as any other page.
+        client = FakeClient({"w:a": "wiki edit\n"})
+        staged = {"w:a": "ours\n"}
+        manifest = {"w:a": deploy_export.page_hash("older\n")}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            client.pages["w:a"] = "a second, unreviewed edit\n"
+            result = self._apply(plan, staged, client, manifest, mpath,
+                                 overwrite=["w:a"])
+            self.assertEqual(client.saves, [])
+            self.assertEqual(result.skipped, ["w:a"])
+
+    def test_readback_of_none_is_a_failure_not_a_bogus_baseline(self):
+        # A page that reads back as absent right after a successful save
+        # means the write did not stick. Recording page_hash("") would put a
+        # knowingly-wrong baseline in the manifest; route it through the
+        # existing partial-failure path instead, which reports and exits 1.
+        class Amnesiac(FakeClient):
+            def save_page(self, pid, text, summary=None):
+                self.saves.append(pid)  # accepted, but nothing is stored
+
+        client = Amnesiac()
+        staged = {"w:a": "ours\n"}
+        manifest = {}
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "m.json"
+            plan = deploy_export.plan_deploy(staged, manifest, client.get_page, "w")
+            result = self._apply(plan, staged, client, manifest, mpath)
+            self.assertIsNotNone(result.failure)
+            self.assertIn("w:a", result.failure)
+            self.assertEqual(result.written, [])
+            self.assertNotIn("w:a", manifest)
+            self.assertNotIn("w:a", deploy_export.load_manifest(mpath))
+
     def test_resolved_orphans_dropped_from_manifest(self):
         client = FakeClient({"w:a": "x\n"})
         staged = {"w:a": "x\n"}
@@ -1278,6 +1421,73 @@ class TestRunDeploy(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertEqual(client.saves, [])
             self.assertIn("adopt", out)
+
+    def test_overwrite_of_unheld_page_refused_in_both_modes(self):
+        # A dry run's whole value is fidelity to the run it rehearses. Before
+        # this, `--overwrite <typo>` printed a plan labelling that page
+        # `overwrite` and counted it in "N page(s) would be written", while
+        # the same invocation with --go refused outright.
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "x\n"})
+            for go in (False, True):
+                with self.subTest(go=go):
+                    client = FakeClient()
+                    with self.assertRaises(deploy_export.DeployError) as ctx:
+                        self._run(d, staging, client, go=go,
+                                  overwrite=["test:npcs:typo"])
+                    self.assertIn("test:npcs:typo", str(ctx.exception))
+                    self.assertEqual(client.saves, [])
+
+    def test_midrun_edit_is_reported_and_exits_nonzero(self):
+        class EditingClient(FakeClient):
+            """A human editing the wiki mid-run: the first save this deploy
+            performs is the moment their edit lands."""
+
+            def __init__(self, pages=None, edits=None):
+                super().__init__(pages)
+                self.edits = dict(edits or {})
+
+            def save_page(self, pid, text, summary=None):
+                super().save_page(pid, text, summary)
+                self.pages.update(self.edits)
+                self.edits = {}
+
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "ours\n",
+                                      "test:npcs:bob": "ours\n"})
+            client = EditingClient(edits={"test:npcs:bob": "human edit\n"})
+            rc, out = self._run(d, staging, client, go=True)
+            self.assertEqual(rc, 1)                       # never a silent skip
+            self.assertEqual(client.saves, ["test:npcs:ana"])
+            self.assertIn("test:npcs:bob", out)
+            self.assertIn("SKIPPED", out)
+            self.assertIn("Re-run", out)                  # names the next step
+            self.assertEqual(client.pages["test:npcs:bob"], "human edit\n")
+            manifest = deploy_export.load_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json")
+            self.assertNotIn("test:npcs:bob", manifest)
+
+    def test_resolved_orphan_alone_exits_zero(self):
+        # The exit-code contract counts held-back pages and *reported*
+        # orphans. A resolved orphan is neither: the human already deleted
+        # the page, so the run's only job is to drop it from the manifest and
+        # say so. Nothing was held back, so the run is clean.
+        with tempfile.TemporaryDirectory() as d:
+            d = make_workspace(Path(d))
+            staging = self._stage(d, {"test:npcs:ana": "x\n"})
+            client = FakeClient({"test:npcs:ana": "x\n"})  # :gone is absent
+            deploy_export.save_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json",
+                {"test:npcs:ana": deploy_export.page_hash("x\n"),
+                 "test:npcs:gone": "somehash"})
+            rc, out = self._run(d, staging, client, go=True)
+            self.assertEqual(rc, 0)
+            self.assertIn("resolved", out)
+            self.assertIn("test:npcs:gone", out)
+            self.assertNotIn("test:npcs:gone", deploy_export.load_manifest(
+                d / ".bunnyforge" / "wiki-manifest.json"))
 
     def test_drift_dir_recreated_each_planning_run(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_dokuwiki_rpc.py
+++ b/tests/test_dokuwiki_rpc.py
@@ -1,0 +1,204 @@
+import json
+import unittest
+import urllib.error
+from unittest import mock
+
+from bunnyforge import _dokuwiki_rpc as rpc
+from bunnyforge._dokuwiki_rpc import RpcClient, RpcError
+
+
+def fake_transport(responses):
+    """A transport returning canned bodies; records every request."""
+    calls = []
+
+    def transport(request, timeout):
+        calls.append((request, timeout))
+        body = responses[len(calls) - 1]
+        if isinstance(body, Exception):
+            raise body
+        return body
+
+    transport.calls = calls
+    return transport
+
+
+def ok(result):
+    return json.dumps({"result": result}).encode("utf-8")
+
+
+class TestRequestShape(unittest.TestCase):
+    def test_posts_to_pathinfo_endpoint_with_headers(self):
+        t = fake_transport([ok("x")])
+        client = RpcClient("https://<wiki>", "tok123", transport=t)
+        client.call("core.getPage", {"page": "a:b"})
+        request, timeout = t.calls[0]
+        self.assertEqual(
+            request.full_url, "https://<wiki>/lib/exe/jsonrpc.php/core.getPage")
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.get_header("Authorization"), "Bearer tok123")
+        self.assertEqual(request.get_header("Content-type"), "application/json")
+        self.assertTrue(request.get_header("User-agent").startswith("bunnyforge/"))
+        self.assertEqual(json.loads(request.data.decode("utf-8")), {"page": "a:b"})
+        self.assertEqual(timeout, 30.0)
+
+    def test_trailing_slash_on_base_url_tolerated(self):
+        t = fake_transport([ok(1)])
+        RpcClient("https://<wiki>/", "t", transport=t).call("m", {})
+        self.assertEqual(
+            t.calls[0][0].full_url, "https://<wiki>/lib/exe/jsonrpc.php/m")
+
+
+class TestSuccessShapes(unittest.TestCase):
+    """The key-presence trap, pinned: all three success shapes must pass."""
+
+    def test_error_absent(self):
+        c = RpcClient("https://w", "t", transport=fake_transport([ok("body")]))
+        self.assertEqual(c.call("m", {}), "body")
+
+    def test_error_null(self):
+        body = json.dumps({"result": "body", "error": None}).encode()
+        c = RpcClient("https://w", "t", transport=fake_transport([body]))
+        self.assertEqual(c.call("m", {}), "body")
+
+    def test_error_code_zero(self):
+        body = json.dumps(
+            {"result": "body", "error": {"code": 0, "message": "success"}}).encode()
+        c = RpcClient("https://w", "t", transport=fake_transport([body]))
+        self.assertEqual(c.call("m", {}), "body")
+
+    def test_error_code_nonzero_raises(self):
+        body = json.dumps(
+            {"result": None, "error": {"code": 111, "message": "no"}}).encode()
+        c = RpcClient("https://w", "t", transport=fake_transport([body]))
+        with self.assertRaises(RpcError) as ctx:
+            c.call("core.savePage", {})
+        self.assertEqual(ctx.exception.code, 111)
+        self.assertEqual(ctx.exception.method, "core.savePage")
+
+    def test_non_json_body_is_no_endpoint(self):
+        c = RpcClient("https://w", "t",
+                      transport=fake_transport([b"<html>login</html>"]))
+        with self.assertRaises(RpcError) as ctx:
+            c.call("m", {})
+        self.assertEqual(ctx.exception.code, "no-endpoint")
+
+
+class TestWrappers(unittest.TestCase):
+    def test_get_page_121_is_none(self):
+        body = json.dumps({"error": {"code": 121, "message": "absent"}}).encode()
+        c = RpcClient("https://w", "t", transport=fake_transport([body]))
+        self.assertIsNone(c.get_page("a:b"))
+
+    def test_get_page_other_error_propagates(self):
+        body = json.dumps({"error": {"code": 111, "message": "acl"}}).encode()
+        c = RpcClient("https://w", "t", transport=fake_transport([body]))
+        with self.assertRaises(RpcError):
+            c.get_page("a:b")
+
+    def test_save_page_params_and_summary(self):
+        t = fake_transport([ok(True)])
+        RpcClient("https://w", "t", transport=t).save_page("a:b", "text\n")
+        params = json.loads(t.calls[0][0].data.decode("utf-8"))
+        self.assertEqual(params["page"], "a:b")
+        self.assertEqual(params["text"], "text\n")
+        self.assertEqual(params["summary"], "bunnyforge deploy-export")
+
+
+class TestUrlPolicy(unittest.TestCase):
+    def test_plain_http_refused(self):
+        with self.assertRaises(ValueError) as ctx:
+            RpcClient("http://<wiki>", "t")
+        self.assertIn("http://", str(ctx.exception))
+        self.assertIn("clear", str(ctx.exception))  # names why: token in clear
+
+    def test_http_localhost_allowed(self):
+        for host in ("localhost", "127.0.0.1"):
+            RpcClient(f"http://{host}:8080", "t")  # must not raise
+
+    def test_https_allowed(self):
+        RpcClient("https://<wiki>", "t")
+
+    def test_garbage_scheme_refused(self):
+        with self.assertRaises(ValueError):
+            RpcClient("ftp://<wiki>", "t")
+
+
+class TestDefaultTransport(unittest.TestCase):
+    def test_urlerror_is_unreachable(self):
+        with mock.patch("urllib.request.urlopen",
+                        side_effect=urllib.error.URLError("dns fail")):
+            c = RpcClient("https://<wiki>", "t")
+            with self.assertRaises(RpcError) as ctx:
+                c.call("m", {})
+            self.assertEqual(ctx.exception.code, "unreachable")
+
+    def test_timeout_is_unreachable(self):
+        with mock.patch("urllib.request.urlopen", side_effect=TimeoutError()):
+            c = RpcClient("https://<wiki>", "t")
+            with self.assertRaises(RpcError) as ctx:
+                c.call("m", {})
+            self.assertEqual(ctx.exception.code, "unreachable")
+
+    def test_http_404_is_no_endpoint(self):
+        err = urllib.error.HTTPError("u", 404, "nf", {}, None)
+        with mock.patch("urllib.request.urlopen", side_effect=err):
+            c = RpcClient("https://<wiki>", "t")
+            with self.assertRaises(RpcError) as ctx:
+                c.call("m", {})
+            self.assertEqual(ctx.exception.code, "no-endpoint")
+
+    def test_http_error_body_still_parsed(self):
+        # JSON-RPC errors can ride a non-200 status: the body wins.
+        import io
+        payload = json.dumps({"error": {"code": -32605, "message": "off"}}).encode()
+        err = urllib.error.HTTPError("u", 403, "forbidden", {}, io.BytesIO(payload))
+        with mock.patch("urllib.request.urlopen", side_effect=err):
+            c = RpcClient("https://<wiki>", "t")
+            with self.assertRaises(RpcError) as ctx:
+                c.call("m", {})
+            self.assertEqual(ctx.exception.code, -32605)
+
+
+class TestTranslation(unittest.TestCase):
+    """Every row of the spec's error table names its fix."""
+
+    def check(self, code, *needles):
+        msg = rpc.translate_error(RpcError(code, "raw detail", "core.savePage"),
+                                  "https://<wiki>")
+        for needle in needles:
+            self.assertIn(needle, msg)
+        return msg
+
+    def test_unreachable_names_url(self):
+        self.check("unreachable", "https://<wiki>", "connectivity")
+
+    def test_no_endpoint_names_minimum_release(self):
+        self.check("no-endpoint", rpc.MIN_RELEASE)
+
+    def test_32605_names_conf_local(self):
+        self.check(-32605, "$conf['remote'] = 1", "conf/local.php",
+                   "conf/dokuwiki.php")
+
+    def test_32604_names_both_token_sources(self):
+        self.check(-32604, "BUNNYFORGE_WIKI_TOKEN", ".bunnyforge/wiki-token",
+                   "remoteuser")
+
+    def test_111_names_acl(self):
+        self.check(111, "ACL", "edit")
+
+    def test_133_names_lock_expiry(self):
+        self.check(133, "lock", "15 minutes")
+
+    def test_134_names_wordblock(self):
+        self.check(134, "wordblock")
+
+    def test_client_defects_say_report(self):
+        for code in (-32606, -32700, -32602, 131, 132):
+            self.assertIn("bug in bunnyforge, please report", self.check(code))
+
+    def test_unknown_code_prints_raw(self):
+        self.check(999, "core.savePage", "999", "raw detail", "please report")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dokuwiki_rpc.py
+++ b/tests/test_dokuwiki_rpc.py
@@ -1,6 +1,11 @@
+import email.message
+import http.client
+import io
 import json
+import ssl
 import unittest
 import urllib.error
+import urllib.request
 from unittest import mock
 
 from bunnyforge import _dokuwiki_rpc as rpc
@@ -35,7 +40,15 @@ class TestRequestShape(unittest.TestCase):
         self.assertEqual(
             request.full_url, "https://<wiki>/lib/exe/jsonrpc.php/core.getPage")
         self.assertEqual(request.get_method(), "POST")
+        # The token is an *unredirected* header: sent on the wire like any
+        # other, but never copied onto a redirected request. get_header falls
+        # back to unredirected_hdrs, so it cannot tell the two apart — assert
+        # on the exact dicts, which fails if the token moves back to the
+        # redirectable ones.
         self.assertEqual(request.get_header("Authorization"), "Bearer tok123")
+        self.assertEqual(request.unredirected_hdrs.get("Authorization"),
+                         "Bearer tok123")
+        self.assertNotIn("Authorization", request.headers)
         self.assertEqual(request.get_header("Content-type"), "application/json")
         self.assertTrue(request.get_header("User-agent").startswith("bunnyforge/"))
         self.assertEqual(json.loads(request.data.decode("utf-8")), {"page": "a:b"})
@@ -124,16 +137,24 @@ class TestUrlPolicy(unittest.TestCase):
 
 
 class TestDefaultTransport(unittest.TestCase):
+    """The real transport, with the opener's `open` stubbed — still no socket.
+
+    These patch `rpc._OPENER.open` rather than `urllib.request.urlopen`,
+    because the module deliberately does not use the default opener: the
+    default one forwards the Bearer token across redirects (see
+    TestRedirectRefusal).
+    """
+
     def test_urlerror_is_unreachable(self):
-        with mock.patch("urllib.request.urlopen",
-                        side_effect=urllib.error.URLError("dns fail")):
+        with mock.patch.object(rpc._OPENER, "open",
+                               side_effect=urllib.error.URLError("dns fail")):
             c = RpcClient("https://<wiki>", "t")
             with self.assertRaises(RpcError) as ctx:
                 c.call("m", {})
             self.assertEqual(ctx.exception.code, "unreachable")
 
     def test_timeout_is_unreachable(self):
-        with mock.patch("urllib.request.urlopen", side_effect=TimeoutError()):
+        with mock.patch.object(rpc._OPENER, "open", side_effect=TimeoutError()):
             c = RpcClient("https://<wiki>", "t")
             with self.assertRaises(RpcError) as ctx:
                 c.call("m", {})
@@ -141,7 +162,7 @@ class TestDefaultTransport(unittest.TestCase):
 
     def test_http_404_is_no_endpoint(self):
         err = urllib.error.HTTPError("u", 404, "nf", {}, None)
-        with mock.patch("urllib.request.urlopen", side_effect=err):
+        with mock.patch.object(rpc._OPENER, "open", side_effect=err):
             c = RpcClient("https://<wiki>", "t")
             with self.assertRaises(RpcError) as ctx:
                 c.call("m", {})
@@ -152,11 +173,140 @@ class TestDefaultTransport(unittest.TestCase):
         import io
         payload = json.dumps({"error": {"code": -32605, "message": "off"}}).encode()
         err = urllib.error.HTTPError("u", 403, "forbidden", {}, io.BytesIO(payload))
-        with mock.patch("urllib.request.urlopen", side_effect=err):
+        with mock.patch.object(rpc._OPENER, "open", side_effect=err):
             c = RpcClient("https://<wiki>", "t")
             with self.assertRaises(RpcError) as ctx:
                 c.call("m", {})
             self.assertEqual(ctx.exception.code, -32605)
+
+
+class TestMidStreamFailures(unittest.TestCase):
+    """urlopen only wraps OSError raised inside the request; anything raised
+    by getresponse() or resp.read() arrives unwrapped. Every one of them must
+    still become a one-line instructional RpcError, never a traceback — an
+    unhandled exception here also skips apply_deploy's written/not-written
+    report."""
+
+    def check(self, exc):
+        with mock.patch.object(rpc._OPENER, "open", side_effect=exc):
+            c = RpcClient("https://<wiki>", "t")
+            with self.assertRaises(RpcError) as ctx:
+                c.call("m", {})
+            self.assertEqual(ctx.exception.code, "unreachable")
+            self.assertTrue(ctx.exception.message)  # never an empty message
+            return ctx.exception
+
+    def test_remote_disconnected(self):
+        self.check(http.client.RemoteDisconnected(
+            "Remote end closed connection without response"))
+
+    def test_connection_reset(self):
+        self.check(ConnectionResetError(104, "Connection reset by peer"))
+
+    def test_incomplete_read(self):
+        self.check(http.client.IncompleteRead(b"partial"))
+
+    def test_ssl_error_mid_stream(self):
+        self.check(ssl.SSLError("record layer failure"))
+
+    def test_bare_httpexception_still_names_its_type(self):
+        # http.client.HTTPException is not an OSError, and a bare instance
+        # str()s to "" — the message must still say something usable.
+        exc = self.check(http.client.HTTPException())
+        self.assertIn("HTTPException", exc.message)
+
+
+class TestRedirectRefusal(unittest.TestCase):
+    """A JSON-RPC POST to lib/exe/jsonrpc.php/<method> never legitimately
+    redirects. urllib's default HTTPRedirectHandler copies every header except
+    content-length/content-type onto the redirected request — including
+    Authorization, and unlike requests it does not strip it on a host change —
+    and turns a 301/302/303 POST into a GET. So an ordinary apex->www or
+    https->http redirect would put a live campaign's API token in clear, or on
+    a host the user never configured. Refuse the redirect instead."""
+
+    def _headers(self, location):
+        msg = email.message.Message()
+        msg["Location"] = location
+        return msg
+
+    def _request(self):
+        return urllib.request.Request(
+            "https://<wiki>/lib/exe/jsonrpc.php/core.savePage",
+            data=b"{}",
+            headers={"Authorization": "Bearer SECRET",
+                     "Content-Type": "application/json"},
+            method="POST")
+
+    def test_a_real_client_request_carries_no_redirectable_token(self):
+        # Belt to _NoRedirect's braces, checked on a request the client
+        # actually built: even handed to the stock handler, there is no
+        # Authorization header for it to forward.
+        t = fake_transport([ok("x")])
+        RpcClient("https://<wiki>", "tok123", transport=t).call("core.getPage", {})
+        sent = t.calls[0][0]
+        new = urllib.request.HTTPRedirectHandler().redirect_request(
+            sent, io.BytesIO(b""), 302, "Found",
+            self._headers("http://<other-host>/collect"),
+            "http://<other-host>/collect")
+        self.assertNotIn("Authorization", new.headers)
+        self.assertNotIn("Authorization", new.unredirected_hdrs)
+        # ...while the wire request do_open assembles still carries it.
+        wire = dict(sent.unredirected_hdrs)
+        wire.update({k: v for k, v in sent.headers.items() if k not in wire})
+        self.assertEqual(wire["Authorization"], "Bearer tok123")
+
+    def test_stdlib_default_would_have_leaked_the_token(self):
+        # Pins the reason this module refuses redirects at all: if a future
+        # Python ever stops forwarding Authorization, this test fails and the
+        # refusal can be re-argued from evidence rather than from memory.
+        new = urllib.request.HTTPRedirectHandler().redirect_request(
+            self._request(), io.BytesIO(b""), 302, "Found",
+            self._headers("http://<other-host>/collect"),
+            "http://<other-host>/collect")
+        self.assertEqual(new.get_header("Authorization"), "Bearer SECRET")
+
+    def test_handler_refuses_and_names_the_fix(self):
+        with self.assertRaises(RpcError) as ctx:
+            rpc._NoRedirect().redirect_request(
+                self._request(), io.BytesIO(b""), 302, "Found",
+                self._headers("http://<other-host>/collect"),
+                "http://<other-host>/collect")
+        exc = ctx.exception
+        self.assertEqual(exc.code, "no-endpoint")
+        self.assertEqual(exc.method, "core.savePage")
+        self.assertIn("http://<other-host>/collect", exc.message)
+        self.assertIn("[wiki] url", exc.message)  # names the fix
+
+    def test_refusing_handler_is_installed_in_the_opener(self):
+        # Not just "the class exists": drive the opener's own error chain, so
+        # a build_opener call that failed to displace the stock
+        # HTTPRedirectHandler is caught here.
+        handlers = [type(h).__name__ for h in rpc._OPENER.handlers]
+        self.assertIn("_NoRedirect", handlers)
+        self.assertNotIn("HTTPRedirectHandler", handlers)
+        for code in (301, 302, 303, 307):
+            with self.subTest(code=code):
+                with self.assertRaises(RpcError) as ctx:
+                    rpc._OPENER.error(
+                        "http", self._request(), io.BytesIO(b""), code, "R",
+                        self._headers("https://<other-host>/x"))
+                self.assertEqual(ctx.exception.code, "no-endpoint")
+
+    def test_translation_reads_for_both_no_endpoint_causes(self):
+        redirect = rpc.translate_error(
+            RpcError("no-endpoint",
+                     "redirected to https://<other-host>/x — point [wiki] url "
+                     "at the wiki's canonical base URL; the API token is never "
+                     "sent to a redirect target",
+                     "core.savePage"),
+            "https://<wiki>")
+        self.assertIn("redirected to https://<other-host>/x", redirect)
+        self.assertIn("[wiki] url", redirect)
+        not_found = rpc.translate_error(
+            RpcError("no-endpoint", "HTTP 404", "core.getPage"), "https://<wiki>")
+        self.assertIn("HTTP 404", not_found)
+        self.assertIn(rpc.MIN_RELEASE, not_found)
 
 
 class TestTranslation(unittest.TestCase):

--- a/tests/test_dokuwiki_rpc.py
+++ b/tests/test_dokuwiki_rpc.py
@@ -49,6 +49,21 @@ class TestRequestShape(unittest.TestCase):
         self.assertEqual(request.unredirected_hdrs.get("Authorization"),
                          "Bearer tok123")
         self.assertNotIn("Authorization", request.headers)
+        # X-DokuWiki-Token rides alongside Authorization (both verified live,
+        # 2026-08-05): some hosts strip the Authorization header when PHP
+        # runs as CGI/FastCGI, so a Bearer-only client is silently
+        # unauthenticated there. X-DokuWiki-Token is not special-cased by
+        # Apache and DokuWiki prefers it over Authorization when both are
+        # present — so sending both is strictly more compatible than either
+        # alone. Same unredirected-header treatment, same reason: a
+        # credential must never ride a redirect.
+        # http.client capitalizes a header key as key.capitalize() — first
+        # character up, everything else down — so "X-DokuWiki-Token" is
+        # stored (and must be looked up) as "X-dokuwiki-token".
+        self.assertEqual(request.get_header("X-dokuwiki-token"), "tok123")
+        self.assertEqual(request.unredirected_hdrs.get("X-dokuwiki-token"),
+                         "tok123")
+        self.assertNotIn("X-dokuwiki-token", request.headers)
         self.assertEqual(request.get_header("Content-type"), "application/json")
         self.assertTrue(request.get_header("User-agent").startswith("bunnyforge/"))
         self.assertEqual(json.loads(request.data.decode("utf-8")), {"page": "a:b"})
@@ -98,9 +113,38 @@ class TestSuccessShapes(unittest.TestCase):
 
 class TestWrappers(unittest.TestCase):
     def test_get_page_121_is_none(self):
+        # Older DokuWiki builds may still raise 121 for a missing page — kept
+        # even though the live API-14 install (below) no longer does.
         body = json.dumps({"error": {"code": 121, "message": "absent"}}).encode()
         c = RpcClient("https://w", "t", transport=fake_transport([body]))
         self.assertIsNone(c.get_page("a:b"))
+
+    def test_get_page_empty_result_is_none(self):
+        # Verified live against a real 2026-07-14a "Mort" install, JSON-RPC
+        # API version 14 (2026-08-05): core.getPage on a missing page ID
+        # returns "" with a *success* error object, {"code": 0, "message":
+        # "success"} — 121 is never raised at all. DokuWiki cannot hold an
+        # empty page (core.savePage refuses to create one with error 132,
+        # which is exactly why the render half translates a zero-byte
+        # placeholder to ~~NOTOC~~ before upload), so a page cannot
+        # simultaneously be empty and exist — "" unambiguously means "does
+        # not exist".
+        body = json.dumps(
+            {"result": "", "error": {"code": 0, "message": "success"}}).encode()
+        c = RpcClient("https://w", "t", transport=fake_transport([body]))
+        self.assertIsNone(c.get_page("a:b"))
+
+    def test_get_page_empty_result_bare_is_none(self):
+        # Same empty-string case with `error` entirely absent (one of the
+        # three success shapes `call` already accepts).
+        c = RpcClient("https://w", "t", transport=fake_transport([ok("")]))
+        self.assertIsNone(c.get_page("a:b"))
+
+    def test_get_page_nonempty_result_returns_text(self):
+        # Guards the empty-string fix from over-firing: real content must
+        # still come back verbatim.
+        c = RpcClient("https://w", "t", transport=fake_transport([ok("real text")]))
+        self.assertEqual(c.get_page("a:b"), "real text")
 
     def test_get_page_other_error_propagates(self):
         body = json.dumps({"error": {"code": 111, "message": "acl"}}).encode()
@@ -241,7 +285,8 @@ class TestRedirectRefusal(unittest.TestCase):
     def test_a_real_client_request_carries_no_redirectable_token(self):
         # Belt to _NoRedirect's braces, checked on a request the client
         # actually built: even handed to the stock handler, there is no
-        # Authorization header for it to forward.
+        # Authorization or X-DokuWiki-Token header for it to forward — both
+        # credential headers get the same unredirected treatment.
         t = fake_transport([ok("x")])
         RpcClient("https://<wiki>", "tok123", transport=t).call("core.getPage", {})
         sent = t.calls[0][0]
@@ -251,10 +296,13 @@ class TestRedirectRefusal(unittest.TestCase):
             "http://<other-host>/collect")
         self.assertNotIn("Authorization", new.headers)
         self.assertNotIn("Authorization", new.unredirected_hdrs)
-        # ...while the wire request do_open assembles still carries it.
+        self.assertNotIn("X-dokuwiki-token", new.headers)
+        self.assertNotIn("X-dokuwiki-token", new.unredirected_hdrs)
+        # ...while the wire request do_open assembles still carries both.
         wire = dict(sent.unredirected_hdrs)
         wire.update({k: v for k, v in sent.headers.items() if k not in wire})
         self.assertEqual(wire["Authorization"], "Bearer tok123")
+        self.assertEqual(wire["X-dokuwiki-token"], "tok123")
 
     def test_stdlib_default_would_have_leaked_the_token(self):
         # Pins the reason this module refuses redirects at all: if a future
@@ -329,9 +377,27 @@ class TestTranslation(unittest.TestCase):
         self.check(-32605, "$conf['remote'] = 1", "conf/local.php",
                    "conf/dokuwiki.php")
 
-    def test_32604_names_both_token_sources(self):
-        self.check(-32604, "BUNNYFORGE_WIKI_TOKEN", ".bunnyforge/wiki-token",
-                   "remoteuser")
+    def test_32603_names_stripped_authorization_header(self):
+        # -32603 = not authenticated: DokuWiki's JsonRpcServer.php raises this
+        # (HTTP 401) when $INPUT->server has no REMOTE_USER at all — the
+        # request carried no usable credential. Verified live (2026-08-05):
+        # a host running PHP as CGI/FastCGI strips the Authorization header
+        # before PHP ever sees it, so a Bearer-only client is silently
+        # unauthenticated there. Names both token sources and remoteuser,
+        # since the cause is common and non-obvious.
+        self.check(-32603, "BUNNYFORGE_WIKI_TOKEN", ".bunnyforge/wiki-token",
+                   "remoteuser", "CGI", "Authorization")
+
+    def test_32604_names_forbidden_and_acl(self):
+        # -32604 = authenticated but forbidden: JsonRpcServer.php raises this
+        # (HTTP 403) when $INPUT->server *does* have REMOTE_USER — the
+        # credential was accepted, this user just may not call the method.
+        # Previously mapped to "check the token", which named the wrong
+        # layer entirely; corrected now that the live source resolves the
+        # ambiguity the spec had deferred (2026-08-05).
+        self.check(-32604, "remoteuser", "forbidden")
+        msg = self.check(-32604)
+        self.assertNotIn("BUNNYFORGE_WIKI_TOKEN", msg)
 
     def test_111_names_acl(self):
         self.check(111, "ACL", "edit")

--- a/tests/test_import_perceptions.py
+++ b/tests/test_import_perceptions.py
@@ -331,7 +331,7 @@ class TestMain(unittest.TestCase):
             data, perceptions = d / "data", d / "Perceptions"
             _write_page(data / "pages", "party:mira", "====== Mira ======\n\nbody\n")
 
-            rc = self._run_main(d, "--wiki-data", str(data))
+            rc = self._run_main(d, "--wiki-data", str(data), "--go")
 
             self.assertEqual(rc, 0)
             out_file = perceptions / "party-mira.md"
@@ -349,7 +349,7 @@ class TestMain(unittest.TestCase):
             data = d / "data"
             _write_page(data / "pages", "party:mira", "====== Mira ======\n\nbody\n")
 
-            rc = self._run_main(d, "--wiki-data", str(data))
+            rc = self._run_main(d, "--wiki-data", str(data), "--go")
 
             self.assertEqual(rc, 0)
             self.assertTrue((d / "PlayerBeliefs" / "party-mira.md").exists())
@@ -371,7 +371,7 @@ class TestMain(unittest.TestCase):
             _write_attic(data / "attic", "party:mira", 100,
                          "====== Mira ======\n\narchived body\n")
 
-            rc = self._run_main(d, "--wiki-data", str(data), "--as-of", "2020-01-01")
+            rc = self._run_main(d, "--wiki-data", str(data), "--as-of", "2020-01-01", "--go")
 
             self.assertEqual(rc, 0)
             out_file = perceptions / "party-mira--2020-01-01.md"
@@ -391,11 +391,15 @@ class TestMain(unittest.TestCase):
             dest.write_text("SENTINEL - pre-existing", encoding="utf-8")
             _write_page(data / "pages", "party:mira", "====== Mira ======\n\nnew body\n")
 
+            # No --go here: the file already exists and --overwrite is not
+            # given, so this hits the "skip (exists)" path before the
+            # dry-run/--go branch is ever consulted — a dry run proves the
+            # same thing a --go run would.
             rc = self._run_main(d, "--wiki-data", str(data))
             self.assertEqual(rc, 0)
             self.assertEqual(dest.read_text(encoding="utf-8"), "SENTINEL - pre-existing")
 
-            rc = self._run_main(d, "--wiki-data", str(data), "--overwrite")
+            rc = self._run_main(d, "--wiki-data", str(data), "--overwrite", "--go")
             self.assertEqual(rc, 0)
             content = dest.read_text(encoding="utf-8")
             self.assertIn("new body", content)
@@ -408,12 +412,40 @@ class TestMain(unittest.TestCase):
             data, perceptions = d / "data", d / "Perceptions"
             _write_page(data / "pages", "party:mira", "====== Mira ======\n\nbody\n")
 
-            rc = self._run_main(d, "--wiki-data", str(data), "--dry-run")
+            # No --go: the bare run IS the dry run now (package-wide
+            # convention), so this is the default invocation, not a flag.
+            rc = self._run_main(d, "--wiki-data", str(data))
 
             self.assertEqual(rc, 0)
-            # --dry-run must never create the destination directory, let
+            # A dry run must never create the destination directory, let
             # alone write into it.
             self.assertFalse(perceptions.exists())
+
+    def test_go_writes(self):
+        # Mirror of test_dry_run_writes_nothing with --go: the file actually
+        # appears, with the expected front matter.
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            _write_campaign_toml(d)
+            data, perceptions = d / "data", d / "Perceptions"
+            _write_page(data / "pages", "party:mira", "====== Mira ======\n\nbody\n")
+
+            rc = self._run_main(d, "--wiki-data", str(data), "--go")
+
+            self.assertEqual(rc, 0)
+            out_file = perceptions / "party-mira.md"
+            self.assertTrue(out_file.exists())
+            self.assertIn("canon: perception", out_file.read_text(encoding="utf-8"))
+
+    def test_dry_run_flag_removed(self):
+        # --dry-run is gone, not deprecated: argparse rejects it loudly
+        # (exit code 2) rather than silently accepting a stale script's flag
+        # with a now-different meaning.
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            with self.assertRaises(SystemExit) as ctx:
+                ip.main(["--wiki-data", "/nonexistent", "--dry-run"])
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_malformed_as_of_returns_nonzero(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -327,6 +327,17 @@ class TestWhatInitWrites(unittest.TestCase):
                 self.assertTrue(line.lstrip().startswith("#"),
                                 f"line {n} is live code: {line!r}")
 
+    def test_gitignore_covers_wiki_token_and_drift(self):
+        # The wiki credential and the tool-owned drift copies must never be
+        # committed. The ignores must be two specific entries, never a
+        # whole-directory ignore that would silently swallow the deploy
+        # manifest too.
+        target = _scaffold(self)
+        text = (target / ".gitignore").read_text(encoding="utf-8")
+        self.assertIn(".bunnyforge/wiki-token", text)
+        self.assertIn(".bunnyforge/wiki-drift/", text)
+        self.assertNotIn(".bunnyforge/\n", text)
+
     def test_a_scaffolded_workspace_reports_no_tests_rather_than_crashing(self):
         # The whole feature, end to end: init a workspace, then run the very
         # command a new user runs first. Before the scaffold this printed an

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -694,6 +694,60 @@ class TestWikiPluginsCheck(unittest.TestCase):
             self.assertEqual(review.check_wiki_plugins([], root), [])
 
 
+class TestWikiRemote(unittest.TestCase):
+    def _wiki(self, d: Path, local_php="", dokuwiki_php=""):
+        (d / "conf").mkdir(parents=True, exist_ok=True)
+        (d / "lib" / "plugins").mkdir(parents=True, exist_ok=True)
+        (d / "conf" / "dokuwiki.php").write_text(
+            "<?php\n" + dokuwiki_php, encoding="utf-8")
+        if local_php:
+            (d / "conf" / "local.php").write_text(
+                "<?php\n" + local_php, encoding="utf-8")
+        return d
+
+    def _findings(self, d):
+        return review.check_wiki_remote([], d)
+
+    def test_disabled_is_no_finding(self):
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(Path(d), dokuwiki_php="$conf['remote'] = 0;\n")
+            self.assertEqual(self._findings(wiki), [])
+
+    def test_enabled_without_remoteuser_is_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(Path(d), local_php="$conf['remote'] = 1;\n")
+            findings = self._findings(wiki)
+            self.assertTrue(any(f.severity == "error" and
+                                "remoteuser" in f.message for f in findings))
+
+    def test_stock_not_set_placeholder_counts_as_unset(self):
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(Path(d), local_php=(
+                "$conf['remote'] = 1;\n"
+                "$conf['remoteuser'] = '!!not set!!';\n"))
+            findings = self._findings(wiki)
+            self.assertTrue(any("remoteuser" in f.message for f in findings))
+
+    def test_scoped_remoteuser_is_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(Path(d), local_php=(
+                "$conf['remote'] = 1;\n"
+                "$conf['remoteuser'] = 'deploybot';\n"))
+            self.assertEqual(self._findings(wiki), [])
+
+    def test_enabled_from_dokuwiki_php_is_provenance_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(Path(d), dokuwiki_php=(
+                "$conf['remote'] = 1;\n"
+                "$conf['remoteuser'] = 'deploybot';\n"))
+            findings = self._findings(wiki)
+            self.assertTrue(any(f.severity == "error" and
+                                "dokuwiki.php" in f.message for f in findings))
+
+    def test_wiki_suite_includes_wiki_remote(self):
+        self.assertIn("wiki-remote", review.SUITES["wiki"])
+
+
 class TestWikiSuiteWiring(unittest.TestCase):
     def test_checkup_does_not_include_any_wiki_check(self):
         # CI has no wiki. The separation is the whole skippability mechanism,

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -744,6 +744,55 @@ class TestWikiRemote(unittest.TestCase):
             self.assertTrue(any(f.severity == "error" and
                                 "dokuwiki.php" in f.message for f in findings))
 
+    def test_remoteuser_scoped_but_from_dokuwiki_php_is_provenance_error(self):
+        # remote itself is correctly scoped to local.php; remoteuser is the
+        # one that reverts on upgrade. This is the sharper failure the
+        # provenance rule on `remote` alone misses entirely: the check
+        # passes clean today and hands every account the API back the next
+        # time DokuWiki upgrades.
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(
+                Path(d),
+                local_php="$conf['remote'] = 1;\n",
+                dokuwiki_php="$conf['remoteuser'] = 'deploybot';\n")
+            findings = self._findings(wiki)
+            self.assertTrue(
+                any(f.severity == "error" and "remoteuser" in f.message
+                    and "dokuwiki.php" in f.message for f in findings),
+                findings)
+            # And nothing else fires: `remote` itself is clean, so only the
+            # remoteuser-provenance finding should be present.
+            self.assertEqual(len(findings), 1, findings)
+
+    def test_placeholder_remoteuser_from_dokuwiki_php_is_still_unset(self):
+        # The placeholder is DokuWiki's not-configured sentinel regardless
+        # of which file it appears in. It must trip the unset finding, not
+        # the provenance one — there is nothing to move to local.php, the
+        # deploy user was simply never scoped.
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(
+                Path(d),
+                local_php="$conf['remote'] = 1;\n",
+                dokuwiki_php="$conf['remoteuser'] = '!!not set!!';\n")
+            findings = self._findings(wiki)
+            self.assertTrue(
+                any(f.severity == "error" and "unset" in f.message
+                    for f in findings),
+                findings)
+            self.assertFalse(
+                any(f.file and "dokuwiki.php" in f.file for f in findings),
+                findings)
+            self.assertEqual(len(findings), 1, findings)
+
+    def test_both_scoped_to_local_php_is_still_clean(self):
+        # Confirms the new provenance rule does not false-alarm on the
+        # already-correct configuration.
+        with tempfile.TemporaryDirectory() as d:
+            wiki = self._wiki(Path(d), local_php=(
+                "$conf['remote'] = 1;\n"
+                "$conf['remoteuser'] = 'deploybot';\n"))
+            self.assertEqual(self._findings(wiki), [])
+
     def test_wiki_suite_includes_wiki_remote(self):
         self.assertIn("wiki-remote", review.SUITES["wiki"])
 


### PR DESCRIPTION
Implements the approved design in
`docs/superpowers/specs/2026-08-05-deploy-export-rpc-transport-design.md`
(merged in #10), following the 12-task plan alongside it.

`deploy-export` previously rendered a staging tree and stopped; a human copied
it onto the wiki by hand. This closes that gap over DokuWiki's JSON-RPC API —
the package's first network capability.

## Files changed

**New**
- `src/bunnyforge/_dokuwiki_rpc.py` — JSON-RPC client, `RpcError`, error-translation table
- `tests/test_dokuwiki_rpc.py`

**Modified**
- `src/bunnyforge/deploy_export.py` — transport half (manifest, classification, plan/apply, drift report) + new CLI; render half untouched
- `src/bunnyforge/_config.py` — `[wiki]` table, API-token resolution
- `src/bunnyforge/review.py` — `wiki-remote` check
- `src/bunnyforge/import_perceptions.py` — dry-run default, `--go`, `--dry-run` removed
- `src/bunnyforge/cli.py` — `deploy-export` summary line
- `src/bunnyforge/data/root/gitignore` — two entries (not the directory)
- `README.md`, `src/bunnyforge/README.md`, `pyproject.toml` (0.2.0)
- `docs/superpowers/specs/2026-07-27-player-wiki-export-design.md` — supersession annotation
- `tests/` — `test_deploy_export`, `test_config`, `test_review`, `test_import_perceptions`, `test_init`

## Work breakdown

**Transport.** Stdlib-only client speaking the simplified `PATH_INFO` form.
Success is `error` absent, `null`, or `code == 0` — never key presence, since
DokuWiki returns `{"error": {"code": 0, "message": "success"}}` on success and a
key-presence client would call every success a failure. Transport is injectable,
so no test opens a socket.

**Drift detection.** A committed manifest (`.bunnyforge/wiki-manifest.json`)
records the hash of what the wiki returned after each save — never the bytes
sent, since DokuWiki normalizes on save. An eight-row pure classifier decides
per page: write, skip, adopt, or hold back. Held-back pages get a unified diff
and their current wiki text copied to `.bunnyforge/wiki-drift/` for manual merge.
Orphans are reported, never deleted.

**CLI convention.** The default run is a dry run; `--go` writes. Applied to
`deploy-export` and, breaking, to `import-perceptions`. `--render-only` is
deliberately outside the convention — it is a different, offline deliverable,
and needs no `[wiki]` config and no token.

**Review.** `review wiki` gains `wiki-remote`: the remote API enabled without a
scoped `remoteuser`, or enabled from the upgrade-overwritten `conf/dokuwiki.php`.
Filesystem-only, so CI still never needs a live wiki.

## Test expectations

All green — **436 → 540 tests**, portability check passes. No failures expected.

## Review notes — please read before merging

A final whole-branch review found a **Critical** defect that the per-task
reviews structurally could not see, now fixed in `af695e0`:

> The Bearer token was forwarded across HTTP redirects. `urllib` copies all
> headers onto a redirected request and, unlike `requests`, does not strip
> `Authorization` on host change. The `http://` refusal applied only to the
> *configured* base URL, so an ordinary apex→www or https→http redirect would
> have sent a live API token in clear, or to a host the user never configured.

Redirects on the RPC endpoint are now refused outright, and the token rides
`add_unredirected_header` as a second layer. Verified by socket-level simulation:
exactly one request is sent on a 302, and the token never leaves the configured
host.

**Three known minors, deliberately not fixed** (happy to take any before merge):
1. `_dokuwiki_rpc.py`'s `return exc.read()` sits outside the broadened `except`
   arm, so a mid-stream failure reading a **non-200** body still escapes
   unwrapped. Needs a non-200 status *and* a truncated body. One-line fix.
2. `check_overwrite` runs before `write_drift_copies`, so a run refused for a bad
   `--overwrite` leaves the prior run's `wiki-drift/` intact, contradicting that
   docstring for one path.
3. A comment in `_config.py` claims `mkdir` under a normal umask leaves `0o755` —
   true for umask 022, not 002, where the new parent-directory guard would refuse
   the tool's own directory.

**Two spec gaps found by the final review were closed in `c725bf2`:** the
`wiki-remote` check now applies its upgrade-provenance rule to `remoteuser` as
well as `remote` (it previously handed out advice it did not enforce), and the
`core.getPage` assumption moved onto the first-live-deploy checklist.

## Verified against a live wiki

This branch has now been run end-to-end against a real DokuWiki
(`2026-07-14a "Mort"`, JSON-RPC API version 14). **That found two genuine bugs
no amount of unit testing would have caught**, both fixed in `0948ae1`:

**The `Authorization: Bearer` header is unusable on much of the web.** Apache
strips it before PHP runs whenever PHP is dispatched as CGI/FastCGI — most
shared hosting. DokuWiki's `getallheaders()` still returns a non-empty array
without it, so its own `$_SERVER` fallback never runs either; no `.htaccess`
env-var trick or `preload.php` normalisation can reach it, and `CGIPassAuth On`
is rejected by older Apache. The client now also sends `X-DokuWiki-Token`,
which DokuWiki prefers when present and which Apache does not special-case.
Both headers ride `add_unredirected_header`, so the redirect defence added
earlier still holds for each.

**`core.getPage` returns `""`, not error 121, for a page that does not exist.**
Error 121 never occurred at all. `get_page()` therefore never returned `None`,
and `classify_page`'s matrix misfired: **the first deploy would have classified
every page as `drift-manual-era` and written nothing.** `get_page()` now treats
an empty result as absent. That is sound rather than a heuristic, and the live
wiki confirmed the premise: `core.savePage` refuses an empty page with error
132 (*"Refusing to write an empty new wiki page"*), so a page cannot be both
empty and existing.

**`-32603` was also misdiagnosed.** It was translated as *"unrecognised code,
please report it"*, sending users to file a bunnyforge bug for a web-server
configuration problem. The live source resolves the ambiguity the spec had
recorded: `JsonRpcServer` throws 401/`-32603` when `REMOTE_USER` is unset (not
authenticated) and 403/`-32604` when set (authenticated but forbidden). Both
now carry proper instructional messages, and `-32604`'s previous "check the
token" text — now known to be wrong — is corrected.

### Live battery, all passing

First deploy with the content page written before its wrapper; idempotent
re-run (`unchanged`, zero writes, which also proves the read-back hash
discipline); Markdown→DokuWiki conversion and `{{page>}}` wrapper includes;
adopt / resume-after-crash; drift hold-back with a correct unified diff and
inbound copy — **a real wiki edit survived a redeploy rather than being
clobbered**, which is the design's headline guarantee; `--overwrite` clobbering
on demand; `--overwrite` refusing an unknown page ID *in dry run*; exit code 1
whenever anything is held back, in both modes; and read-back hashes stable over
time and still matching the manifest.

### Provenance

- Agent: Claude Code (VS Code extension), subagent-driven execution — fresh
  implementer per task, task-scoped review after each, final whole-branch review
- Model / version: the session requested Fable 5 for the design and plan, Opus 5
  for execution; task implementers and reviewers ran on Sonnet 5 and Haiku 4.5,
  the final review and its fix wave on Opus 5

