### PR TITLE
doctrine: read _Archive freely for precedent; never read _Ignore

### DIFF
--- a/src/bunnyforge/data/doctrine/AGENTS.md
+++ b/src/bunnyforge/data/doctrine/AGENTS.md
@@ -7,9 +7,11 @@ This is a creative writing workspace for a long-running tabletop RPG campaign.
 It is not a software project. The canonical material lives in files in this
 directory. Conversation history is not canon and must not be treated as such.
 
-Two directories are outside the canon: `_Archive/` (retired material that was
-used) and `_Ignore/` (raw material, plus retired work that set no precedent).
-Do not read either unless explicitly asked.
+Two directories are outside the canon, and they are not treated alike.
+`_Archive/` holds retired material that was used: **read it freely and reason
+from it** — decisions rest on precedent, which is the whole reason it is kept.
+`_Ignore/` holds raw material, plus retired work that set no precedent: **never
+read it** unless I name a file in it and ask.
 
 ## Read order
 
@@ -165,7 +167,10 @@ include the separator, even if the GM notes section is empty. A handout is a
 - Do not give NPCs knowledge they have no in-world route to acquiring.
 - Do not contradict `[[front-burner]]`; it outranks older files.
 - Do not rename, renumber, or silently retcon existing entities.
-- Do not draw facts from `_Archive/`. It is retired history, not canon.
+- Do not present `_Archive/` material as current. Read it freely — what was
+  decided, what was tried, and why the thing that replaced it looks the way it
+  does is exactly what it is for — but it is superseded by definition, so where
+  it disagrees with a live file, the live file wins.
 - Do not read `_Ignore/`. It is unmigrated raw material, unreviewed and
   partly contradicted by the rest of the workspace — plus retired work that set
   no precedent (see the deletion rule below). It is not canon, and it is not a
@@ -294,7 +299,7 @@ apply to any prep material produced here:
 - Nothing is deleted. Superseded material that was **used** moves to
   `_Archive/` with `status: retired`: it happened, so it is part of the record,
   and a retired thing still explains why what replaced it looks the way it
-  does. That is why `_Archive/` may be read when I ask for it.
+  does. That is why `_Archive/` is read freely rather than on request.
   Material that never got used, or that was used once and can never be relevant
   again, sets no precedent — an abandoned draft of something later rebuilt from
   scratch, or a one-time instruction that did its job and whose steps the

--- a/src/bunnyforge/data/doctrine/AGENTS.md
+++ b/src/bunnyforge/data/doctrine/AGENTS.md
@@ -7,8 +7,9 @@ This is a creative writing workspace for a long-running tabletop RPG campaign.
 It is not a software project. The canonical material lives in files in this
 directory. Conversation history is not canon and must not be treated as such.
 
-Two directories are outside the canon: `_Archive/` (retired) and `_Ignore/`
-(unmigrated raw material). Do not read either unless explicitly asked.
+Two directories are outside the canon: `_Archive/` (retired material that was
+used) and `_Ignore/` (raw material, plus retired work that set no precedent).
+Do not read either unless explicitly asked.
 
 ## Read order
 
@@ -166,8 +167,9 @@ include the separator, even if the GM notes section is empty. A handout is a
 - Do not rename, renumber, or silently retcon existing entities.
 - Do not draw facts from `_Archive/`. It is retired history, not canon.
 - Do not read `_Ignore/`. It is unmigrated raw material, unreviewed and
-  partly contradicted by the rest of the workspace. It is not canon, and it is
-  not a fallback when an answer cannot be found elsewhere. The only exception is
+  partly contradicted by the rest of the workspace — plus retired work that set
+  no precedent (see the deletion rule below). It is not canon, and it is not a
+  fallback when an answer cannot be found elsewhere. The only exception is
   a file in it that I name explicitly and ask you to work on.
 - Do not read `_ExtractInbound/` unless I ask you to extract from it. It is a
   staging area for imported material, none of it canon. See its own section
@@ -289,8 +291,18 @@ apply to any prep material produced here:
 - Brief filenames must match their writeup: `Briefs/session-014/mira-venn.md` pairs
   with `NPCs/mira-venn.md`. A mismatch produces a sheet built from the brief alone.
 - Generated sheets in `Sheets/` are not canon and are not edited by hand.
