### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump only — one line in `pyproject.toml`. Nothing else changes.

## Files changed

- `pyproject.toml` (modified) — `0.2.0` → `0.2.1`

## Work breakdown

`main` has carried unreleased user-facing work since `v0.2.0` while still
declaring `0.2.0`, which is exactly the version/tag drift the README's
Releasing section warns about. With development pausing, that is the worst
state to leave behind: `main` and PyPI would report the same version but hold
different code.

Released by this bump:

- **`[wiki] install_root`** (#13/#14) — `campaign.toml` can name the DokuWiki
  install root, so `bunnyforge review wiki` no longer needs `--wiki-root`
  retyped every run. `--wiki-root` still wins when given.
- **Live-check link resolution** (#12/#17) — verifies a rewritten absolute link
  resolves from inside an included page, closing the last open item from the
  2026-07-27 player-wiki-export design. Test-only; `tests/` is not shipped in
  the wheel, so this does not affect what users install.

**A patch bump rather than 0.3.0.** `install_root` is additive configuration
with no behaviour change when absent; 0.3.0 is reserved to mark the next line
of new functionality.

## Test expectations

None — no code changed. `main` is green at 548 tests.

## Operational impact

After merge: tag `v0.2.1` and push, which triggers `publish.yml`. CI refuses a
tag that disagrees with `pyproject.toml`, which is why this bump is its own
step. The campaign repo's pin can then move from 0.2.0 to 0.2.1 in its own
commit — needed only if it wants `install_root`.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: Opus 5