### PR TITLE
chore: bump version to 0.3.0 — first GPL-3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.2.3"
+version = "0.3.0"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Cuts the release that ships #25 (relicense) and #26 (doctrine). Replaces #28, whose head branch carried the earlier patch-bump commit.

## Files changed

- `pyproject.toml` (modified) — `version = "0.2.3"` → `"0.3.0"`. One line; the version has exactly one home.

## Work breakdown

**Minor, not patch, because this is the first GPL-3.0-or-later release.** #25 relicensed the project and the README states the change "applies from the next release onward" — this is that release. No code changed, so semver-by-API argues for a patch; but semver governs API compatibility, and this changes the terms under which the artifact may be used. A patch bump is where people look least, and anyone auto-upgrading within `0.2.x` would cross the licence line in silence. Releases up to and including **0.2.3 stay MIT forever** — that grant cannot be withdrawn, and the README already says so, so it needs no edit.

**Also ships #26**, the `_Archive` / `_Ignore` doctrine correction:

- `_Archive/` is **read freely** for precedent — what was tried, what was decided, why the thing that replaced it looks the way it does — rather than only on request. This inverted a standing prohibition (`Do not draw facts from _Archive/`), keeping its useful half as a currency rule: never present retired material as current, and a live file wins any disagreement.
- `_Ignore/` keeps the hard bar: never read unless the human names a file in it.
- The third case that had no home — work that was real but sets no precedent (an abandoned draft; a one-time instruction whose steps the result has since contradicted) — belongs in `_Ignore/`.
- Names a cost that was implicit: `_Ignore/` is git-ignored, so demoting a file there takes it out of version control.

## Test expectations

**One pre-existing failure, unrelated** — `test_every_packaged_file_is_named_by_the_manifest`, tripping on `__pycache__` in the installed package's data root. Filed as #27; confirmed pre-existing on clean `main` by stashing. 596 of 597 pass.

## Operational impact

Merging this does **not** publish. `publish.yml` fires on a `v*` tag push and guards that the tag matches `pyproject.toml`, so the sequence is: merge → tag `v0.3.0` on `main` → push the tag. **The tag push is the irreversible step**: PyPI will not accept a re-upload of a version, and this one carries the licence transition.

Downstream: the Anjeong campaign adopts the doctrine back into its own `AGENTS.md` once 0.3.0 is installed, dropping a divergence it is currently carrying deliberately.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: transcript requested `claude-opus-5[1m]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)