### PR TITLE
review: let a workspace accept a known finding (#19)

### DIFF
--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -529,6 +529,54 @@ goes in `_NEEDS_WORKSPACE`; one needing a DokuWiki install root goes in
 `_NEEDS_WIKI`. The agent-judgment half of the checkup lives in
 `checks/checkup.md`.
 
+### Accepting a finding
+
+A check that reports a finding the operator has already judged and accepted
+reports it forever, exits non-zero on every future run, and eventually trains
+the operator to stop reading the summary — at which point the next *real*
+finding gets lost in the noise. Record that judgement in `campaign.toml`:
+
+```toml
+[[review.accepted]]
+check  = "wiki-acl"
+file   = "conf/acl.auth.php"
+match  = "<ns>:* grants to a group"
+reason = "Intentional: account creation is restricted, so any logged-in account is a small trusted set."
+```
+
+All four keys are required, and `reason` must be non-empty — `load()` refuses
+an entry missing either, naming the offending entry, because an acceptance
+with no rationale is indistinguishable from a mistake six months later. A
+finding is accepted when `check` and `file` match exactly and `match` is a
+**substring** of the finding's message (substring rather than the whole
+message, so a reworded but otherwise-unchanged message doesn't silently
+un-accept a judgement).
+
+**This accepts one specific finding, never a check.** Only a finding whose
+check, file, and message substring all match is excluded; a *different*
+finding from the same check — a new file, a new scope, a new namespace — still
+reports and still fails the run. Wholesale-silencing `wiki-acl` would hide the
+next namespace that gets it wrong; the unit of acceptance is deliberately the
+finding, not the check.
+
+Accepted findings never vanish: they're excluded from the exit code and from
+each check's issue count, but listed in their own `Accepted` section of both
+the terminal and HTML report, each with its recorded reason — so the decision
+stays visible instead of quietly disappearing. If one acceptance's `match`
+turns out to cover more than one finding this run, that finding count is
+reported alongside it, so an operator can see a loose `match` covering more
+than intended. And if an acceptance matches nothing this run — the config it
+described has since changed — it's reported as a `warn`-severity finding
+under a synthetic `review-accepted` check, so a stale judgement surfaces
+rather than sitting invisibly forever; being `warn` rather than `error`, it
+never reddens the run on its own.
+
+The mechanism applies to every suite (`checkup`, `wiki`, and any future one),
+not just `wiki` — one mechanism is easier to explain than a per-suite variant.
+An acceptance whose `check` belongs to a suite that isn't currently running is
+simply not evaluated (neither matched nor reported stale) — a `wiki-acl`
+acceptance sitting unused during a `checkup` run doesn't spuriously warn.
+
 ### The `wiki` suite
 
     python3 -m bunnyforge.review wiki --wiki-root /path/to/dokuwiki

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -36,11 +36,19 @@ Config = namedtuple(
     "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
     "exclude_dirs names_cultures names_official_culture names_spelling "
     "briefs_dir sheets_dir perceptions_dir type_dirs wiki_url "
-    "wiki_install_root",
-    # wiki_url and wiki_install_root only — [wiki] is entirely optional: the
-    # RPC transport needs a URL, the `wiki` review suite needs a local
-    # install root, and a workspace using neither leaves both None.
-    defaults=[None, None])
+    "wiki_install_root accepted",
+    # wiki_url and wiki_install_root: [wiki] is entirely optional, so a
+    # workspace using neither RPC nor the `wiki` review suite leaves both
+    # None. accepted: [[review.accepted]] is likewise optional, so a
+    # workspace with no recorded acceptances gets an empty tuple.
+    defaults=[None, None, ()])
+
+# An accepted review finding, recorded in campaign.toml as
+# [[review.accepted]]. See review.py's apply_acceptances for how these are
+# matched against a run's findings, and its README section for the mechanism
+# this exists to support: accepting one specific finding, never disabling a
+# check wholesale.
+Acceptance = namedtuple("Acceptance", "check file match reason")
 
 
 class ConfigError(Exception):
@@ -146,6 +154,69 @@ def _type_dirs(section: dict) -> dict[str, str]:
     return dict(raw)
 
 
