### PR TITLE
review wiki: let campaign.toml name the wiki install root (#13)

### DIFF
--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -271,6 +271,10 @@ do not include it:
 url = "https://<wiki>"
 ```
 
+(The same table can also carry `install_root`, an unrelated key read only by
+the `wiki` review suite below — a local filesystem path, never sent over the
+wire.)
+
 `https://` is required. A plain `http://` URL is refused — the token would
 cross the wire in clear — except for `localhost`, `127.0.0.1`, or `::1`,
 where a local test install has nothing to leak.
@@ -527,6 +531,20 @@ Asserts configuration invariants of a **live DokuWiki install** — the only
 checks here that look outside the workspace. `--wiki-root` is the installation
 root, the directory holding `conf/` and `lib/`. (Note that is *not* the same
 path as `import_perceptions`'s `--wiki-data`, which points at `data/`.)
+
+That path does not change between runs, so rather than retyping it every time,
+name it once in `campaign.toml`:
+
+```toml
+[wiki]
+install_root = "/path/to/a/wiki/copy"
+```
+
+`--wiki-root` still wins when both are given. Either way the value is
+expanded (`~`) and resolved the same way before use. Neither supplied is an
+error naming both routes; this key does not acquire the copy for you — it
+must already exist on disk, however obtained (a mount, an unpacked backup, a
+synced folder).
 
 **Run it after every DokuWiki upgrade.** An upgrade is precisely when this
 drifts, and the two worst failures on record were both config drift that no

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -35,8 +35,12 @@ Config = namedtuple(
     "Config",
     "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
     "exclude_dirs names_cultures names_official_culture names_spelling "
-    "briefs_dir sheets_dir perceptions_dir type_dirs wiki_url",
-    defaults=[None])  # wiki_url only — [wiki] is optional and network-only
+    "briefs_dir sheets_dir perceptions_dir type_dirs wiki_url "
+    "wiki_install_root",
+    # wiki_url and wiki_install_root only — [wiki] is entirely optional: the
+    # RPC transport needs a URL, the `wiki` review suite needs a local
+    # install root, and a workspace using neither leaves both None.
+    defaults=[None, None])
 
 
 class ConfigError(Exception):
@@ -194,6 +198,9 @@ def load(workspace: Path) -> Config:
     wiki_url = wiki.get("url")
     if wiki_url is not None and not isinstance(wiki_url, str):
         raise ConfigError(f"{path}: wiki.url must be a string")
+    wiki_install_root = wiki.get("install_root")
+    if wiki_install_root is not None and not isinstance(wiki_install_root, str):
+        raise ConfigError(f"{path}: wiki.install_root must be a string")
 
     entity_dirs = _str_tuple(ws, "entity_dirs")
     inherit_dirs = _str_tuple(ws, "inherit_dirs")
@@ -226,6 +233,7 @@ def load(workspace: Path) -> Config:
         perceptions_dir=_str(ws, "perceptions_dir"),
         type_dirs=_type_dirs(ws),
         wiki_url=wiki_url,
+        wiki_install_root=wiki_install_root,
     )
 
 

--- a/src/bunnyforge/review.py
+++ b/src/bunnyforge/review.py
@@ -489,28 +489,36 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--wiki-root", metavar="PATH",
         help="DokuWiki installation root (the directory holding conf/ and "
-             "lib/). Required by the 'wiki' suite; ignored by every other.")
+             "lib/). Required by the 'wiki' suite (or set [wiki] "
+             "install_root in campaign.toml); ignored by every other.")
     args = parser.parse_args(argv)
 
     if args.suite not in SUITES:
         parser.error(f"unknown suite: {args.suite}. Known: {', '.join(SUITES)}")
