### PR TITLE
Bring the init scaffold inventory current, and document the .vscode/ pair (#34 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ campaign tests it invites you to write — the setting-specific invariants
 and ships a worked example, commented out, to adapt. `bunnyforge test`
 runs them, and checks that no test wrote into your campaign while running.
 
+It also scaffolds a `.vscode/` pair, shipped switched off. `settings.json`
+holds a block that colours `.md` files by their front-matter `visibility`
+— red for `gm-only`, green for `player-visible`, cyan for `mixed`, in
+dark and light variants — with every line of it commented out behind a
+`//- ` prefix, so a fresh workspace renders exactly as it would without
+the file. Delete the prefixes to switch it on; the header comment says so
+in place, and carries two alternate palettes to swap in.
+`extensions.json` recommends the extension that renders it — without it
+installed, the files simply render plain.
+
 ## Names
 
 `bunnyforge names` builds names from syllable inventories you write

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -56,14 +56,24 @@ not exist, or must be an empty directory — a file, a non-empty directory, or a
 existing `campaign.toml` is one `error:` line and exit 1. There is no `--force`
 and no overwrite semantics.
 
-What it writes: `campaign.toml` (live keys for name, namespace and the culture
-directory; every defaultable key present as a comment showing its default), the
-8 root docs, the 10 content directories each with its README, all 16
-`_Templates/` files, a starter culture at `names/cultures/vashkand.toml`, and a
-minimal `.gitignore`. It does not run `git init`; version control is your move.
-The result passes `review checkup` with 0 errors and 0 warnings and runs
-`generate_names` with no manual fixes — asserted by
+What it writes — 38 files, every one of them a `MANIFEST` entry: `campaign.toml`
+(live keys for name, namespace and the culture directory; every defaultable key
+present as a comment showing its default), the 8 root docs, the 10 content
+directories each with its README, the 12 `_Templates/` files, a starter culture
+at `names/cultures/vashkand.toml`, a minimal `.gitignore`, the 3-file `tests/`
+scaffold, and 2 files under `.vscode/`. It does not run `git init`; version
+control is your move. The result passes `review checkup` with 0 errors and 0
+warnings and runs `generate_names` with no manual fixes — asserted by
 `tests/test_init.py::TestFreshWorkspacePassesTheGate`.
+
+The `.vscode/` pair ships **inert**: `settings.json` carries a colouring block
+that tints `.md` files by their front-matter `visibility`, disabled line by line
+behind a reserved `//- ` prefix between two `bunnyforge:` marker comments, and
+`extensions.json` recommends the extension that renders it. A scaffolded
+workspace therefore looks exactly like one without the files until someone
+deletes the prefixes. The markers and the off-prefix are a frozen format —
+`tests/test_init.py::TestVscodeScaffold` pins them, and parses the file as
+strict JSON in both toggle states.
 
 The files live in `src/bunnyforge/data/`, and a single `MANIFEST` in `init.py`
 maps each to its destination and to the in-repo file it must stay


### PR DESCRIPTION
Follow-up to #35 (merged). Documentation only — no code, no test changes.

Base branch: **`main`** (not stacked on anything).

## Files changed
- `src/bunnyforge/README.md` (modified) — the `init.py` "What it writes" inventory, plus a paragraph on the `.vscode/` pair.
- `README.md` (modified) — a user-facing paragraph on the `.vscode/` pair in "The workspace".

## Work breakdown

**The inventory had drifted twice over.** `src/bunnyforge/README.md` listed what `init` writes as *"the 8 root docs, the 10 content directories each with its README, all 16 `_Templates/` files, a starter culture …, and a minimal `.gitignore`"*. Measured against MANIFEST:

| group | README said | actual |
|---|---|---|
| `_Templates/` files | 16 | **12** |
| `tests/` scaffold | *(absent)* | **3** |
| `.vscode/` | *(absent)* | **2** |
| root docs | 8 | 8 ✓ |
| content dir READMEs | 10 | 10 ✓ |

The `_Templates/` count went stale when the two doctrine skeletons stopped landing there (they now land once, at the workspace root under their canonical names); `tests/` was never added when that scaffold shipped; `.vscode/` is new in #35. The rewritten sentence leads with the total — **38 files, every one of them a MANIFEST entry** — and the per-group figures sum to exactly `len(MANIFEST)`, checked programmatically rather than counted by hand.

**Documents the `.vscode/` pair** in both READMEs, at the altitude each one works at: the package README explains the inert-behind-`//- ` mechanism and names `TestVscodeScaffold` as the test that pins the format; the root README tells a user what they'll see (which colour means what, that it's off, how to turn it on) without any of the internals.

**Wording is command-neutral throughout** — the `bunnyforge vscode` toggle does not exist until #33, so nothing here names it. #33 will want to revisit both paragraphs to point at the command once it lands.

## Verification
- Every factual claim checked against the code, not against my reading of it: the group counts (summing to 38 = `len(MANIFEST)`), the three hue-to-visibility mappings and the dark/light variants, that the settings header really does tell the reader to delete the `//- ` prefixes, that there really are exactly two ALTERNATE palettes, and that `extensions.json` really says files render plain without the extension.
- `python3 -m unittest discover -s tests -t .` → **605 tests, OK**. No test asserts README prose (grepped), so this is genuinely doc-only.
- Secret scan over the diff: no matches.

## Operational impact
None.

## Provenance
- Agent: Claude Code (VS Code extension)
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)