### PR TITLE
review wiki: warn on a stale snapshot, add --fetch-latest (#23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.2.2"
+version = "0.2.3"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -639,3 +639,81 @@ disagreeing, which is worse than not checking; the alternative is shelling out
 to DokuWiki's `auth_aclcheck`, which needs PHP and a real install rather than a
 readable copy. The universal denial rule above catches the same class of defect
 without either cost.
+
+### Is the snapshot fresh? (`wiki-snapshot`)
+
+The suite above checks a **copy**, and nothing connects that copy to the wiki
+it came from. A stale copy checks last month's configuration and reports
+nothing wrong — the most dangerous kind of pass, because it looks identical to
+a genuinely clean run.
+
+**And the copy cannot date itself.** `rsync -a` preserves the remote's
+mtimes, so every timestamp inside it — files and directories alike —
+describes the *wiki's* history, not the copy's. A snapshot pulled ten minutes
+ago and one pulled in March read identically by their own file times.
+
+The `wiki-snapshot` check instead reads a marker the fetch script writes at
+the snapshot root: `<install_root>/.bunnyforge-snapshot-fetched-at`, an
+ISO-8601 UTC timestamp (`date -u +"%Y-%m-%dT%H:%M:%SZ"`, e.g.
+`2026-08-06T00:21:01Z`). Every finding it produces is `warn`, never `error` —
+the point is to stop a stale pass from looking clean, not to redden a run:
+
+- **Marker absent** — a copy obtained by hand, a mount, an unpacked backup —
+  warns that the snapshot's age is unknown, honestly rather than
+  accusingly: absence is a legitimate way to get a copy.
+- **Marker present but older than the threshold** warns, naming the age in
+  days and the threshold.
+- **Marker malformed or unparseable** warns saying so.
+- **Marker present and fresh** produces no finding.
+
+A stale or unknown-age snapshot never changes the exit code by itself — only
+an `error`-severity finding does that, and this check never produces one. The
+threshold defaults to 30 days and is configurable:
+
+```toml
+[wiki]
+snapshot_max_age_days = 14
+```
+
+Must be a positive integer; refused instructionally otherwise (a wrong type,
+or a value ≤ 0, at `campaign.toml` parse time).
+
+### Refreshing the snapshot (`--fetch-latest`)
+
+    python3 -m bunnyforge.review wiki --fetch-latest
+
+Two commands where one would do is exactly how a stale snapshot happens:
+forgetting to refresh the copy before reviewing. `--fetch-latest` runs a
+**configured command** and refuses to review if it fails:
+
+```toml
+[wiki]
+fetch_command = "./scripts/fetch-wiki-snapshot.sh"
+```
+
+**bunnyforge never learns what ssh is.** It runs whatever the operator
+configured, waits, and checks the exit status — rsync, scp, sftp, a mount
+refresh, anything. That keeps the tool transport-agnostic, and keeps it
+useful to someone on a hosted wiki with no shell access, who simply does not
+set `fetch_command` and does not pass the flag.
+
+Mechanically: the command is split with `shlex.split` and run with
+`shell=False` — never a shell — from the **workspace root**, so a relative
+path like `./scripts/...` resolves the way the operator wrote it. Its
+stdout and stderr are always printed: the whole point of this flag is that
+the fetch owns its own self-labelled error messages, so swallowing them would
+defeat it. A non-zero exit means the review is refused (a non-zero exit,
+`--html` not written, the suite never runs) with a message making clear the
+*fetch* failed, not a check — exactly what `fetch && review` does in a shell,
+and equally clear about which half failed.
+
+`--fetch-latest` with no `fetch_command` configured is refused
+instructionally, naming the key and the TOML shape, before anything runs.
+It is also refused on a suite that does not use a wiki root (`checkup`) —
+there being nothing there for it to refresh.
+
+**This is a code-execution surface.** `fetch_command` is a shell command
+`campaign.toml` names and `review.py` executes. It is the operator's own
+file, at the same trust level as a `Makefile` or an `npm` script — not
+sandboxed, not vetted — and should be treated that way rather than
+discovered.

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -36,12 +36,16 @@ Config = namedtuple(
     "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
     "exclude_dirs names_cultures names_official_culture names_spelling "
     "briefs_dir sheets_dir perceptions_dir type_dirs wiki_url "
-    "wiki_install_root accepted",
+    "wiki_install_root accepted snapshot_max_age_days fetch_command",
     # wiki_url and wiki_install_root: [wiki] is entirely optional, so a
     # workspace using neither RPC nor the `wiki` review suite leaves both
     # None. accepted: [[review.accepted]] is likewise optional, so a
     # workspace with no recorded acceptances gets an empty tuple.
-    defaults=[None, None, ()])
+    # snapshot_max_age_days: the wiki-snapshot review check's staleness
+    # threshold, in days; 30 unless overridden. fetch_command: the shell
+    # command `review --fetch-latest` runs to refresh the snapshot before
+    # reviewing; None means the flag is refused (see review.py).
+    defaults=[None, None, (), 30, None])
 
 # An accepted review finding, recorded in campaign.toml as
 # [[review.accepted]]. See review.py's apply_acceptances for how these are
