### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Cuts the release that ships #30 (closes #27).

## Files changed

- `pyproject.toml` (modified) — `version = "0.3.0"` → `"0.3.1"`. One line.

## Work breakdown

Patch bump: #30 is test-only. It excludes `__pycache__` from `test_every_packaged_file_is_named_by_the_manifest`, which walks the installed package's data root — `data/tests/` ships sample test files, and running them (what `bunnyforge run-tests` does in a real workspace) leaves `.pyc` beside them in site-packages, which the check then read as MANIFEST drift. Fires only on a working machine, never in CI, some time after the run that caused it.

It also adds a guard that the exclusions cannot go broad enough to hide a genuine unmanifested file.

## Test expectations

None. 598 pass on `main` with the fix in; before it, 597 with 1 failure.

## Operational impact

Merging does not publish. `publish.yml` fires on a `v*` tag push and guards the tag against `pyproject.toml`, so: merge → tag `v0.3.1` → push.

## Provenance

- Agent: Claude Code (VS Code extension)
- Model / version: transcript requested `claude-opus-5[1m]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)