### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.2.1"
+version = "0.3.0"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump only — one line in `pyproject.toml`.

## Files changed

- `pyproject.toml` (modified) — `0.2.1` → `0.3.0`

## Work breakdown

Releases the accepted-findings mechanism (#19 / #20): a workspace can record in
`campaign.toml` that a specific review finding has been considered and accepted,
so the suite stops reporting it and stops exiting non-zero for it — while a
**new** finding from the same check still reports and still fails.

## Why 0.3.0 rather than 0.2.2

`install_root` took a patch bump because it was additive *configuration* with no
behaviour change: a second way to supply a value the CLI already accepted.

This is a functionality line, which is what 0.3.0 was reserved for. It adds a
new config table (`[[review.accepted]]`), a new section to the terminal and HTML
reports, a new `review-accepted` check that surfaces stale acceptances, and it
changes how the exit code is computed when acceptances are in play.

Absent config, behaviour is unchanged — so this is still backward-compatible,
and MINOR rather than MAJOR is the right level.

**If you would rather this were 0.2.2, say so and I will retag before
publishing** — nothing is tagged yet, and PyPI never lets a version number be
reused, so this is the last cheap moment to change it.

## Test expectations

None — no code changed. `main` is green at 572 tests.

## Operational impact

After merge: tag `v0.3.0` and push, which triggers `publish.yml`. CI refuses a
tag disagreeing with `pyproject.toml`, which is why the bump is its own step.

Then the campaign pin can move — and **wait for PyPI's index to serve the new
version to a fresh resolver before merging that pin bump.** Doing it three
minutes after publishing is what reddened `main` on `51cf890`; the campaign CI
now retries, but the underlying lag is still real.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: Opus 5