@@ -272,6 +276,21 @@ def load(workspace: Path) -> Config:
     wiki_install_root = wiki.get("install_root")
     if wiki_install_root is not None and not isinstance(wiki_install_root, str):
         raise ConfigError(f"{path}: wiki.install_root must be a string")
+    fetch_command = wiki.get("fetch_command")
+    if fetch_command is not None and not isinstance(fetch_command, str):
+        raise ConfigError(f"{path}: wiki.fetch_command must be a string")
+    snapshot_max_age_days = wiki.get("snapshot_max_age_days", 30)
+    # bool is an int subclass in Python, so isinstance(True, int) is True;
+    # excluded explicitly or `snapshot_max_age_days = true` would silently
+    # parse as 1.
+    if isinstance(snapshot_max_age_days, bool) or \
+            not isinstance(snapshot_max_age_days, int):
+        raise ConfigError(
+            f"{path}: wiki.snapshot_max_age_days must be an integer")
+    if snapshot_max_age_days <= 0:
+        raise ConfigError(
+            f"{path}: wiki.snapshot_max_age_days must be a positive "
+            f"integer, got {snapshot_max_age_days}")
 
     review_section = raw.get("review", {})
     if not isinstance(review_section, dict):
@@ -311,6 +330,8 @@ def load(workspace: Path) -> Config:
         wiki_url=wiki_url,
         wiki_install_root=wiki_install_root,
         accepted=accepted,
+        snapshot_max_age_days=snapshot_max_age_days,
+        fetch_command=fetch_command,
     )
 
 

--- a/src/bunnyforge/review.py
+++ b/src/bunnyforge/review.py
@@ -21,8 +21,10 @@ from __future__ import annotations
 import argparse
 import html
 import re
+import shlex
 import sys
 from collections import namedtuple
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Imported as a module as well as by name: tests reach through
@@ -426,6 +428,63 @@ def check_wiki_remote(files: list[FileRec], wiki_root: Path) -> list[Finding]:
     return out
 
 