+_ACCEPTED_KEYS = ("check", "file", "match", "reason")
+
+
+def _accepted(review_section: dict, path: Path) -> tuple[Acceptance, ...]:
+    """Validate and parse review.accepted: an array of tables, each pinning
+    one specific finding as deliberately accepted.
+
+    All four keys are required on every entry — a loosely-keyed acceptance
+    (e.g. no `file`) could silently swallow findings from checks or files it
+    was never meant to cover. `reason` must also be non-empty: an acceptance
+    with no rationale is indistinguishable from a mistake six months later,
+    so this refuses at parse time rather than accepting silently.
+    """
+    raw = review_section.get("accepted", [])
+    if not isinstance(raw, list):
+        raise ConfigError(f"{path}: review.accepted must be an array of tables "
+                          "([[review.accepted]])")
+
+    out = []
+    for i, entry in enumerate(raw, start=1):
+        if not isinstance(entry, dict):
+            raise ConfigError(
+                f"{path}: [[review.accepted]] entry {i} must be a table, e.g.\n"
+                '  [[review.accepted]]\n'
+                '  check  = "<check-name>"\n'
+                '  file   = "<path>"\n'
+                '  match  = "<substring of the finding message>"\n'
+                '  reason = "<why this is intentional>"')
+
+        missing = [k for k in _ACCEPTED_KEYS if k not in entry]
+        if missing:
+            given = ", ".join(f"{k}={entry[k]!r}" for k in _ACCEPTED_KEYS
+                              if k in entry)
+            identifies = f" ({given})" if given else ""
+            raise ConfigError(
+                f"{path}: [[review.accepted]] entry {i}{identifies} is "
+                f"missing required key(s): {', '.join(missing)} — check, "
+                "file, match, and reason are all required, e.g.\n"
+                '  [[review.accepted]]\n'
+                '  check  = "<check-name>"\n'
+                '  file   = "<path>"\n'
+                '  match  = "<substring of the finding message>"\n'
+                '  reason = "<why this is intentional>"')
+
+        for k in _ACCEPTED_KEYS:
+            if not isinstance(entry[k], str):
+                raise ConfigError(
+                    f"{path}: [[review.accepted]] entry {i}: {k} must be a "
+                    "string")
+
+        if not entry["reason"].strip():
+            raise ConfigError(
+                f"{path}: [[review.accepted]] entry {i} (check="
+                f"{entry['check']!r}, file={entry['file']!r}) has an empty "
+                "`reason` — write down why this finding is accepted; an "
+                "acceptance with no rationale is indistinguishable from a "
+                "mistake six months later")
+
+        out.append(Acceptance(check=entry["check"], file=entry["file"],
+                              match=entry["match"], reason=entry["reason"]))
+    return tuple(out)
+
+
 def load(workspace: Path) -> Config:
     """Read campaign.toml from `workspace`. Raises ConfigError on any problem.
 
@@ -202,6 +273,11 @@ def load(workspace: Path) -> Config:
     if wiki_install_root is not None and not isinstance(wiki_install_root, str):
         raise ConfigError(f"{path}: wiki.install_root must be a string")
 
+    review_section = raw.get("review", {})
+    if not isinstance(review_section, dict):
+        raise ConfigError(f"{path}: [review] must be a table")
+    accepted = _accepted(review_section, path)
+
     entity_dirs = _str_tuple(ws, "entity_dirs")
     inherit_dirs = _str_tuple(ws, "inherit_dirs")
     # iter_content_files walks entity_dirs and then inherit_dirs, so a
@@ -234,6 +310,7 @@ def load(workspace: Path) -> Config:
         type_dirs=_type_dirs(ws),
         wiki_url=wiki_url,
         wiki_install_root=wiki_install_root,
+        accepted=accepted,
     )
 
 

--- a/src/bunnyforge/review.py
+++ b/src/bunnyforge/review.py
@@ -42,10 +42,22 @@ from bunnyforge._common import (
 )
 from bunnyforge import _dokuwiki_install as dwi
 from bunnyforge._dokuwiki_install import InstallError
-from bunnyforge._config import ConfigError, Workspace, resolve_workspace
+from bunnyforge._config import Acceptance, ConfigError, Workspace, resolve_workspace
 from bunnyforge._workspace import WorkspaceError
 
 Finding = namedtuple("Finding", "severity check file message")
+
+# One accepted finding, ready for a report: the finding itself, the reason
+# recorded for it in campaign.toml, and how many findings this run the
+# accepting Acceptance matched in total (so an over-broad `match` — one
+# substring that turns out to cover several distinct findings — is visible
+# rather than silently swallowing more than the operator intended).
+AcceptedEntry = namedtuple("AcceptedEntry", "finding reason match_count")
+
+# The check name a stale acceptance (one that matched nothing this run) is
+# reported under. Not a real check — no CHECKS entry, no SUITES membership —
+# so it is never run, only ever surfaced as a synthetic warning.
+STALE_ACCEPTANCE_CHECK = "review-accepted"
 
 
 def _rel(path: Path, workspace: Path) -> str:
@@ -56,12 +68,19 @@ VALID_CANON = {"canon", "draft", "speculative", "perception"}
 VALID_VISIBILITY = {"gm-only", "player-visible", "mixed"}
 
 
-def write_html(suite: str, findings: list[Finding], workspace: Path) -> Path:
+def write_html(suite: str, findings: list[Finding], workspace: Path,
+              accepted: list[AcceptedEntry] = ()) -> Path:
     """Write Reviews/<suite>.html under `workspace` and return its path.
 
     Takes the root rather than a whole Workspace, matching the convention the
     checks below follow: each takes exactly what it needs, and this needs no
     config.