-- Nothing is deleted. Superseded material moves to `_Archive/` with `status:
-  retired`.
+- Nothing is deleted. Superseded material that was **used** moves to
+  `_Archive/` with `status: retired`: it happened, so it is part of the record,
+  and a retired thing still explains why what replaced it looks the way it
+  does. That is why `_Archive/` may be read when I ask for it.
+  Material that never got used, or that was used once and can never be relevant
+  again, sets no precedent — an abandoned draft of something later rebuilt from
+  scratch, or a one-time instruction that did its job and whose steps the
+  result has since contradicted. That moves to `_Ignore/` instead, which is
+  never read at all. Note what the second move costs: `_Ignore/` is git-ignored,
+  so the file leaves version control. It stays on disk, and its history up to
+  the move remains, but a fresh clone will not contain it — which is the
+  intended end state for material that constrains nothing.
 
 ## At the end of a working session
 


### PR DESCRIPTION
## Files changed

- `src/bunnyforge/data/doctrine/AGENTS.md` (modified) — four passages: the two-directory summary, the `_Archive/` rule, the `_Ignore/` rule, and the deletion rule. Two commits: the third-case addition, then the correction below.

## Work breakdown

Two changes, and the second is the substantive one.

**1. A missing case.** The doctrine said "nothing is deleted; superseded material moves to `_Archive/`", and described `_Ignore/` only as "unmigrated raw material". Between them there was no home for work that was real but sets no precedent: an abandoned draft of something later rebuilt from scratch, or a one-time instruction that did its job and whose steps the result has since contradicted. The test is now stated — **was it used, and does it still set precedent?** — with the used-and-still-instructive going to `_Archive/` and everything else to `_Ignore/`.

**2. The two directories were never alike, and the old rule had it backwards.** The first pass preserved the standing symmetry, "do not read either unless explicitly asked". That is wrong about `_Archive/`: **decisions rest on precedent**, so retired material that was used should be read freely, not on request.

This inverts a prohibition rather than refining one. `- Do not draw facts from `_Archive/`. It is retired history, not canon.` forbade exactly what the directory is for. What was worth keeping in that line is its other half — retired material is superseded by definition — so the rule now bars presenting it as **current** rather than reading it at all, and states that the live file wins any disagreement:

> - Do not present `_Archive/` material as current. Read it freely — what was decided, what was tried, and why the thing that replaced it looks the way it does is exactly what it is for — but it is superseded by definition, so where it disagrees with a live file, the live file wins.

An agent that treats a retired NPC writeup as live canon is still wrong; an agent that consults it to understand why the current one looks as it does is doing the intended thing. `_Ignore/` keeps the hard bar: never read, unless the human names a file in it and asks.

**One cost named that was previously implicit:** `_Ignore/` is git-ignored — this repo's own `run_tests.py` says so — so demoting a file there takes it out of version control. It stays on disk and its history up to the move remains, but a fresh clone will not contain it. Right end state for material that constrains nothing, but it should be a decision rather than a discovery.

**Where this came from.** Retiring a spent conlang generation prompt in a campaign workspace: used exactly once, never usable again, and three of its instructions had since been contradicted by the canon it generated.

## Test expectations

**One pre-existing failure, unrelated to this change** — filed as #27 rather than fixed here, to keep this PR single-purpose:

```
FAIL: test_every_packaged_file_is_named_by_the_manifest
AssertionError: Items in the first set but not the second:
'tests/__pycache__/example.cpython-313.pyc'
```

Confirmed pre-existing by stashing this change and re-running on clean `main`. Cause: `__pycache__` inside the **installed** package's data root, left when the packaged sample tests run. That test already filters `.DS_Store` for the same class of reason.

Otherwise green: 596 of 597 pass. This PR changes no code path — it edits one markdown file.

## Operational impact

Doctrine-only. It reaches workspaces on their next `bunnyforge init` or doctrine adoption, so it needs a release before the campaign that prompted it can adopt it back and drop its local divergence.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: transcript requested `claude-opus-5[1m]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)