+# The marker a campaign-side fetch script writes at the snapshot root: an
+# ISO-8601 UTC timestamp (e.g. "2026-08-06T00:21:01Z") recording when the
+# snapshot itself was pulled. Nothing else in a snapshot can answer that
+# question: `rsync -a` preserves the remote's mtimes, so every timestamp
+# *inside* the copy — files and directories alike — describes the wiki's
+# history, not the copy's (verified on a real snapshot: conf/local.php reads
+# the same mtime locally and remotely).
+_SNAPSHOT_MARKER = ".bunnyforge-snapshot-fetched-at"
+
+_DEFAULT_SNAPSHOT_MAX_AGE_DAYS = 30
+
+
+def check_wiki_snapshot(files: list[FileRec], wiki_root: Path,
+                        max_age_days: int = _DEFAULT_SNAPSHOT_MAX_AGE_DAYS
+                        ) -> list[Finding]:
+    """Warn when the local wiki snapshot's age is unknown or stale.
+
+    A stale copy checks last month's configuration and reports nothing
+    wrong — the most dangerous kind of pass, indistinguishable from a
+    genuinely clean run. Every finding here is `warn`, never `error`: the
+    point is to stop that silent pass, not to redden a run over something
+    that may be entirely legitimate (a copy obtained by hand, a mount, an
+    unpacked backup) or merely a few days past a conservative default.
+    """
+    marker = wiki_root / _SNAPSHOT_MARKER
+    if not marker.is_file():
+        return [Finding(
+            "warn", "wiki-snapshot", _SNAPSHOT_MARKER,
+            f"snapshot age unknown (no {_SNAPSHOT_MARKER}) — if this copy is "
+            f"old, these findings describe an old configuration")]
+
+    raw = marker.read_text(encoding="utf-8").strip()
+    try:
+        fetched_at = datetime.fromisoformat(raw)
+    except ValueError:
+        return [Finding(
+            "warn", "wiki-snapshot", _SNAPSHOT_MARKER,
+            f"{_SNAPSHOT_MARKER} is malformed ({raw!r}) — expected an "
+            f"ISO-8601 UTC timestamp like 2026-08-06T00:21:01Z")]
+    if fetched_at.tzinfo is None:
+        # A naive timestamp can't be compared against datetime.now(utc); the
+        # marker is documented as UTC, so treat a missing offset as that
+        # rather than refusing outright.
+        fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+
+    age = datetime.now(timezone.utc) - fetched_at
+    if age > timedelta(days=max_age_days):
+        age_days = age.total_seconds() / 86400
+        return [Finding(
+            "warn", "wiki-snapshot", _SNAPSHOT_MARKER,
+            f"snapshot is {age_days:.1f} day(s) old (threshold: "
+            f"{max_age_days} day(s)) — these findings may describe an old "
+            f"configuration; refresh the copy, e.g. with "
+            f"--fetch-latest")]
+    return []
+
+
 CHECKS = {
     "visibility-audit": check_visibility_audit,
     "front-matter": check_front_matter,
@@ -436,6 +495,7 @@ CHECKS = {
     "wiki-acl": check_wiki_acl,
     "wiki-plugins": check_wiki_plugins,
     "wiki-remote": check_wiki_remote,
+    "wiki-snapshot": check_wiki_snapshot,
 }
 
 SUITES = {
@@ -444,7 +504,8 @@ SUITES = {
     # Deliberately not part of checkup: it needs a live install, which CI does
     # not have. Keeping it a separate suite is the whole skippability
     # mechanism — checkup never reaches off the local machine.
-    "wiki": ["wiki-conf", "wiki-acl", "wiki-plugins", "wiki-remote"],
+    "wiki": ["wiki-conf", "wiki-acl", "wiki-plugins", "wiki-remote",
+             "wiki-snapshot"],
 }
 
 # Checks that need the full Workspace (its config), rather than just the
@@ -453,7 +514,8 @@ SUITES = {
 _NEEDS_WORKSPACE = frozenset({"wikilinks", "compendium"})
 # Checks taking a DokuWiki install root instead of anything from the
 # workspace — a third argument shape, alongside Workspace and workspace root.
-_NEEDS_WIKI = frozenset({"wiki-conf", "wiki-acl", "wiki-plugins", "wiki-remote"})
+_NEEDS_WIKI = frozenset({"wiki-conf", "wiki-acl", "wiki-plugins",
+                         "wiki-remote", "wiki-snapshot"})
 
 
 def run_suite(suite: str, ws: Workspace,
@@ -470,7 +532,15 @@ def run_suite(suite: str, ws: Workspace,
             arg = ws
         else:
             arg = ws.root
-        findings.extend(CHECKS[name](files, arg))
+        # wiki-snapshot is the one _NEEDS_WIKI check that also needs a value
+        # from campaign.toml (the staleness threshold), which the other
+        # wiki_root-only checks have no use for — special-cased here rather
+        # than widening every wiki check's signature for one check's sake.
+        if name == "wiki-snapshot":
+            findings.extend(
+                CHECKS[name](files, arg, ws.config.snapshot_max_age_days))
+        else:
+            findings.extend(CHECKS[name](files, arg))
     return findings
 
 
@@ -579,7 +649,37 @@ def format_terminal(findings: list[Finding], suite: str,
     return "\n".join(lines)
 
 
-def main(argv: list[str] | None = None) -> int:
+def run_fetch_command(command: str, cwd: Path, runner=None) -> int:
+    """Run the configured `[wiki] fetch_command`, print its stdout/stderr,
+    and return its exit status.
+
+    Split with shlex, run with shell=False: an operator needing pipes or
+    redirection can wrap them in a script, which is a better trade than
+    handing a config file a shell. `runner` defaults to subprocess.run;
+    tests inject a fake so nothing in this suite ever spawns a real process.
+
+    stdout/stderr are captured rather than inherited so they can be printed
+    deterministically — the whole argument for --fetch-latest is that the
+    fetch owns its own self-labelled error messages, so swallowing them
+    would defeat the point.
+    """
+    if runner is None:
+        import subprocess
+        runner = subprocess.run
+    argv = shlex.split(command)
+    result = runner(argv, cwd=cwd, capture_output=True, text=True)
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+        if not result.stdout.endswith("\n"):
+            sys.stdout.write("\n")
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+        if not result.stderr.endswith("\n"):
+            sys.stderr.write("\n")
+    return result.returncode
+
+
+def main(argv: list[str] | None = None, *, fetch_runner=None) -> int:
     parser = argparse.ArgumentParser(
         prog="bunnyforge review", description="Run a named workspace review suite.")
     parser.add_argument("suite", nargs="?", default="checkup",
@@ -595,10 +695,22 @@ def main(argv: list[str] | None = None) -> int:
         help="DokuWiki installation root (the directory holding conf/ and "
              "lib/). Required by the 'wiki' suite (or set [wiki] "
              "install_root in campaign.toml); ignored by every other.")
+    parser.add_argument(
+        "--fetch-latest", action="store_true",
+        help="Run [wiki] fetch_command to refresh the local snapshot before "
+             "reviewing, and refuse to review if it fails. Only meaningful "
+             "for a suite that needs a wiki root (e.g. 'wiki').")
     args = parser.parse_args(argv)
 
     if args.suite not in SUITES:
         parser.error(f"unknown suite: {args.suite}. Known: {', '.join(SUITES)}")
+
+    suite_needs_wiki = any(name in _NEEDS_WIKI for name in SUITES[args.suite])
+    if args.fetch_latest and not suite_needs_wiki:
+        print(f"error: --fetch-latest only makes sense for a suite that "
+              f"needs a wiki root (e.g. 'wiki'); '{args.suite}' does not "
+              f"use one", file=sys.stderr)
+        return 1
 
     try:
         ws = resolve_workspace(args.workspace)
@@ -606,12 +718,29 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
+    if args.fetch_latest:
+        fetch_command = ws.config.fetch_command
+        if not fetch_command:
+            print(f"error: --fetch-latest needs [wiki] fetch_command set in "
+                  f"campaign.toml, e.g.:\n"
+                  f"  [wiki]\n"
+                  f'  fetch_command = "./scripts/fetch-wiki-snapshot.sh"',
+                  file=sys.stderr)
+            return 1
+        rc = run_fetch_command(fetch_command, ws.root, runner=fetch_runner)
+        if rc != 0:
+            print(f"error: --fetch-latest's fetch_command "
+                  f"({fetch_command!r}) exited {rc} — review refused; see "
+                  f"its output above for why the fetch itself failed",
+                  file=sys.stderr)
+            return 1
+
     # Required conditionally rather than globally: making a wiki root
     # mandatory would break checkup, which never touches a wiki. Resolved
     # after the workspace, not before, since the configured fallback lives
     # in that workspace's campaign.toml — --wiki-root still wins when given.
     wiki_root = None
-    if any(name in _NEEDS_WIKI for name in SUITES[args.suite]):
+    if suite_needs_wiki:
         configured = ws.config.wiki_install_root
         if args.wiki_root:
             wiki_root = Path(args.wiki_root).expanduser().resolve()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -435,6 +435,50 @@ class TestWikiConfig(unittest.TestCase):
         with self.assertRaises(_config.ConfigError):
             self._load('wiki = "x"\n[campaign]\nnamespace = "test"\n')
 
+    def test_snapshot_max_age_days_defaults_to_30(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n')
+        self.assertEqual(cfg.snapshot_max_age_days, 30)
+
+    def test_snapshot_max_age_days_parsed(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n'
+                         '[wiki]\nsnapshot_max_age_days = 7\n')
+        self.assertEqual(cfg.snapshot_max_age_days, 7)
+
+    def test_snapshot_max_age_days_non_int_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n'
+                       '[wiki]\nsnapshot_max_age_days = "30"\n')
+
+    def test_snapshot_max_age_days_bool_refused(self):
+        # bool is an int subclass; `= true` must not silently parse as 1.
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n'
+                       '[wiki]\nsnapshot_max_age_days = true\n')
+
+    def test_snapshot_max_age_days_zero_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n'
+                       '[wiki]\nsnapshot_max_age_days = 0\n')
+
+    def test_snapshot_max_age_days_negative_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n'
+                       '[wiki]\nsnapshot_max_age_days = -1\n')
+
+    def test_fetch_command_parsed(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n'
+                         '[wiki]\nfetch_command = "./scripts/fetch-wiki-snapshot.sh"\n')
+        self.assertEqual(cfg.fetch_command, "./scripts/fetch-wiki-snapshot.sh")
+
+    def test_fetch_command_absent_is_none(self):
+        cfg = self._load('[campaign]\nnamespace = "test"\n')
+        self.assertIsNone(cfg.fetch_command)
+
+    def test_fetch_command_non_string_refused(self):
+        with self.assertRaises(_config.ConfigError):
+            self._load('[campaign]\nnamespace = "test"\n'
+                       '[wiki]\nfetch_command = 7\n')
+
 
 class TestAcceptedConfig(unittest.TestCase):
     """[[review.accepted]] — accepting a specific finding, never a whole

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -3,7 +3,9 @@ import io
 import os
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from bunnyforge import _common
@@ -894,6 +896,217 @@ class TestWikiSuiteWiring(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertNotIn("~", err.getvalue())
             self.assertIn(expected, err.getvalue())
+
+
+def _marker_ts(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestWikiSnapshotCheck(unittest.TestCase):
+    """check_wiki_snapshot: dates a local wiki copy that rsync -a otherwise
+    leaves undateable. See issue #23."""
+
+    def _write_marker(self, root: Path, text: str) -> None:
+        (root / review._SNAPSHOT_MARKER).write_text(text, encoding="utf-8")
+
+    def test_marker_absent_warns_honestly_not_accusingly(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_install(Path(d))
+            findings = review.check_wiki_snapshot([], root)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(f.severity, "warn")
+        self.assertEqual(f.check, "wiki-snapshot")
+        self.assertIn("unknown", f.message)
+        self.assertIn("old configuration", f.message)
+
+    def test_marker_fresh_no_finding(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_install(Path(d))
+            self._write_marker(root, _marker_ts(datetime.now(timezone.utc)))
+            findings = review.check_wiki_snapshot([], root)
+        self.assertEqual(findings, [])
+
+    def test_marker_within_custom_threshold_no_finding(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_install(Path(d))
+            ts = datetime.now(timezone.utc) - timedelta(days=10)
+            self._write_marker(root, _marker_ts(ts))
+            findings = review.check_wiki_snapshot([], root, max_age_days=30)
+        self.assertEqual(findings, [])
+
+    def test_marker_older_than_threshold_warns_naming_age_and_threshold(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_install(Path(d))
+            ts = datetime.now(timezone.utc) - timedelta(days=45)
+            self._write_marker(root, _marker_ts(ts))
+            findings = review.check_wiki_snapshot([], root, max_age_days=30)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(f.severity, "warn")
+        self.assertIn("45", f.message)
+        self.assertIn("30", f.message)
+
+    def test_marker_malformed_warns(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = make_install(Path(d))
+            self._write_marker(root, "not-a-timestamp")
+            findings = review.check_wiki_snapshot([], root)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(f.severity, "warn")
+        self.assertIn("malformed", f.message)
+
+    def test_none_of_the_four_states_ever_produce_an_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            absent = make_install(Path(d) / "absent")
+            fresh = make_install(Path(d) / "fresh")
+            self._write_marker(fresh, _marker_ts(datetime.now(timezone.utc)))
+            stale = make_install(Path(d) / "stale")
+            self._write_marker(
+                stale, _marker_ts(datetime.now(timezone.utc) - timedelta(days=90)))
+            malformed = make_install(Path(d) / "malformed")
+            self._write_marker(malformed, "nope")
+            for root in (absent, fresh, stale, malformed):
+                findings = review.check_wiki_snapshot([], root)
+                self.assertTrue(all(f.severity != "error" for f in findings),
+                               f"unexpected error from {root.name}: {findings}")
+
+    def test_stale_snapshot_does_not_flip_exit_code_by_itself(self):
+        # A stale marker must warn, never error -- proven end to end: an
+        # otherwise-clean wiki install with a 90-day-old marker still exits
+        # 0, and the finding is visible in the report.
+        with tempfile.TemporaryDirectory() as d:
+            root = make_install(Path(d) / "wiki",
+                                local_php="$conf['useacl'] = 1;\n"
+                                          "$conf['useheading'] = 1;\n",
+                                plugins=("include",))
+            self._write_marker(
+                root, _marker_ts(datetime.now(timezone.utc) - timedelta(days=90)))
+            (Path(d) / "camp").mkdir()
+            ws = make_workspace(Path(d) / "camp", {})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws),
+                                  "--wiki-root", str(root)])
+            self.assertEqual(rc, 0)
+            self.assertIn("wiki-snapshot", out.getvalue())
+
+
+class TestWikiSnapshotWiring(unittest.TestCase):
+    def test_registered_in_checks(self):
+        self.assertIn("wiki-snapshot", review.CHECKS)
+
+    def test_in_wiki_suite(self):
+        self.assertIn("wiki-snapshot", review.SUITES["wiki"])
+
+    def test_in_needs_wiki(self):
+        self.assertIn("wiki-snapshot", review._NEEDS_WIKI)
+
+    def test_not_in_checkup(self):
+        self.assertNotIn("wiki-snapshot", review.SUITES["checkup"])
+
+
+class TestRunSuiteThreadsSnapshotThreshold(unittest.TestCase):
+    def test_configured_threshold_reaches_the_check(self):
+        with tempfile.TemporaryDirectory() as d:
+            wiki_root = make_install(Path(d) / "wiki",
+                                     local_php="$conf['useacl'] = 1;\n"
+                                               "$conf['useheading'] = 1;\n",
+                                     plugins=("include",))
+            (wiki_root / review._SNAPSHOT_MARKER).write_text(
+                _marker_ts(datetime.now(timezone.utc) - timedelta(days=10)),
+                encoding="utf-8")
+            camp = make_workspace(Path(d) / "camp", {
+                "campaign.toml": '[campaign]\nnamespace = "test"\n'
+                                 '[wiki]\nsnapshot_max_age_days = 5\n'})
+            ws = _config.open_workspace(camp)
+            findings = review.run_suite("wiki", ws, wiki_root)
+        snap = [f for f in findings if f.check == "wiki-snapshot"]
+        self.assertEqual(len(snap), 1)
+        self.assertIn("5", snap[0].message)
+
+
+class TestFetchLatest(unittest.TestCase):
+    """--fetch-latest: runs a configured command before the suite and
+    refuses to review if it fails. See issue #23. No test here spawns a
+    real process -- run_fetch_command's `runner` is always a fake."""
+
+    def test_missing_fetch_command_refused_instructionally(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = make_workspace(Path(d), {})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws),
+                                  "--wiki-root", d, "--fetch-latest"])
+            self.assertEqual(rc, 1)
+            self.assertIn("fetch_command", err.getvalue())
+            self.assertIn("[wiki]", err.getvalue())
+
+    def test_fetch_latest_on_checkup_refused_instructionally(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = make_workspace(Path(d), {})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["checkup", "--workspace", str(ws),
+                                  "--fetch-latest"])
+            self.assertEqual(rc, 1)
+            self.assertIn("--fetch-latest", err.getvalue())
+            self.assertIn("checkup", err.getvalue())
+
+    def test_command_split_with_shlex_run_without_shell_from_workspace_root(self):
+        calls = []
+
+        def fake_runner(argv, cwd, **kwargs):
+            calls.append((argv, cwd, kwargs))
+            return SimpleNamespace(returncode=0, stdout="fetched ok\n", stderr="")
+
+        with tempfile.TemporaryDirectory() as d:
+            wiki_root = make_install(Path(d) / "wiki",
+                                     local_php="$conf['useacl'] = 1;\n"
+                                               "$conf['useheading'] = 1;\n",
+                                     plugins=("include",))
+            ws = make_workspace(Path(d) / "camp", {
+                "campaign.toml": '[campaign]\nnamespace = "test"\n'
+                                 '[wiki]\n'
+                                 f'install_root = "{wiki_root}"\n'
+                                 'fetch_command = '
+                                 '"./scripts/fetch-wiki-snapshot.sh --go"\n'})
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws),
+                                  "--fetch-latest"], fetch_runner=fake_runner)
+            self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        argv, cwd, kwargs = calls[0]
+        self.assertEqual(argv, ["./scripts/fetch-wiki-snapshot.sh", "--go"])
+        self.assertEqual(Path(cwd).resolve(), Path(ws).resolve())
+        self.assertNotIn("shell", kwargs)
+        self.assertIn("fetched ok", out.getvalue())
+
+    def test_fetch_failure_refuses_review_exits_nonzero_and_surfaces_output(self):
+        def fake_runner(argv, cwd, **kwargs):
+            return SimpleNamespace(returncode=3, stdout="",
+                                   stderr="ssh: connection refused\n")
+
+        with tempfile.TemporaryDirectory() as d:
+            ws = make_workspace(Path(d) / "camp", {
+                "campaign.toml": '[campaign]\nnamespace = "test"\n'
+                                 '[wiki]\n'
+                                 'fetch_command = '
+                                 '"./scripts/fetch-wiki-snapshot.sh"\n'})
+            nonexistent_wiki = str(Path(d) / "does-not-exist")
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = review.main(["wiki", "--workspace", str(ws),
+                                  "--wiki-root", nonexistent_wiki,
+                                  "--fetch-latest"], fetch_runner=fake_runner)
+            self.assertEqual(rc, 1)
+        self.assertIn("ssh: connection refused", err.getvalue())
+        self.assertIn("fetch", err.getvalue().lower())
+        # The suite (and its wiki-root resolution) never ran: no trace of
+        # the bogus --wiki-root reaching an error message.
+        self.assertNotIn("does-not-exist", err.getvalue())
 
 
 class TestApplyAcceptances(unittest.TestCase):