+
+    `findings` is what the caller has already excluded accepted findings
+    from (apply_acceptances' `remaining`, plus any stale-acceptance
+    warnings); `accepted` is listed in its own section below, each with the
+    reason recorded for it, so an accepted finding stays visible rather than
+    vanishing outright.
     """
     def esc(s: str) -> str:
         return html.escape(s)
@@ -79,6 +98,13 @@ def write_html(suite: str, findings: list[Finding], workspace: Path) -> Path:
         f"<tr><td>{esc(f.file)}</td><td>{esc(f.message)}</td></tr>"
         for f in sorted(audit, key=lambda x: x.file)
     ) or "<tr><td colspan='2'>No entity files.</td></tr>"
+
+    accepted_rows = "\n".join(
+        f"<tr><td>{esc(e.finding.check)}</td><td>{esc(e.finding.file)}</td>"
+        f"<td>{esc(e.finding.message)}</td><td>{esc(e.reason)}</td>"
+        f"<td>{e.match_count}</td></tr>"
+        for e in sorted(accepted, key=lambda e: (e.finding.check, e.finding.file))
+    ) or "<tr><td colspan='5'>No accepted findings.</td></tr>"
 
     doc = f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -99,6 +125,10 @@ def write_html(suite: str, findings: list[Finding], workspace: Path) -> Path:
 <h2>Visibility audit</h2>
 <table><tr><th>file</th><th>audience</th></tr>
 {audit_rows}
+</table>
+<h2>Accepted</h2>
+<table><tr><th>check</th><th>file</th><th>message</th><th>reason</th><th>matches</th></tr>
+{accepted_rows}
 </table>
 </body></html>
 """