-
-    # Required conditionally rather than globally: making --wiki-root
-    # mandatory would break checkup, which never touches a wiki.
-    wiki_root = None
-    if any(name in _NEEDS_WIKI for name in SUITES[args.suite]):
-        if not args.wiki_root:
-            print(f"error: the '{args.suite}' suite needs --wiki-root PATH "
-                  f"(the DokuWiki installation root, holding conf/ and lib/)",
-                  file=sys.stderr)
-            return 1
-        wiki_root = Path(args.wiki_root).expanduser().resolve()
 
     try:
         ws = resolve_workspace(args.workspace)
     except (WorkspaceError, ConfigError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+
+    # Required conditionally rather than globally: making a wiki root
+    # mandatory would break checkup, which never touches a wiki. Resolved
+    # after the workspace, not before, since the configured fallback lives
+    # in that workspace's campaign.toml — --wiki-root still wins when given.
+    wiki_root = None
+    if any(name in _NEEDS_WIKI for name in SUITES[args.suite]):
+        configured = ws.config.wiki_install_root
+        if args.wiki_root:
+            wiki_root = Path(args.wiki_root).expanduser().resolve()
+        elif configured:
+            wiki_root = Path(configured).expanduser().resolve()
+        else:
+            print(f"error: the '{args.suite}' suite needs --wiki-root PATH "
+                  f"(the DokuWiki installation root, holding conf/ and "
+                  f"lib/), or [wiki] install_root in campaign.toml",
+                  file=sys.stderr)
+            return 1
 
     try:
         findings = run_suite(args.suite, ws, wiki_root)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -397,6 +397,35 @@ class TestWikiConfig(unittest.TestCase):
         with self.assertRaises(_config.ConfigError):
             self._load('[campaign]\nnamespace = "test"\n[wiki]\nurl = 7\n')
 
+    def test_wiki_install_root_parsed(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n'
+                         '[wiki]\ninstall_root = "/path/to/a/wiki/copy"\n')
+        self.assertEqual(cfg.wiki_install_root, "/path/to/a/wiki/copy")
+
+    def test_wiki_install_root_absent_is_none(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n[wiki]\n'
+                         'url = "https://<wiki>"\n')
+        self.assertIsNone(cfg.wiki_install_root)
+
+    def test_wiki_table_absent_install_root_is_none(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n')
+        self.assertIsNone(cfg.wiki_install_root)
+
+    def test_wiki_install_root_non_string_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n'
+                       '[wiki]\ninstall_root = 7\n')
+
+    def test_wiki_url_and_install_root_both_parsed(self):
+        # The two keys are independent — one names where the RPC transport
+        # talks to, the other a local filesystem copy for the `wiki` review
+        # suite — so setting both must not make either one clobber the other.
+        cfg = self._load('[campaign]\nnamespace = "test"\n[wiki]\n'
+                         'url = "https://<wiki>"\n'
+                         'install_root = "/path/to/a/wiki/copy"\n')
+        self.assertEqual(cfg.wiki_url, "https://<wiki>")
+        self.assertEqual(cfg.wiki_install_root, "/path/to/a/wiki/copy")
+
     def test_wiki_non_table_refused(self):
         # `wiki = "x"` must precede any table header, same TOML-scoping trap
         # noted in TestConfigLoad.test_names_section_must_be_a_table: a bare

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,8 +1,10 @@
 import contextlib
 import io
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from bunnyforge import _common
 from bunnyforge import _config
@@ -815,11 +817,20 @@ class TestWikiSuiteWiring(unittest.TestCase):
         self.assertEqual(registered, in_suites)
 
     def test_the_wiki_suite_requires_wiki_root(self):
-        out, err = io.StringIO(), io.StringIO()
-        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-            rc = review.main(["wiki"])
-        self.assertEqual(rc, 1)
-        self.assertIn("--wiki-root", err.getvalue())
+        # No --wiki-root and no [wiki] install_root in campaign.toml: the
+        # instructional error must name both routes. A real workspace is
+        # needed here (--wiki-root's absence can only be resolved against
+        # config once the workspace holding that config is known), so this
+        # uses an explicit one rather than relying on ambient cwd/env.
+        with tempfile.TemporaryDirectory() as d:
+            ws = make_workspace(Path(d), {})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws)])
+            self.assertEqual(rc, 1)
+            self.assertIn("--wiki-root", err.getvalue())
+            self.assertIn("install_root", err.getvalue())
+            self.assertIn("campaign.toml", err.getvalue())
 
     def test_a_bad_wiki_root_is_one_error_line_not_a_traceback(self):
         with tempfile.TemporaryDirectory() as d:
@@ -830,3 +841,56 @@ class TestWikiSuiteWiring(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertIn("error:", err.getvalue())
             self.assertNotIn("Traceback", err.getvalue())
+
+    def test_configured_install_root_used_when_flag_absent(self):
+        # --wiki-root absent, [wiki] install_root set: the configured path
+        # is used. Proven without a real DokuWiki install by pointing at a
+        # nonexistent directory and checking that _dokuwiki_install's own
+        # (already-instructional) refusal names that exact path — evidence
+        # the configured value, not some other default, reached check_root.
+        with tempfile.TemporaryDirectory() as d:
+            configured = str(Path(d) / "configured-wiki-copy")
+            ws = make_workspace(Path(d) / "ws", {
+                "campaign.toml": '[campaign]\nnamespace = "test"\n'
+                                 f'[wiki]\ninstall_root = "{configured}"\n'})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws)])
+            self.assertEqual(rc, 1)
+            self.assertIn(configured, err.getvalue())
+
+    def test_flag_overrides_configured_install_root(self):
+        # Explicit beats configured: when both are present, --wiki-root
+        # wins. Distinguished the same way as above — two different
+        # nonexistent paths, and only the flag's should appear in the error.
+        with tempfile.TemporaryDirectory() as d:
+            configured = str(Path(d) / "configured-wiki-copy")
+            flagged = str(Path(d) / "flagged-wiki-copy")
+            ws = make_workspace(Path(d) / "ws", {
+                "campaign.toml": '[campaign]\nnamespace = "test"\n'
+                                 f'[wiki]\ninstall_root = "{configured}"\n'})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws),
+                                  "--wiki-root", flagged])
+            self.assertEqual(rc, 1)
+            self.assertIn(flagged, err.getvalue())
+            self.assertNotIn(configured, err.getvalue())
+
+    def test_configured_install_root_expands_tilde(self):
+        # The CLI already expands ~ and resolves --wiki-root; the configured
+        # value must get the same treatment rather than being handed to
+        # check_root as a literal "~/...".
+        with tempfile.TemporaryDirectory() as home:
+            ws = make_workspace(Path(home) / "ws", {
+                "campaign.toml": '[campaign]\nnamespace = "test"\n'
+                                 '[wiki]\ninstall_root = '
+                                 '"~/configured-wiki-copy"\n'})
+            expected = str(Path(home) / "configured-wiki-copy")
+            out, err = io.StringIO(), io.StringIO()
+            with mock.patch.dict(os.environ, {"HOME": home}, clear=False), \
+                 contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws)])
+            self.assertEqual(rc, 1)
+            self.assertNotIn("~", err.getvalue())
+            self.assertIn(expected, err.getvalue())


### PR DESCRIPTION
Closes #13.

## Files changed

- `src/bunnyforge/_config.py` (modified) — parse `[wiki] install_root`
- `src/bunnyforge/review.py` (modified) — use it as the `--wiki-root` fallback
- `src/bunnyforge/README.md` (modified) — document the key
- `tests/test_config.py`, `tests/test_review.py` (modified) — covering tests

## Work breakdown

The `wiki` suite needs a DokuWiki installation root, supplied today only by
`--wiki-root PATH`. That path never changes between runs but had nowhere to be
recorded, so it got retyped every time — and the suite is meant to be run after
every DokuWiki upgrade, which is exactly when the friction is least welcome.

```toml
[wiki]
url          = "https://<wiki>"        # existing: base URL for the RPC transport
install_root = "/path/to/a/wiki/copy"  # new: a LOCAL path holding conf/ and lib/
```

Precedence, all four cases covered by tests and verified by hand:

| `--wiki-root` | `[wiki] install_root` | result |
|---|---|---|
| given | — | flag |
| — | set | config |
| given | set | **flag wins** — explicit beats configured |
| — | — | instructional error naming **both** routes |

`install_root` rather than a bare `root`: it sits directly beneath `url`, where
`root` would read as "the wiki's root URL" rather than a filesystem path, and it
matches the vocabulary already used by `_dokuwiki_install.py` and by
`--wiki-root`'s own help text.

Validation is not duplicated — `_dokuwiki_install.check_root` already refuses a
path with no `conf/`, with an instructional message.

## Explicitly not in scope

**Fetching the wiki over the network.** This key names a path that already
exists locally — a copy, a mount, an unpacked backup, a synced folder. A
`fetch-wiki-conf` command was considered and rejected on #13: the ssh host and
remote path are campaign data that cannot live in this public repo; it would
privilege one transport when the suite was deliberately built to work against a
filesystem copy however obtained (many hosted wikis offer no shell access);
and it would mean shelling out to external binaries and inheriting SSH's auth
surface, in a package that is otherwise stdlib-only. Automating the copy belongs
in the campaign repo that legitimately holds the host and path.

## Test expectations

All green — **540 → 548 tests**, portability check passes. No failures expected.

## Operational impact

None. The key is optional and absent config behaves exactly as before.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: Opus 5 driving a Sonnet 5 implementer