### PR DESCRIPTION
Closes #23. Both parts.

## Files changed

- `src/bunnyforge/_config.py` (modified) — `snapshot_max_age_days`, `fetch_command`
- `src/bunnyforge/review.py` (modified) — the `wiki-snapshot` check; `--fetch-latest`
- `src/bunnyforge/README.md` (modified) — both, including the trust note
- `tests/test_config.py`, `tests/test_review.py` (modified) — covering tests
- `pyproject.toml` (modified) — `0.2.2` → `0.2.3`

## Part 1 — the snapshot age warning

`review wiki` checks a local copy. If that copy is old it checks last month's
configuration and reports nothing wrong — a pass indistinguishable from a
genuinely clean one. And the copy could not be dated: `rsync -a` preserves the
remote's mtimes, so every timestamp in it describes the *wiki's* history, not
the copy's.

New `wiki-snapshot` check reads `<install_root>/.bunnyforge-snapshot-fetched-at`
(written by the campaign-side fetch script) and warns when the age is unknown,
stale, or unparseable. **All findings are `warn`, never `error`** — the goal is
to stop a stale pass looking clean, not to redden a run. Threshold is
`[wiki] snapshot_max_age_days`, default 30.

Verified end to end against a real snapshot:

| marker | result | exit |
|---|---|---|
| fresh | no finding | unchanged |
| 217 days old | warn naming age and threshold | **0** |
| absent | warn that age is unknown, honestly (a hand-made copy is legitimate) | **0** |
| malformed | warn showing the expected format | **0** |

