### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump only — one line in `pyproject.toml`. Replaces #21, which proposed
0.3.0; closed rather than force-pushed so the merge commit does not record a
`release-0.3.0` branch against a 0.2.2 release.

## Files changed

- `pyproject.toml` (modified) — `0.2.1` → `0.2.2`

## Work breakdown

Releases the accepted-findings mechanism (#19 / #20): a workspace can record in
`campaign.toml` that a specific review finding has been considered and accepted,
so the suite stops reporting it and stops exiting non-zero for it — while a
**new** finding from the same check still reports and still fails.

A patch bump: absent `[[review.accepted]]`, behaviour is unchanged, so from any
existing workspace's point of view this is purely additive. 0.3.0 stays reserved
to mark a new line of functionality.

## Test expectations

None — no code changed. `main` is green at 572 tests.

## Operational impact

After merge: tag `v0.2.2` and push, which triggers `publish.yml`. CI refuses a
tag disagreeing with `pyproject.toml`, which is why the bump is its own step.

The campaign pin can follow — and **wait for PyPI's index to serve the new
version to a fresh resolver before merging that bump.** Merging it three minutes
after publishing is what reddened campaign `main` on `51cf890`. The campaign CI
now retries, but not creating the condition beats riding it out.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: Opus 5