@@ -444,7 +474,63 @@ def run_suite(suite: str, ws: Workspace,
     return findings
 
 
-def format_terminal(findings: list[Finding], suite: str) -> str:
+def apply_acceptances(
+    findings: list[Finding], acceptances: tuple[Acceptance, ...], suite: str
+) -> tuple[list[Finding], list[AcceptedEntry], list[Finding]]:
+    """Partition `findings` against `acceptances`, honouring only the
+    acceptances that apply to `suite`.
+
+    A finding is accepted when `check` equals the finding's check, `file`
+    equals the finding's file, and `match` is a substring of the finding's
+    message (substring rather than an exact match: an improved message
+    wording must not silently un-accept a judgement). The first matching
+    acceptance wins for a given finding.
+
+    Only acceptances whose `check` actually runs as part of `suite` are
+    considered — an acceptance recorded for a check that belongs to a
+    different suite (e.g. a wiki-acl acceptance while running `checkup`)
+    is neither matched nor reported stale, since staleness only means
+    something for a check that ran this time.
+
+    Returns (remaining, accepted, stale):
+      - remaining: findings no acceptance matched — still reported, still
+        drive the exit code.
+      - accepted: one AcceptedEntry per matched finding, excluded from the
+        exit code and from per-check counts, but never dropped outright.
+      - stale: one warn-severity Finding (check STALE_ACCEPTANCE_CHECK) per
+        acceptance that matched nothing this run — the config may have
+        changed since the judgement was recorded. Warn severity so a stale
+        acceptance surfaces without reddening the run.
+    """
+    relevant = tuple(a for a in acceptances if a.check in SUITES.get(suite, []))
+    match_counts = {a: 0 for a in relevant}
+    pairs: list[tuple[Finding, Acceptance]] = []
+    remaining: list[Finding] = []
+
+    for f in findings:
+        hit = next((a for a in relevant
+                   if a.check == f.check and a.file == f.file and a.match in f.message),
+                  None)
+        if hit is None:
+            remaining.append(f)
+        else:
+            match_counts[hit] += 1
+            pairs.append((f, hit))
+
+    accepted = [AcceptedEntry(f, a.reason, match_counts[a]) for f, a in pairs]
+    stale = [
+        Finding("warn", STALE_ACCEPTANCE_CHECK, a.file,
+                f"accepted entry for check '{a.check}' matching {a.match!r} "
+                f"did not match any finding this run — the config may have "
+                f"changed since this was accepted (reason on file: "
+                f"{a.reason})")
+        for a in relevant if match_counts[a] == 0
+    ]
+    return remaining, accepted, stale
+
+
+def format_terminal(findings: list[Finding], suite: str,
+                    accepted: list[AcceptedEntry] = ()) -> str:
     lines: list[str] = []
 
     audit = [f for f in findings if f.check == "visibility-audit"]
@@ -462,11 +548,29 @@ def format_terminal(findings: list[Finding], suite: str) -> str:
 
     issues = [f for f in findings if f.check != "visibility-audit"]
     marks = {"error": "✗", "warn": "!", "info": "·"}
-    for name in [n for n in SUITES.get(suite, []) if n != "visibility-audit"]:
+    check_names = [n for n in SUITES.get(suite, []) if n != "visibility-audit"]
+    # STALE_ACCEPTANCE_CHECK is universal, not tied to any suite's own check
+    # list (see apply_acceptances), so it only earns a block when this run
+    # actually produced one — unlike the suite's own checks, which always
+    # print a "(0 finding(s))" header even when clean.
+    if STALE_ACCEPTANCE_CHECK not in check_names and \
+            any(f.check == STALE_ACCEPTANCE_CHECK for f in issues):
+        check_names.append(STALE_ACCEPTANCE_CHECK)
+    for name in check_names:
         block = [f for f in issues if f.check == name]
         lines.append(f"{name}  ({len(block)} finding(s))")
         for f in sorted(block, key=lambda x: (x.severity, x.file)):
             lines.append(f"  {marks.get(f.severity, '·')} {f.file}: {f.message}")
+        lines.append("")
+
+    if accepted:
+        lines.append(f"Accepted ({len(accepted)} finding(s))")
+        for entry in sorted(accepted, key=lambda e: (e.finding.check, e.finding.file)):
+            f = entry.finding
+            over_broad = (f"  [{entry.match_count} findings match this "
+                         f"acceptance]" if entry.match_count > 1 else "")
+            lines.append(f"  ✓ {f.check}  {f.file}: {f.message}{over_broad}")
+            lines.append(f"      reason: {entry.reason}")
         lines.append("")
 
     errs = sum(1 for f in findings if f.severity == "error")
@@ -525,13 +629,17 @@ def main(argv: list[str] | None = None) -> int:
     except InstallError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    print(format_terminal(findings, args.suite))
+
+    remaining, accepted, stale = apply_acceptances(
+        findings, ws.config.accepted, args.suite)
+    display = remaining + stale
+    print(format_terminal(display, args.suite, accepted))
 
     if args.html:
-        dest = write_html(args.suite, findings, ws.root)
+        dest = write_html(args.suite, display, ws.root, accepted)
         print(f"\nHTML report: {dest.relative_to(ws.root)}")
 
-    return 1 if any(f.severity == "error" for f in findings) else 0
+    return 1 if any(f.severity == "error" for f in display) else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -436,6 +436,94 @@ class TestWikiConfig(unittest.TestCase):
             self._load('wiki = "x"\n[campaign]\nnamespace = "test"\n')
 
 
+class TestAcceptedConfig(unittest.TestCase):
+    """[[review.accepted]] — accepting a specific finding, never a whole
+    check. See src/bunnyforge/review.py for how these are applied."""
+
+    def _load(self, toml_text):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "campaign.toml").write_text(toml_text, encoding="utf-8")
+            return _config.load(root)
+
+    def test_accepted_table_absent_is_empty_tuple(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n')
+        self.assertEqual(cfg.accepted, ())
+
+    def test_accepted_entry_parsed(self):
+        cfg = self._load(
+            '[campaign]\nnamespace = "test"\n'
+            '[[review.accepted]]\n'
+            'check  = "wiki-acl"\n'
+            'file   = "conf/acl.auth.php"\n'
+            'match  = "<ns>:* grants to a group"\n'
+            'reason = "Intentional: a small trusted set."\n')
+        self.assertEqual(len(cfg.accepted), 1)
+        entry = cfg.accepted[0]
+        self.assertEqual(entry.check, "wiki-acl")
+        self.assertEqual(entry.file, "conf/acl.auth.php")
+        self.assertEqual(entry.match, "<ns>:* grants to a group")
+        self.assertEqual(entry.reason, "Intentional: a small trusted set.")
+
+    def test_multiple_accepted_entries_parsed_in_order(self):
+        cfg = self._load(
+            '[campaign]\nnamespace = "test"\n'
+            '[[review.accepted]]\n'
+            'check = "a"\nfile = "f1"\nmatch = "m1"\nreason = "r1"\n'
+            '[[review.accepted]]\n'
+            'check = "b"\nfile = "f2"\nmatch = "m2"\nreason = "r2"\n')
+        self.assertEqual([a.check for a in cfg.accepted], ["a", "b"])
+
+    def test_missing_reason_refused_instructionally(self):
+        with self.assertRaises(_config.ConfigError) as ctx:
+            self._load(
+                '[campaign]\nnamespace = "test"\n'
+                '[[review.accepted]]\n'
+                'check = "wiki-acl"\nfile = "conf/acl.auth.php"\n'
+                'match = "grants to a group"\n')
+        msg = str(ctx.exception)
+        self.assertIn("reason", msg)
+        self.assertIn("wiki-acl", msg)  # names the offending entry
+
+    def test_empty_reason_refused_instructionally(self):
+        with self.assertRaises(_config.ConfigError) as ctx:
+            self._load(
+                '[campaign]\nnamespace = "test"\n'
+                '[[review.accepted]]\n'
+                'check = "wiki-acl"\nfile = "conf/acl.auth.php"\n'
+                'match = "grants to a group"\nreason = "   "\n')
+        msg = str(ctx.exception)
+        self.assertIn("reason", msg)
+
+    def test_missing_match_refused(self):
+        with self.assertRaises(_config.ConfigError) as ctx:
+            self._load(
+                '[campaign]\nnamespace = "test"\n'
+                '[[review.accepted]]\n'
+                'check = "wiki-acl"\nfile = "conf/acl.auth.php"\n'
+                'reason = "because"\n')
+        self.assertIn("match", str(ctx.exception))
+
+    def test_entry_must_be_a_table(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load(
+                '[campaign]\nnamespace = "test"\n'
+                '[review]\naccepted = ["not-a-table"]\n')
+
+    def test_accepted_non_list_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load(
+                '[campaign]\nnamespace = "test"\n'
+                '[review]\naccepted = "x"\n')
+
+    def test_review_non_table_refused(self):
+        # Same TOML-scoping trap noted for [wiki]/[names]: a bare key before
+        # any table header would otherwise be swallowed into a preceding
+        # table rather than staying a top-level `review` key.
+        with self.assertRaises(_config.ConfigError):
+            self._load('review = "x"\n[campaign]\nnamespace = "test"\n')
+
+
 class TestWikiToken(unittest.TestCase):
     def _token_file(self, root: Path, text, mode=0o600):
         path = root / ".bunnyforge" / "wiki-token"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -894,3 +894,218 @@ class TestWikiSuiteWiring(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertNotIn("~", err.getvalue())
             self.assertIn(expected, err.getvalue())
+
+
+class TestApplyAcceptances(unittest.TestCase):
+    """apply_acceptances: the mechanism that lets a workspace accept one
+    specific finding without disabling the check that produces it. See
+    issue #19 and _config.Acceptance."""
+
+    def _acc(self, check="front-matter", file="NPCs/broken.md",
+             match="missing `visibility`", reason="Intentional."):
+        return _config.Acceptance(check=check, file=file, match=match,
+                                  reason=reason)
+
+    def test_matched_finding_moves_to_accepted_not_remaining(self):
+        f = review.Finding("error", "front-matter", "NPCs/broken.md",
+                           "missing `visibility`")
+        remaining, accepted, stale = review.apply_acceptances(
+            [f], (self._acc(),), "checkup")
+        self.assertEqual(remaining, [])
+        self.assertEqual(len(accepted), 1)
+        self.assertEqual(accepted[0].finding, f)
+        self.assertEqual(accepted[0].reason, "Intentional.")
+        self.assertEqual(accepted[0].match_count, 1)
+        self.assertEqual(stale, [])
+
+    def test_different_finding_from_same_check_is_not_accepted(self):
+        # The property that makes acceptance safe: a *new* finding from the
+        # same check, at a different file or with a different message, must
+        # still report.
+        accepted_f = review.Finding("error", "front-matter", "NPCs/broken.md",
+                                    "missing `visibility`")
+        other_f = review.Finding("error", "front-matter", "NPCs/other.md",
+                                 "missing `visibility`")
+        remaining, accepted, stale = review.apply_acceptances(
+            [accepted_f, other_f], (self._acc(),), "checkup")
+        self.assertEqual(remaining, [other_f])
+        self.assertEqual([e.finding for e in accepted], [accepted_f])
+
+    def test_message_substring_match_survives_reworded_message(self):
+        # match is a substring, not the whole message, so a message that
+        # grew more detail around the accepted substring still matches.
+        f = review.Finding("error", "wiki-acl", "conf/acl.auth.php",
+                           "<ns>:* grants to a group but sets no @ALL or "
+                           "@user rule of its own — accounts outside that "
+                           "group fall through to a broader rule")
+        acc = self._acc(check="wiki-acl", file="conf/acl.auth.php",
+                        match="<ns>:* grants to a group")
+        remaining, accepted, stale = review.apply_acceptances(
+            [f], (acc,), "wiki")
+        self.assertEqual(remaining, [])
+        self.assertEqual(len(accepted), 1)
+
+    def test_acceptance_matching_several_findings_reports_the_count(self):
+        f1 = review.Finding("error", "wiki-acl", "conf/acl.auth.php",
+                            "a:* grants to a group but sets no fallthrough")
+        f2 = review.Finding("error", "wiki-acl", "conf/acl.auth.php",
+                            "b:* grants to a group but sets no fallthrough")
+        acc = self._acc(check="wiki-acl", file="conf/acl.auth.php",
+                        match="grants to a group")
+        _remaining, accepted, _stale = review.apply_acceptances(
+            [f1, f2], (acc,), "wiki")
+        self.assertEqual(len(accepted), 2)
+        self.assertTrue(all(e.match_count == 2 for e in accepted))
+
+    def test_acceptance_matching_nothing_is_reported_stale(self):
+        acc = self._acc(check="front-matter", file="NPCs/gone.md",
+                        match="no longer produced")
+        remaining, accepted, stale = review.apply_acceptances(
+            [], (acc,), "checkup")
+        self.assertEqual(remaining, [])
+        self.assertEqual(accepted, [])
+        self.assertEqual(len(stale), 1)
+        self.assertEqual(stale[0].severity, "warn")
+        self.assertEqual(stale[0].check, "review-accepted")
+        self.assertIn("front-matter", stale[0].message)
+
+    def test_stale_acceptance_does_not_redden_the_run(self):
+        # Stale findings are warn severity, and warnings never drive the
+        # exit code — a config change surfaces as a warning, not a failure.
+        acc = self._acc(match="no longer produced")
+        _remaining, _accepted, stale = review.apply_acceptances(
+            [], (acc,), "checkup")
+        self.assertTrue(stale)
+        self.assertFalse(any(f.severity == "error" for f in stale))
+
+    def test_acceptance_for_a_check_outside_this_suite_is_ignored(self):
+        # An acceptance recorded for wiki-acl must not be evaluated (and
+        # certainly not reported stale) while running `checkup`, which never
+        # runs wiki-acl at all. Otherwise every checkup run would spuriously
+        # warn about every wiki acceptance in the config.
+        acc = self._acc(check="wiki-acl", file="conf/acl.auth.php",
+                        match="grants to a group")
+        remaining, accepted, stale = review.apply_acceptances(
+            [], (acc,), "checkup")
+        self.assertEqual(remaining, [])
+        self.assertEqual(accepted, [])
+        self.assertEqual(stale, [])
+
+    def test_no_acceptances_is_a_no_op(self):
+        f = review.Finding("error", "front-matter", "NPCs/x.md", "missing `type`")
+        remaining, accepted, stale = review.apply_acceptances([f], (), "checkup")
+        self.assertEqual(remaining, [f])
+        self.assertEqual(accepted, [])
+        self.assertEqual(stale, [])
+
+
+class TestAcceptedFindingsInReports(unittest.TestCase):
+    def test_format_terminal_lists_accepted_section_with_reason(self):
+        f = review.Finding("error", "front-matter", "NPCs/broken.md",
+                           "missing `visibility`")
+        entry = review.AcceptedEntry(f, "Intentional: reviewed and fine.", 1)
+        text = review.format_terminal([], "checkup", [entry])
+        self.assertIn("Accepted", text)
+        self.assertIn("NPCs/broken.md", text)
+        self.assertIn("missing `visibility`", text)
+        self.assertIn("Intentional: reviewed and fine.", text)
+
+    def test_format_terminal_notes_an_over_broad_match(self):
+        f1 = review.Finding("error", "wiki-acl", "conf/acl.auth.php", "a:* grants")
+        f2 = review.Finding("error", "wiki-acl", "conf/acl.auth.php", "b:* grants")
+        entries = [review.AcceptedEntry(f1, "r", 2),
+                   review.AcceptedEntry(f2, "r", 2)]
+        text = review.format_terminal([], "wiki", entries)
+        self.assertIn("2", text)
+
+    def test_format_terminal_excludes_accepted_from_summary_counts(self):
+        f = review.Finding("error", "front-matter", "NPCs/broken.md",
+                           "missing `visibility`")
+        entry = review.AcceptedEntry(f, "Intentional.", 1)
+        # `findings` passed to format_terminal is what a caller already
+        # excluded the accepted finding from (apply_acceptances' `remaining`
+        # plus any stale warnings) — so a clean remainder must summarise 0
+        # errors even though one finding is shown in the Accepted section.
+        text = review.format_terminal([], "checkup", [entry])
+        self.assertIn("Summary: 0 error(s)", text)
+
+    def test_write_html_includes_accepted_section(self):
+        f = review.Finding("error", "front-matter", "NPCs/broken.md",
+                           "missing `visibility`")
+        entry = review.AcceptedEntry(f, "Intentional: reviewed and fine.", 1)
+        with tempfile.TemporaryDirectory() as d:
+            dest = review.write_html("checkup", [], Path(d), [entry])
+            html_text = dest.read_text(encoding="utf-8")
+            self.assertIn("NPCs/broken.md", html_text)
+            self.assertIn("Intentional: reviewed and fine.", html_text)
+
+
+class TestAcceptedFindingsEndToEnd(unittest.TestCase):
+    """main() wired end-to-end: campaign.toml's [[review.accepted]] actually
+    changes what a run reports and exits with."""
+
+    def test_accepted_finding_excluded_from_exit_code_but_still_visible(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_workspace(Path(d), {
+                "campaign.toml": (
+                    '[campaign]\nnamespace = "test"\n'
+                    '[[review.accepted]]\n'
+                    'check  = "front-matter"\n'
+                    'file   = "NPCs/broken.md"\n'
+                    'match  = "missing `visibility`"\n'
+                    'reason = "Intentional: reviewed and fine."\n'),
+                "NPCs/broken.md":
+                    "---\ntype: npc\ncanon: draft\nsummary: No vis.\n---\nx",
+            })
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["checkup", "--workspace", str(root)])
+            self.assertEqual(rc, 0, err.getvalue())
+            printed = out.getvalue()
+            self.assertIn("NPCs/broken.md", printed)
+            self.assertIn("Intentional: reviewed and fine.", printed)
+            self.assertIn("Accepted", printed)
+
+    def test_a_different_finding_from_the_same_check_still_fails_the_run(self):
+        # The safety property: accepting one finding must not silence a new
+        # one from the same check.
+        with tempfile.TemporaryDirectory() as d:
+            root = make_workspace(Path(d), {
+                "campaign.toml": (
+                    '[campaign]\nnamespace = "test"\n'
+                    '[[review.accepted]]\n'
+                    'check  = "front-matter"\n'
+                    'file   = "NPCs/broken.md"\n'
+                    'match  = "missing `visibility`"\n'
+                    'reason = "Intentional: reviewed and fine."\n'),
+                "NPCs/broken.md":
+                    "---\ntype: npc\ncanon: draft\nsummary: No vis.\n---\nx",
+                "NPCs/other-broken.md":
+                    "---\ntype: npc\ncanon: draft\nsummary: Also no vis.\n---\nx",
+            })
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["checkup", "--workspace", str(root)])
+            self.assertEqual(rc, 1)
+            self.assertIn("NPCs/other-broken.md", out.getvalue())
+
+    def test_stale_acceptance_surfaces_but_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_workspace(Path(d), {
+                "campaign.toml": (
+                    '[campaign]\nnamespace = "test"\n'
+                    '[[review.accepted]]\n'
+                    'check  = "front-matter"\n'
+                    'file   = "NPCs/gone.md"\n'
+                    'match  = "no longer produced"\n'
+                    'reason = "Was accepted; the file has since been fixed."\n'),
+                "NPCs/good.md":
+                    "---\ntype: npc\ncanon: draft\nvisibility: player-visible\n"
+                    "summary: Good.\n---\nx",
+            })
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["checkup", "--workspace", str(root)])
+            self.assertEqual(rc, 0, err.getvalue())
+            self.assertIn("review-accepted", out.getvalue())
+            self.assertIn("NPCs/gone.md", out.getvalue())


### PR DESCRIPTION
Closes #19.

## Files changed

- `src/bunnyforge/_config.py` (modified) — parse `[[review.accepted]]`, new `Acceptance` namedtuple
- `src/bunnyforge/review.py` (modified) — apply acceptances; report them; adjust the exit code
- `src/bunnyforge/README.md` (modified) — document the mechanism
- `tests/test_config.py`, `tests/test_review.py` (modified) — covering tests

## Work breakdown

A check that reports a finding the operator has already judged and accepted
reports it forever, the suite exits non-zero every run, and the operator learns
to ignore the summary — at which point the next real finding is lost in the
noise. This already bites: a live install produced three `wiki-acl` findings
that were correct readings of the config and all deliberate, with nowhere to
record that judgement.

```toml
[[review.accepted]]
check  = "wiki-acl"
file   = "conf/acl.auth.php"
match  = "<ns>:* grants to a group"
reason = "Intentional: account creation is restricted, so any logged-in account is a small trusted set."
```

**It accepts a specific finding; it never disables a check.** Silencing
`wiki-acl` wholesale would hide the next namespace that gets it wrong. Matching
is `check` and `file` exact, `match` as a substring of the message — substring
so that improved wording does not silently un-accept a judgement.

Decisions taken on the open questions in #19:

- **`reason` is required**, refused at parse time. An acceptance with no
  rationale is indistinguishable from a mistake six months later.
- **Accepted findings do not vanish.** They are excluded from the exit code and
  the per-check counts, but listed in their own section with their reasons, so a
  decision that has quietly gone stale stays visible.
- **A stale acceptance surfaces** as a `warn` under a `review-accepted` check —
  it means the config changed and the judgement may not apply. Warnings do not
  drive the exit code, so it never reddens a run.
- **Over-broad matches are visible**: an acceptance covering several findings
  says so (`[N findings match this acceptance]`).
- **Applies to every suite.** One mechanism is easier to explain than two.

## Test expectations

All green — **548 → 572 tests**, portability passes.

Verified against a real wiki config, not just fixtures:

| property | result |
|---|---|
| accepted finding excluded from exit code, still visible with reason | pass |
| a *different* finding from the same check still errors and exits 1 | pass |
| all findings accepted → exit 0 | pass |
| stale acceptance warns, does not redden the run | pass |
| missing `reason` refused instructionally at parse time | pass |
| over-broad `match` reports how many findings it covered | pass |

The second row is the property that makes the feature safe and has its own test.

## Operational impact

None unless used — absent `[[review.accepted]]`, behaviour is unchanged.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: Opus 5 driving a Sonnet 5 implementer