## Part 2 — `--fetch-latest`

Runs a **configured command**, then reviews; refuses to review if it failed.

```toml
[wiki]
fetch_command = "./scripts/fetch-wiki-snapshot.sh"
```

**bunnyforge never learns what ssh is.** It runs what the operator configured
from the workspace root, waits, and checks the exit status — so it works with
rsync, scp, sftp, a mount refresh, anything, and someone on a hosted wiki with
no shell simply does not configure it.

Verified:

- successful fetch → its output visible, review proceeds
- **failing fetch → output surfaced, review refused, zero checks run**, exit
  non-zero, message attributing the failure to the *fetch* rather than a check
- `--fetch-latest` with no `fetch_command` → refused, showing the TOML to add
- `--fetch-latest` on `checkup` → refused, since that suite uses no wiki root

Split with `shlex.split` and run with `shell=False`: an operator needing pipes
can wrap them in a script, which is a better trade than handing a config file a
shell.

## Two judgement calls worth a look

- **A naive (no-offset) marker timestamp is treated as UTC** rather than
  rejected as malformed. Lenient, and the format the script writes is always
  offset-bearing; flagging in case you'd rather it were strict.
- `run_suite` special-cases `wiki-snapshot` to pass the threshold, as the only
  wiki check needing config beyond the wiki root.

## Test expectations

All green — **572 → 597 tests**, portability passes. No test spawns a real
process or touches the network; the runner is injected.

## Operational impact

`subprocess` is a deliberate, narrow addition — the package is otherwise
stdlib-only with essentially no subprocess use. A configured command that gets
executed is a code-execution surface, at the same trust level as a Makefile or
an npm script; the README says so rather than leaving it to be discovered.

Absent config, nothing changes: no `fetch_command` means the flag is unusable
but everything else behaves as before, and a missing marker only ever warns.

## Release

Includes the version bump to **0.2.3**, so this branch is the next release
rather than leaving `main` describing 0.2.2 while carrying newer work.

A patch bump, consistent with how 0.2.2 versioned the accepted-findings
mechanism: both additions here are inert without config — no `fetch_command`
means the flag is unusable, and a missing marker only ever warns — so from any
existing workspace's point of view this is purely additive. 0.3.0 stays
reserved to mark a new line of functionality.

After merge: tag `v0.2.3` and push. CI refuses a tag disagreeing with
`pyproject.toml`. Then wait for PyPI's index to serve it to a fresh resolver
before bumping any campaign pin — and note that `pip index versions` reads a
local cache and will lie about this; a `--no-cache-dir` install in a fresh
virtualenv is the honest test.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: Opus 5 driving a Sonnet 5 implementer

