### PR TITLE
Add bunnyforge vscode: install/update the preview extension, toggle colouring (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,32 @@ entity files from the templates in `_Templates/`.
 | `import-perceptions` | import player-authored wiki pages into `Perceptions/` |
 | `build-sheets` | build one-page HTML reference sheets for a session |
 | `names` | generate culture-appropriate names |
+| `vscode` | install the preview extension and toggle editor colouring |
 | `test` | run the workspace test suite |
 
 Run `bunnyforge <command> --help` for a command's own options.
+
+## VS Code integration
+
+`bunnyforge init` scaffolds `.vscode/settings.json` and
+`.vscode/extensions.json` with a visibility colour language for the editor —
+every `.md` file coloured by its front-matter `visibility`, the `## GM notes`
+boundary marked. It ships off; `bunnyforge vscode` manages it:
+
+    bunnyforge vscode status      # both halves: installed, available, on/off
+    bunnyforge vscode setup       # install/update, then offer to enable
+    bunnyforge vscode on|off      # toggle the source-view block
+    bunnyforge vscode install|update|uninstall   # the preview extension
+
+The source-view half is rendered by the Marketplace extension
+`fabiospampinato.vscode-highlight`. The markdown-preview half,
+[`dcltdw.bunnyforge-visibility-preview`](https://github.com/dcltdw/bunnyforge-visibility-preview),
+is not on the Marketplace; it sideloads as a `.vsix` from GitHub releases,
+and sideloaded extensions never auto-update — `bunnyforge vscode update`
+checks the release feed. Only Visual Studio Code is tested; VS Code
+Insiders, VSCodium and Cursor are offered but unsupported. `on`/`off`
+rewrite only the marked managed block in `.vscode/settings.json`; the rest
+of the file — including its comments — is yours.
 
 ## The workspace
 
@@ -63,15 +86,9 @@ campaign tests it invites you to write — the setting-specific invariants
 and ships a worked example, commented out, to adapt. `bunnyforge test`
 runs them, and checks that no test wrote into your campaign while running.
 
-It also scaffolds a `.vscode/` pair, shipped switched off. `settings.json`
-holds a block that colours `.md` files by their front-matter `visibility`
-— red for `gm-only`, green for `player-visible`, cyan for `mixed`, in
-dark and light variants — with every line of it commented out behind a
-`//- ` prefix, so a fresh workspace renders exactly as it would without
-the file. Delete the prefixes to switch it on; the header comment says so
-in place, and carries two alternate palettes to swap in.
-`extensions.json` recommends the extension that renders it — without it
-installed, the files simply render plain.
+It also scaffolds a `.vscode/` pair — a visibility colour language for the
+editor — shipped off. `bunnyforge vscode` manages it; see
+[VS Code integration](#vs-code-integration) above.
 
 ## Names
 

--- a/docs/superpowers/plans/2026-08-15-vscode-command.md
+++ b/docs/superpowers/plans/2026-08-15-vscode-command.md
@@ -1,0 +1,2181 @@
+# The `bunnyforge vscode` Command (#33) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development to implement this plan
+> **task-by-task with a fresh subagent per task and review between tasks** —
+> the components have clean seams and each task is TDD-able in isolation.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `bunnyforge vscode` subcommand family that installs/updates the
+markdown-preview extension (sideloaded `.vsix` from GitHub releases) and
+toggles the source-view colouring block that #34 scaffolds inert.
+
+**Architecture:** One new module `src/bunnyforge/vscode.py` with `main(argv)`,
+wired into `cli.py`'s `_COMMANDS`/`_SUMMARIES`. Internally: a pure-text
+marker-region engine over `.vscode/settings.json` (Python has no stdlib JSONC
+round-tripper, and the file's comments carry real documentation — so the tool
+edits lines between markers and refuses when markers are broken); a pinned
+GitHub-releases client with a digest-verified `.vsix` cache; cross-platform
+editor-CLI discovery; and subcommands whose workspace requirement differs
+per-subcommand. Uses argparse subparsers — `cli.py`'s no-subparsers rule is
+about forwarding argv verbatim to other modules, which does not apply inside
+a module that owns all its subcommands.
+
+**Tech Stack:** Python ≥3.11 stdlib only (`urllib.request`, `hashlib`,
+`subprocess`, `shutil.which`, `argparse`, `json`); `unittest` + `unittest.mock`.
+
+**Spec:** https://github.com/dcltdw/bunnyforge/issues/33 — the body plus all
+three comments (decisions 1–6, dated 2026-08-16, and the duplicate-key
+hazard). The settled decisions are restated below so the executor never needs
+GitHub. Prerequisite: **#34 merged to `main` first** — this plan reads the
+packaged `data/vscode/settings.json` it ships.
+
+## Global Constraints
+
+- **Stdlib only**, Python ≥3.11.
+- **Prerequisite:** branch only after #34 is merged; `git checkout main &&
+  git pull` and confirm `src/bunnyforge/data/vscode/settings.json` exists.
+- **House error pattern:** user-facing failures are one `error: <msg>` line on
+  stderr, exit 1, never a traceback (see `init.py:main` for the shape).
+- **Campaign-neutral:** no private campaign's name anywhere; portability tests
+  stay green.
+- **Pinned source:** the extension repo/URL are module constants; never read
+  from config. Print exactly what will be installed and from where; confirm
+  interactively; `--yes` for automation.
+- **Rewrite only between the markers.** The one sanctioned exception: when
+  *creating* the managed block in an existing file, a comma may be appended to
+  the preceding property line. Refuse rather than guess on unbalanced markers.
+- Branch off `main`, PR to `main` (say so explicitly), AGENTS.md PR body
+  (files changed annotated, work breakdown, provenance), `Co-Authored-By:`
+  trailer on every commit.
+- Tests: `python3 -m unittest tests.test_vscode -v` per module; full:
+  `python3 -m unittest discover -s tests -t . -v`.
+
+## Settled decisions (2026-08-16 — do not re-litigate)
+
+1. `on`/`setup` detect a missing `fabiospampinato.vscode-highlight` and offer
+   to install it (Marketplace: `code --install-extension` works directly).
+2. Always the **newest** release of the preview extension. No pinning.
+3. Discovery also finds VS Code Insiders, VSCodium, Cursor and will install
+   into them — stated plainly as **untested/unsupported** in output and docs.
+4. `vscode on` **creates** the managed block when missing (existing
+   workspaces never receive scaffolded files).
+5. Workspace requirement is **per-subcommand**: `install`/`update`/`uninstall`
+   never resolve a workspace; `on`/`off` always; `status` (and `setup`)
+   optionally — report the machine half unconditionally, the workspace half
+   only when one is found, and say plainly when there is not. Worth a sentence
+   in `--help`.
+6. Existing top-level `"highlight.regexes"` outside the markers → never
+   append (silent duplicate key), never overwrite unasked. Prompt:
+   **adopt** (recommended, bracket the user's rules — minimum span: the key
+   through its closing brace), **replace** (packaged rules), **cancel**
+   (nothing, exit non-zero). No TTY → fail naming `--adopt`/`--replace`.
+7. (This design, approved 2026-08-15:) `on --replace` doubles as the
+   **region-level reset**: with markers present it rewrites the region from
+   the packaged bytes, discarding local tuning — explicit flag only, never
+   prompted for, one code path with decision 6's replace arm.
+
+The cross-ticket contract #34 froze (markers, `//- ` off-prefix after the
+indent, region-first, pin outside region) is in
+`docs/superpowers/plans/2026-08-15-vscode-scaffold-files.md` — read it before
+Task 1.
+
+## File structure
+
+- `src/bunnyforge/vscode.py` — everything: constants, region engine,
+  structural edits, discovery, release client, cache, subcommands. One module
+  per command is the house pattern (`review.py`, `deploy_export.py` are
+  larger); internal sections keep it navigable.
+- `tests/test_vscode.py` — all new tests; network, subprocess, TTY and prompt
+  are injected/mocked, nothing touches a real editor or GitHub.
+- Small edits: `cli.py`, `init.py`, the two `data/vscode/*.json` headers,
+  `README.md`, `tests/test_cli.py`, `tests/test_init.py`.
+
+---
+
+### Task 1: Module skeleton, constants, and the packaged-contract drift tests
+
+**Files:**
+- Create: `src/bunnyforge/vscode.py`
+- Create: `tests/test_vscode.py`
+
+**Interfaces:**
+- Produces (consumed by every later task):
+  `VscodeError(Exception)`; constants `EXTENSION_ID: str`,
+  `EXTENSION_REPO: str`, `RELEASES_URL: str`, `HIGHLIGHT_ID: str`,
+  `MARKER_BEGIN: str`, `MARKER_END: str`, `OFF_PREFIX: str`,
+  `SETTINGS_REL: str`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/Github/bunnyforge
+git checkout main && git pull
+test -f src/bunnyforge/data/vscode/settings.json || echo "STOP: #34 not merged"
+git checkout -b feat/33-vscode-command
+```
+
+- [ ] **Step 2: Write the failing drift tests**
+
+`tests/test_vscode.py`:
+
+```python
+"""Tests for bunnyforge.vscode — the editor-integration command.
+
+Everything external is injected or mocked: `_fetch` (network), `_run`
+(subprocess), `_interactive`/`_ask` (TTY). No test touches GitHub or a
+real editor.
+"""
+
+import contextlib
+import io
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bunnyforge import init, vscode
+
+
+class TestPackagedContract(unittest.TestCase):
+    """vscode.py's constants and data/vscode/settings.json are two halves
+    of one contract (#34 froze it); drift between them is a red test."""
+
+    def _lines(self) -> list[str]:
+        return (init.packaged_bytes("vscode/settings.json")
+                .decode("utf-8").split("\n"))
+
+    def test_the_packaged_markers_match_the_constants(self):
+        stripped = [l.strip() for l in self._lines()]
+        self.assertEqual(stripped.count(vscode.MARKER_BEGIN), 1)
+        self.assertEqual(stripped.count(vscode.MARKER_END), 1)
+
+    def test_the_packaged_region_round_trips_through_the_toggle(self):
+        # disable(enable(x)) == x proves the packaged off-form is exactly
+        # what disable_region produces — the byte-level half of the contract.
+        lines = self._lines()
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "off")
+        on = vscode.enable_region(lines, begin, end)
+        self.assertEqual(vscode.region_state(on, begin, end), "on")
+        self.assertEqual(vscode.disable_region(on, begin, end), lines)
+```
+
+(The second test also exercises Task 2's engine; it goes red now and fully
+green at the end of Task 2.)
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `python3 -m unittest tests.test_vscode -v`
+Expected: ERROR — `ImportError`/`AttributeError` (module and names missing).
+
+- [ ] **Step 4: Create the skeleton**
+
+`src/bunnyforge/vscode.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+vscode.py — install/update the visibility-preview extension and toggle the
+source-view colouring.
+
+The extension (dcltdw.bunnyforge-visibility-preview) is not on the VS Code
+Marketplace and will not be (publishing needs an Azure DevOps org linked to
+an active Azure subscription); it sideloads as a .vsix from GitHub releases,
+and sideloaded extensions never auto-update — which is why version detection
+is the feature here rather than a nicety. It also has no runtime on/off
+switch and cannot be given one (static preview contributions cannot read
+extension configuration): for the preview half, "off" means "not installed".
+
+The source-view half is a "highlight.regexes" block in the workspace's
+.vscode/settings.json, delimited by marker comments that `bunnyforge init`
+ships (inert) since #34. Python has no stdlib JSONC round-tripper and the
+file's comments carry real documentation, so this module never parses the
+file as JSON: it rewrites lines between the markers and refuses when the
+markers are missing where required, or unbalanced anywhere.
+
+Workspace requirements differ per subcommand (the first command in the
+package where that is true): install/update/uninstall act on the machine's
+editor and never resolve a workspace; on/off always do; status and setup
+resolve one opportunistically and say plainly when there is none.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from typing import NamedTuple
+
+from bunnyforge import _config, _workspace, init
+
+
+class VscodeError(Exception):
+    """The command cannot proceed. The message is user-facing."""
+
+
+# The extension and its pinned source. Never read from config: this module
+# downloads and installs code, so the source is a constant an auditor can
+# read, not a value a workspace can redirect.
+EXTENSION_ID = "dcltdw.bunnyforge-visibility-preview"
+EXTENSION_REPO = "dcltdw/bunnyforge-visibility-preview"
+RELEASES_URL = ("https://api.github.com/repos/"
+                + EXTENSION_REPO + "/releases/latest")
+HIGHLIGHT_ID = "fabiospampinato.vscode-highlight"
+
+# The managed-region contract, frozen by #34: data/vscode/settings.json
+# ships these exact marker lines, and the disabled form of a line is
+# indent + OFF_PREFIX + body. tests/test_vscode.py pins the packaged file
+# to these constants so neither can drift alone.
+MARKER_BEGIN = "// bunnyforge:begin visibility-colouring"
+MARKER_END = "// bunnyforge:end visibility-colouring"
+OFF_PREFIX = "//- "
+
+SETTINGS_REL = ".vscode/settings.json"
+TIMEOUT = 10  # seconds, every network call
+```
+
+- [ ] **Step 5: Run the first test**
+
+Run: `python3 -m unittest tests.test_vscode.TestPackagedContract.test_the_packaged_markers_match_the_constants -v`
+Expected: PASS (the round-trip test still errors until Task 2 — fine).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: vscode module skeleton and the packaged-contract constants (#33)"
+```
+
+---
+
+### Task 2: The marker-region engine
+
+**Files:**
+- Modify: `src/bunnyforge/vscode.py`
+- Test: `tests/test_vscode.py`
+
+**Interfaces:**
+- Produces:
+  - `maybe_region(lines: list[str]) -> tuple[int, int] | None` — begin/end
+    marker line indices; `None` when *neither* marker exists; `VscodeError`
+    when markers are duplicated, lone, or out of order.
+  - `region_state(lines, begin, end) -> str` — `"off"` (any `OFF_PREFIX`
+    line), else `"on"` (any live line), else `"empty"`.
+  - `enable_region(lines, begin, end) -> list[str]` /
+    `disable_region(lines, begin, end) -> list[str]` — pure, non-mutating.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_vscode.py`:
+
+```python
+SAMPLE_OFF = """\
+{
+  // prose above the marker — never load-bearing
+  // bunnyforge:begin visibility-colouring
+  //- "highlight.regexes": {
+    //- "^x$": { "a": 1 }
+  //- },
+  // ── ALTERNATE ──
+  // "highlight.regexes": { "alt": true }
+  // bunnyforge:end visibility-colouring
+  "markdown.preview.frontMatter": "table"
+}
+""".split("\n")
+
+
+class TestRegionEngine(unittest.TestCase):
+
+    def test_finds_the_marker_pair(self):
+        self.assertEqual(vscode.maybe_region(SAMPLE_OFF), (2, 8))
+
+    def test_no_markers_at_all_is_none_not_an_error(self):
+        self.assertIsNone(vscode.maybe_region(["{", "}"]))
+
+    def test_a_lone_or_duplicated_marker_is_a_refusal(self):
+        lone = [l for l in SAMPLE_OFF if l.strip() != vscode.MARKER_END]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.maybe_region(lone)
+        doubled = SAMPLE_OFF + ["  " + vscode.MARKER_BEGIN]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.maybe_region(doubled)
+
+    def test_end_before_begin_is_a_refusal(self):
+        swapped = ["  " + vscode.MARKER_END, "x", "  " + vscode.MARKER_BEGIN]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.maybe_region(swapped)
+
+    def test_state_off_then_on(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        self.assertEqual(vscode.region_state(SAMPLE_OFF, begin, end), "off")
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(vscode.region_state(on, begin, end), "on")
+
+    def test_enable_preserves_indentation_and_plain_comments(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(on[3], '  "highlight.regexes": {')
+        self.assertEqual(on[4], '    "^x$": { "a": 1 }')
+        self.assertEqual(on[6], "  // ── ALTERNATE ──")   # untouched
+        self.assertEqual(on[7], '  // "highlight.regexes": { "alt": true }')
+        self.assertEqual(on[9], '  "markdown.preview.frontMatter": "table"')
+
+    def test_disable_prefixes_only_live_lines(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(vscode.disable_region(on, begin, end), SAMPLE_OFF)
+
+    def test_both_transforms_are_idempotent(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        off2 = vscode.disable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(off2, SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(vscode.enable_region(on, begin, end), on)
+
+    def test_transforms_do_not_mutate_their_input(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        copy = list(SAMPLE_OFF)
+        vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(SAMPLE_OFF, copy)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m unittest tests.test_vscode.TestRegionEngine -v`
+Expected: ERROR — names not defined.
+
+- [ ] **Step 3: Implement**
+
+Append to `src/bunnyforge/vscode.py`:
+
+```python
+# ── The marker-region engine ────────────────────────────────────────────
+# Pure text -> text. State is always DERIVED from the region's content,
+# never stored anywhere it could disagree with reality.
+
+def _split_indent(line: str) -> tuple[str, str]:
+    body = line.lstrip(" \t")
+    return line[:len(line) - len(body)], body
+
+
+def maybe_region(lines: list[str]) -> tuple[int, int] | None:
+    """The (begin, end) marker line indices, or None when neither marker
+    exists (the create-the-block case). A lone, duplicated, or reversed
+    marker raises: rewriting between markers that cannot be trusted would
+    destroy a file the user hand-edited, so refuse and say why.
+    """
+    begins = [i for i, l in enumerate(lines) if l.strip() == MARKER_BEGIN]
+    ends = [i for i, l in enumerate(lines) if l.strip() == MARKER_END]
+    if not begins and not ends:
+        return None
+    if len(begins) != 1 or len(ends) != 1 or ends[0] < begins[0]:
+        raise VscodeError(
+            f"the managed markers in {SETTINGS_REL} are unbalanced "
+            f"({len(begins)} begin, {len(ends)} end) — refusing to guess "
+            f"which lines are managed; restore the single marker pair by "
+            f"hand, then re-run")
+    return begins[0], ends[0]
+
+
+def region_state(lines: list[str], begin: int, end: int) -> str:
+    """"off" outranks "on": a region holding both disabled and live lines
+    was hand-mangled, and reporting it off lets `on` heal it (enabling
+    strips every prefix, converging the region to fully live)."""
+    live = False
+    for line in lines[begin + 1:end]:
+        body = line.strip()
+        if body.startswith(OFF_PREFIX):
+            return "off"
+        if body and not body.startswith("//"):
+            live = True
+    return "on" if live else "empty"
+
+
+def enable_region(lines: list[str], begin: int, end: int) -> list[str]:
+    out = list(lines)
+    for i in range(begin + 1, end):
+        indent, body = _split_indent(out[i])
+        if body.startswith(OFF_PREFIX):
+            out[i] = indent + body[len(OFF_PREFIX):]
+    return out
+
+
+def disable_region(lines: list[str], begin: int, end: int) -> list[str]:
+    out = list(lines)
+    for i in range(begin + 1, end):
+        indent, body = _split_indent(out[i])
+        if body and not body.startswith("//"):
+            out[i] = indent + OFF_PREFIX + body
+    return out
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `python3 -m unittest tests.test_vscode -v`
+Expected: PASS — including Task 1's round-trip contract test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: marker-region engine — find, state, enable, disable (#33)"
+```
+
+---
+
+### Task 3: Structural edits — create, adopt, replace
+
+**Files:**
+- Modify: `src/bunnyforge/vscode.py`
+- Test: `tests/test_vscode.py`
+
+**Interfaces:**
+- Consumes: Task 2's engine; `init.packaged_bytes("vscode/settings.json")`.
+- Produces:
+  - `key_span(lines, start: int) -> int` — last line index of the value
+    opened on `lines[start]`; `VscodeError` if braces never balance.
+  - `find_unmanaged_key(lines, region: tuple[int, int] | None) -> int | None`
+    — line index of a live top-level `"highlight.regexes"` outside `region`.
+  - `packaged_region_lines() -> list[str]` — markers inclusive, from the
+    packaged settings file.
+  - `splice_region(lines) -> list[str]` — insert the packaged region before
+    the final `}`, comma-fixing the preceding property (the one sanctioned
+    outside-the-markers edit).
+  - `adopt_key(lines, key_idx: int) -> list[str]` — bracket the minimum span
+    (key line through closing brace) with the markers.
+  - `replace_region(lines, begin, end) -> list[str]` — region content :=
+    packaged region content.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+UNMANAGED = """\
+{
+  "editor.rulers": [80],
+  "highlight.regexes": {
+    "^(## GM notes{2}\\\\s*)$": {
+      "decorations": [{ "quote": "}" }]
+    }
+  },
+  "markdown.preview.frontMatter": "table"
+}
+""".split("\n")
+
+
+class TestStructuralEdits(unittest.TestCase):
+
+    def test_key_span_ignores_braces_in_strings_and_comments(self):
+        # The value spans lines 2..6; "{2}" and the "}" string literal and
+        # any // comment must not confuse the scan.
+        self.assertEqual(vscode.key_span(UNMANAGED, 2), 6)
+
+    def test_key_span_on_a_single_line_value(self):
+        doc = ['{', '  "highlight.regexes": {},', '}']
+        self.assertEqual(vscode.key_span(doc, 1), 1)
+
+    def test_key_span_refuses_unbalanced_braces(self):
+        with self.assertRaises(vscode.VscodeError):
+            vscode.key_span(['{', '  "highlight.regexes": {', ''], 1)
+
+    def test_finds_the_unmanaged_key_and_skips_comments(self):
+        self.assertEqual(vscode.find_unmanaged_key(UNMANAGED, None), 2)
+        commented = ['{', '  // "highlight.regexes": {}', '}']
+        self.assertIsNone(vscode.find_unmanaged_key(commented, None))
+
+    def test_the_managed_region_is_not_reported_as_unmanaged(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertIsNone(vscode.find_unmanaged_key(on, (begin, end)))
+
+    def test_packaged_region_lines_are_marker_delimited(self):
+        region = vscode.packaged_region_lines()
+        self.assertEqual(region[0].strip(), vscode.MARKER_BEGIN)
+        self.assertEqual(region[-1].strip(), vscode.MARKER_END)
+
+    def test_splice_adds_the_region_and_a_comma(self):
+        doc = ['{', '  // a comment', '  "editor.rulers": [80]', '}', '']
+        out = vscode.splice_region(doc)
+        self.assertEqual(out[2], '  "editor.rulers": [80],')
+        begin, end = vscode.maybe_region(out)
+        self.assertEqual(out[-2].strip(), "}")
+        # enabled result must be strict JSON once comments drop
+        enabled = vscode.enable_region(out, begin, end)
+        data = json.loads("\n".join(
+            l for l in enabled if not l.strip().startswith("//")))
+        self.assertIn("highlight.regexes", data)
+        self.assertEqual(data["editor.rulers"], [80])
+
+    def test_splice_into_an_empty_object_needs_no_comma(self):
+        out = vscode.splice_region(['{', '}'])
+        begin, end = vscode.maybe_region(out)
+        enabled = vscode.enable_region(out, begin, end)
+        json.loads("\n".join(
+            l for l in enabled if not l.strip().startswith("//")))
+
+    def test_splice_refuses_a_file_with_no_closing_brace(self):
+        with self.assertRaises(vscode.VscodeError):
+            vscode.splice_region(['not a settings object'])
+
+    def test_adopt_brackets_the_minimum_span(self):
+        out = vscode.adopt_key(UNMANAGED, 2)
+        begin, end = vscode.maybe_region(out)
+        self.assertEqual(out[begin].strip(), vscode.MARKER_BEGIN)
+        self.assertEqual(out[begin + 1], UNMANAGED[2])   # content untouched
+        self.assertEqual(out[end - 1], UNMANAGED[6])
+        self.assertEqual(vscode.region_state(out, begin, end), "on")
+        # everything outside the span is byte-identical
+        self.assertEqual(out[:begin], UNMANAGED[:2])
+        self.assertEqual(out[end + 1:], UNMANAGED[7:])
+
+    def test_replace_swaps_region_content_for_packaged(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        out = vscode.replace_region(SAMPLE_OFF, begin, end)
+        nbegin, nend = vscode.maybe_region(out)
+        self.assertEqual(out[nbegin:nend + 1], vscode.packaged_region_lines())
+        self.assertEqual(out[:nbegin], SAMPLE_OFF[:begin])   # outside kept
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m unittest tests.test_vscode.TestStructuralEdits -v`
+Expected: ERROR — names not defined.
+
+- [ ] **Step 3: Implement**
+
+```python
+# ── Structural edits: create, adopt, replace ────────────────────────────
+
+def key_span(lines: list[str], start: int) -> int:
+    """Last line index of the JSON value opened on lines[start].
+
+    A character scan tracking string state (so braces inside regex keys
+    and string values don't count) and line comments, balancing {}/[].
+    """
+    depth = 0
+    opened = False
+    for i in range(start, len(lines)):
+        line = lines[i]
+        in_string = False
+        j = 0
+        while j < len(line):
+            ch = line[j]
+            if in_string:
+                if ch == "\\":
+                    j += 1
+                elif ch == '"':
+                    in_string = False
+            elif ch == '"':
+                in_string = True
+            elif line[j:j + 2] == "//":
+                break
+            elif ch in "{[":
+                depth += 1
+                opened = True
+            elif ch in "}]":
+                depth -= 1
+            j += 1
+        if opened and depth <= 0:
+            return i
+    raise VscodeError(
+        f'the "highlight.regexes" value in {SETTINGS_REL} never closes '
+        f"its braces — fix the file by hand, then re-run")
+
+
+def find_unmanaged_key(lines: list[str],
+                       region: tuple[int, int] | None) -> int | None:
+    """A live top-level "highlight.regexes" outside the managed region —
+    the duplicate-key hazard: appending a second copy would be a silent
+    last-one-wins that clobbers whatever the user tuned."""
+    for i, line in enumerate(lines):
+        if region and region[0] <= i <= region[1]:
+            continue
+        if line.strip().startswith('"highlight.regexes"'):
+            return i
+    return None
+
+
+def packaged_region_lines() -> list[str]:
+    lines = (init.packaged_bytes("vscode/settings.json")
+             .decode("utf-8").split("\n"))
+    begin, end = maybe_region(lines)  # never None: the drift test pins it
+    return lines[begin:end + 1]
+
+
+def splice_region(lines: list[str]) -> list[str]:
+    """Insert the packaged managed region before the final closing brace.
+
+    The comma appended to the preceding property is the one sanctioned
+    edit outside the markers, and it happens only here, at creation.
+    """
+    close = next((i for i in range(len(lines) - 1, -1, -1)
+                  if lines[i].strip() == "}"), None)
+    if close is None:
+        raise VscodeError(
+            f"{SETTINGS_REL} does not end with a closing brace — not a "
+            f"settings object this tool can edit; fix or remove the file, "
+            f"then re-run")
+    out = list(lines)
+    last = next((i for i in range(close - 1, -1, -1)
+                 if out[i].strip() and not out[i].strip().startswith("//")),
+                None)
+    if last is not None and not out[last].rstrip().endswith(("{", ",")):
+        out[last] = out[last].rstrip() + ","
+    return out[:close] + packaged_region_lines() + out[close:]
+
+
+def adopt_key(lines: list[str], key_idx: int) -> list[str]:
+    """Bracket the existing rules with the markers, content untouched —
+    the minimum span, key line through its closing brace. Nearby
+    commented-out blocks stay outside: they are comments, and `off` never
+    needs to touch them."""
+    end = key_span(lines, key_idx)
+    indent = _split_indent(lines[key_idx])[0]
+    out = list(lines)
+    out.insert(end + 1, indent + MARKER_END)
+    out.insert(key_idx, indent + MARKER_BEGIN)
+    return out
+
+
+def replace_region(lines: list[str], begin: int, end: int) -> list[str]:
+    return lines[:begin] + packaged_region_lines() + lines[end + 1:]
+```
+
+- [ ] **Step 4: Run to verify green, then commit**
+
+Run: `python3 -m unittest tests.test_vscode -v` — Expected: PASS.
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: managed-block create, adopt, and replace edits (#33)"
+```
+
+---
+
+### Task 4: Editor discovery and version handling
+
+**Files:**
+- Modify: `src/bunnyforge/vscode.py`
+- Test: `tests/test_vscode.py`
+
+**Interfaces:**
+- Produces:
+  - `class Editor(NamedTuple): cli_id: str; label: str; path: str;
+    supported: bool`
+  - `discover_editors(which=shutil.which, platform=sys.platform,
+    exists=<Path.is_file>) -> list[Editor]`
+  - `pick_editor(editors: list[Editor], wanted: str | None) -> Editor`
+  - `parse_version(text: str) -> tuple[int, ...]`
+  - `installed_version(editor: Editor, extension_id: str = EXTENSION_ID)
+    -> tuple[int, ...] | None`
+  - `_run(argv: list[str]) -> subprocess.CompletedProcess` (the subprocess
+    seam every test mocks), `_interactive() -> bool`, `_ask(prompt) -> str`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def _proc(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+class TestEditorDiscovery(unittest.TestCase):
+
+    def test_finds_editors_on_path_in_stable_first_order(self):
+        which = {"code": "/usr/bin/code", "cursor": "/usr/bin/cursor"}.get
+        found = vscode.discover_editors(which=which, platform="linux")
+        self.assertEqual([(e.cli_id, e.supported) for e in found],
+                         [("code", True), ("cursor", False)])
+
+    def test_falls_back_to_the_mac_app_bundle(self):
+        mac = ("/Applications/Visual Studio Code.app/Contents/Resources"
+               "/app/bin/code")
+        found = vscode.discover_editors(
+            which=lambda _: None, platform="darwin",
+            exists=lambda p: p == mac)
+        self.assertEqual([e.path for e in found], [mac])
+
+    def test_pick_honours_the_flag_and_rejects_unknown(self):
+        editors = [vscode.Editor("code", "Visual Studio Code",
+                                 "/usr/bin/code", True)]
+        self.assertEqual(vscode.pick_editor(editors, "code"), editors[0])
+        with self.assertRaises(vscode.VscodeError):
+            vscode.pick_editor(editors, "codium")
+
+    def test_pick_with_none_found_names_the_command_palette(self):
+        with self.assertRaises(vscode.VscodeError) as ctx:
+            vscode.pick_editor([], None)
+        self.assertIn("Shell Command", str(ctx.exception))
+
+    def test_pick_defaults_to_stable_without_a_tty(self):
+        editors = [
+            vscode.Editor("code", "Visual Studio Code", "/u/code", True),
+            vscode.Editor("cursor", "Cursor", "/u/cursor", False),
+        ]
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            self.assertEqual(vscode.pick_editor(editors, None).cli_id, "code")
+
+    def test_pick_without_stable_and_no_tty_names_the_flag(self):
+        editors = [vscode.Editor("cursor", "Cursor", "/u/cursor", False),
+                   vscode.Editor("codium", "VSCodium", "/u/codium", False)]
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            with self.assertRaises(vscode.VscodeError) as ctx:
+                vscode.pick_editor(editors, None)
+        self.assertIn("--editor", str(ctx.exception))
+
+
+class TestVersions(unittest.TestCase):
+
+    def test_parse_version_accepts_v_prefix(self):
+        self.assertEqual(vscode.parse_version("v0.1.0"), (0, 1, 0))
+        self.assertEqual(vscode.parse_version("0.10.2"), (0, 10, 2))
+
+    def test_parse_version_refuses_garbage(self):
+        with self.assertRaises(vscode.VscodeError):
+            vscode.parse_version("latest")
+
+    def test_installed_version_parses_the_listing(self):
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        listing = ("other.extension@9.9.9\n"
+                   "dcltdw.bunnyforge-visibility-preview@0.1.0\n")
+        with mock.patch.object(vscode, "_run",
+                               return_value=_proc(listing)) as run:
+            self.assertEqual(vscode.installed_version(editor), (0, 1, 0))
+        run.assert_called_once_with(
+            ["/u/code", "--list-extensions", "--show-versions"])
+
+    def test_installed_version_none_when_absent(self):
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        with mock.patch.object(vscode, "_run", return_value=_proc("a@1\n")):
+            self.assertIsNone(vscode.installed_version(editor))
+
+    def test_installed_version_surfaces_a_failing_cli(self):
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        with mock.patch.object(vscode, "_run",
+                               return_value=_proc("", 1, "boom")):
+            with self.assertRaises(vscode.VscodeError):
+                vscode.installed_version(editor)
+```
+
+- [ ] **Step 2: Run to verify failure**, then **Step 3: Implement**
+
+```python
+# ── Editors ─────────────────────────────────────────────────────────────
+# Stable first: it is the tested editor and every default resolves to it.
+# The rest are offered because sideloading a .vsix is exactly how the
+# non-Marketplace editors install things (decision 3) — but they are
+# untested, and every mention of them says so.
+_EDITORS = (
+    ("code", "Visual Studio Code", True),
+    ("code-insiders", "VS Code Insiders", False),
+    ("codium", "VSCodium", False),
+    ("cursor", "Cursor", False),
+)
+
+# PATH is searched first everywhere; these app-bundle paths cover the one
+# platform whose installer does NOT put the CLI on PATH (macOS — the
+# machine this was developed on had `which code` fail with the binary at
+# this exact path). Windows and Linux installers put the CLI on PATH by
+# default, so PATH is their discovery.
+_MAC_APPS = {
+    "code": ("/Applications/Visual Studio Code.app"
+             "/Contents/Resources/app/bin/code"),
+    "code-insiders": ("/Applications/Visual Studio Code - Insiders.app"
+                      "/Contents/Resources/app/bin/code-insiders"),
+    "codium": "/Applications/VSCodium.app/Contents/Resources/app/bin/codium",
+    "cursor": "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+}
+
+
+class Editor(NamedTuple):
+    cli_id: str
+    label: str
+    path: str
+    supported: bool
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def _interactive() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _ask(prompt: str) -> str:
+    return input(prompt)
+
+
+def discover_editors(which=shutil.which, platform=sys.platform,
+                     exists=lambda p: Path(p).is_file()) -> list[Editor]:
+    found = []
+    for cli_id, label, supported in _EDITORS:
+        path = which(cli_id)
+        if path is None and platform == "darwin" and exists(_MAC_APPS[cli_id]):
+            path = _MAC_APPS[cli_id]
+        if path:
+            found.append(Editor(cli_id, label, path, supported))
+    return found
+
+
+def pick_editor(editors: list[Editor], wanted: str | None) -> Editor:
+    if wanted:
+        match = next((e for e in editors if e.cli_id == wanted), None)
+        if match is None:
+            raise VscodeError(
+                f"--editor {wanted}: not found (found: "
+                f"{', '.join(e.cli_id for e in editors) or 'none'})")
+        return match
+    if not editors:
+        raise VscodeError(
+            "no editor CLI found on PATH or in known locations — in VS "
+            "Code, run \"Shell Command: Install 'code' command in PATH\" "
+            "from the Command Palette, then re-run")
+    if len(editors) == 1:
+        return editors[0]
+    stable = next((e for e in editors if e.cli_id == "code"), None)
+    if not _interactive():
+        if stable:
+            return stable
+        raise VscodeError(
+            "several editors found and no terminal to ask — pass "
+            "--editor " + "|".join(e.cli_id for e in editors))
+    print("several editors found:")
+    for n, e in enumerate(editors, 1):
+        note = "" if e.supported else "  (untested — may have bugs)"
+        print(f"  [{n}] {e.label}{note}")
+    default = editors.index(stable) + 1 if stable else 1
+    answer = _ask(f"install into [{default}]: ").strip()
+    if answer.isdigit() and 1 <= int(answer) <= len(editors):
+        return editors[int(answer) - 1]
+    return editors[default - 1]
+
+
+# ── Versions ────────────────────────────────────────────────────────────
+
+def parse_version(text: str) -> tuple[int, ...]:
+    body = text.strip().removeprefix("v")
+    try:
+        return tuple(int(part) for part in body.split("."))
+    except ValueError:
+        raise VscodeError(f"unparseable version {text!r}") from None
+
+
+def installed_version(editor: Editor,
+                      extension_id: str = EXTENSION_ID
+                      ) -> tuple[int, ...] | None:
+    proc = _run([editor.path, "--list-extensions", "--show-versions"])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --list-extensions failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    for line in proc.stdout.splitlines():
+        name, _, version = line.partition("@")
+        if name.strip().lower() == extension_id:
+            return parse_version(version)
+    return None
+```
+
+- [ ] **Step 4: Run to verify green, then commit**
+
+Run: `python3 -m unittest tests.test_vscode -v` — Expected: PASS.
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: editor discovery and installed-version detection (#33)"
+```
+
+---
+
+### Task 5: Release client, cache, and verified download
+
+**Files:**
+- Modify: `src/bunnyforge/vscode.py`
+- Test: `tests/test_vscode.py`
+
+**Interfaces:**
+- Produces:
+  - `class Release(NamedTuple): version: tuple[int, ...]; tag: str;
+    vsix_name: str; url: str; size: int; sha256: str | None`
+  - `_fetch(url: str) -> bytes` (the network seam; urllib +
+    `User-Agent: bunnyforge`, `TIMEOUT`)
+  - `latest_release(fetch=_fetch) -> Release` — `VscodeError` with an
+    offline-flavoured message on any `OSError`.
+  - `cache_dir(platform=sys.platform, environ=os.environ) -> Path`
+  - `obtain_vsix(release: Release, fetch=_fetch) -> Path` — cache hit
+    (verified) or download+verify+store; never returns an unverified file.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+RELEASE_JSON = json.dumps({
+    "tag_name": "v0.2.0",
+    "assets": [
+        {"name": "notes.txt", "browser_download_url": "u1", "size": 1},
+        {"name": "bunnyforge-visibility-preview-0.2.0.vsix",
+         "browser_download_url": "https://example.invalid/x.vsix",
+         "size": 4,
+         "digest": "sha256:" + __import__("hashlib")
+             .sha256(b"vsix").hexdigest()},
+    ],
+}).encode("utf-8")
+
+
+class TestReleaseClient(unittest.TestCase):
+
+    def test_parses_tag_asset_size_and_digest(self):
+        release = vscode.latest_release(fetch=lambda url: RELEASE_JSON)
+        self.assertEqual(release.version, (0, 2, 0))
+        self.assertEqual(release.tag, "v0.2.0")
+        self.assertEqual(release.vsix_name,
+                         "bunnyforge-visibility-preview-0.2.0.vsix")
+        self.assertEqual(release.size, 4)
+        self.assertEqual(len(release.sha256), 64)
+
+    def test_a_missing_digest_is_tolerated(self):
+        data = json.loads(RELEASE_JSON)
+        del data["assets"][1]["digest"]
+        release = vscode.latest_release(
+            fetch=lambda url: json.dumps(data).encode())
+        self.assertIsNone(release.sha256)
+
+    def test_no_vsix_asset_is_an_error(self):
+        data = json.loads(RELEASE_JSON)
+        data["assets"] = data["assets"][:1]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.latest_release(fetch=lambda url: json.dumps(data).encode())
+
+    def test_network_failure_degrades_to_a_named_error(self):
+        def down(url):
+            raise OSError("no route to host")
+        with self.assertRaises(vscode.VscodeError) as ctx:
+            vscode.latest_release(fetch=down)
+        self.assertIn("GitHub", str(ctx.exception))
+
+
+class TestCache(unittest.TestCase):
+
+    def test_cache_dir_per_platform(self):
+        home = Path.home()
+        self.assertEqual(
+            vscode.cache_dir(platform="darwin", environ={}),
+            home / "Library" / "Caches" / "bunnyforge" / "vsix")
+        self.assertEqual(
+            vscode.cache_dir(platform="linux",
+                             environ={"XDG_CACHE_HOME": "/xdg"}),
+            Path("/xdg") / "bunnyforge" / "vsix")
+        self.assertEqual(
+            vscode.cache_dir(platform="linux", environ={}),
+            home / ".cache" / "bunnyforge" / "vsix")
+        self.assertEqual(
+            vscode.cache_dir(platform="win32",
+                             environ={"LOCALAPPDATA": r"C:\U\l"}),
+            Path(r"C:\U\l") / "bunnyforge" / "vsix")
+
+    def _release(self):
+        return vscode.latest_release(fetch=lambda url: RELEASE_JSON)
+
+    def test_downloads_verifies_and_caches(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        calls = []
+
+        def fetch(url):
+            calls.append(url)
+            return b"vsix"
+
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            path = vscode.obtain_vsix(self._release(), fetch=fetch)
+            self.assertEqual(path.read_bytes(), b"vsix")
+            # second run: cache hit, no re-download
+            vscode.obtain_vsix(self._release(), fetch=fetch)
+        self.assertEqual(calls, ["https://example.invalid/x.vsix"])
+
+    def test_a_truncated_download_never_lands_in_the_cache(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            with self.assertRaises(vscode.VscodeError):
+                vscode.obtain_vsix(self._release(), fetch=lambda url: b"vs")
+        self.assertEqual(list(tmp.iterdir()), [])
+
+    def test_a_digest_mismatch_never_lands_in_the_cache(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            with self.assertRaises(vscode.VscodeError):
+                vscode.obtain_vsix(self._release(), fetch=lambda url: b"eviL")
+        self.assertEqual(list(tmp.iterdir()), [])
+
+    def test_a_corrupt_cached_file_is_re_downloaded(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        release = self._release()
+        stale = tmp / f"{release.tag}-{release.vsix_name}"
+        stale.write_bytes(b"junk-of-wrong-size")
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            path = vscode.obtain_vsix(release, fetch=lambda url: b"vsix")
+        self.assertEqual(path.read_bytes(), b"vsix")
+```
+
+- [ ] **Step 2: Run to verify failure**, then **Step 3: Implement**
+
+```python
+# ── The release feed and the .vsix cache ────────────────────────────────
+
+class Release(NamedTuple):
+    version: tuple[int, ...]
+    tag: str
+    vsix_name: str
+    url: str
+    size: int
+    sha256: str | None      # release assets predating GitHub digests: None
+
+
+def _fetch(url: str) -> bytes:
+    request = urllib.request.Request(url, headers={
+        "User-Agent": "bunnyforge",
+        "Accept": "application/vnd.github+json",
+    })
+    with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+        return response.read()
+
+
+def latest_release(fetch=_fetch) -> Release:
+    """The newest release (decision 2: no pinning) from the pinned repo.
+
+    Unauthenticated: 60 requests/hour is ample for a human-driven command,
+    but offline or rate-limited must degrade to a clear error the caller
+    can choose to swallow (status) or surface (install)."""
+    try:
+        raw = fetch(RELEASES_URL)
+    except OSError as exc:
+        raise VscodeError(
+            f"couldn't reach GitHub for the latest release ({exc}) — "
+            f"check the network and retry") from exc
+    data = json.loads(raw)
+    asset = next((a for a in data.get("assets", [])
+                  if a.get("name", "").endswith(".vsix")), None)
+    if asset is None:
+        raise VscodeError(
+            f"release {data.get('tag_name', '?')} of {EXTENSION_REPO} has "
+            f"no .vsix asset — report it at "
+            f"https://github.com/{EXTENSION_REPO}/issues")
+    digest = asset.get("digest") or ""
+    return Release(
+        version=parse_version(data["tag_name"]),
+        tag=data["tag_name"],
+        vsix_name=asset["name"],
+        url=asset["browser_download_url"],
+        size=asset["size"],
+        sha256=digest.removeprefix("sha256:") if digest.startswith("sha256:")
+               else None)
+
+
+def cache_dir(platform=sys.platform, environ=os.environ) -> Path:
+    if platform == "darwin":
+        base = Path.home() / "Library" / "Caches"
+    elif platform.startswith("win"):
+        base = Path(environ.get("LOCALAPPDATA")
+                    or Path.home() / "AppData" / "Local")
+    else:
+        base = Path(environ.get("XDG_CACHE_HOME")
+                    or Path.home() / ".cache")
+    return base / "bunnyforge" / "vsix"
+
+
+def _matches(data: bytes, release: Release) -> bool:
+    if len(data) != release.size:
+        return False
+    if release.sha256 is None:
+        return True
+    return hashlib.sha256(data).hexdigest() == release.sha256
+
+
+def obtain_vsix(release: Release, fetch=_fetch) -> Path:
+    """A verified .vsix on disk: the cache if it checks out, else a fresh
+    download — verified BEFORE it lands in the cache, so a truncated or
+    tampered file is never present to be installed later."""
+    dest = cache_dir() / f"{release.tag}-{release.vsix_name}"
+    if dest.is_file() and _matches(dest.read_bytes(), release):
+        return dest
+    try:
+        data = fetch(release.url)
+    except OSError as exc:
+        raise VscodeError(
+            f"downloading {release.vsix_name} failed ({exc}) — check the "
+            f"network and retry") from exc
+    if len(data) != release.size:
+        raise VscodeError(
+            f"download of {release.vsix_name} is {len(data)} bytes; the "
+            f"release says {release.size} — truncated, not installing")
+    if release.sha256 and hashlib.sha256(data).hexdigest() != release.sha256:
+        raise VscodeError(
+            f"download of {release.vsix_name} does not match the release "
+            f"digest — not installing")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+    return dest
+```
+
+- [ ] **Step 4: Run to verify green, then commit**
+
+Run: `python3 -m unittest tests.test_vscode -v` — Expected: PASS.
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: pinned release client and digest-verified vsix cache (#33)"
+```
+
+---
+
+### Task 6: The machine-half subcommands and the argparse front door
+
+**Files:**
+- Modify: `src/bunnyforge/vscode.py`
+- Test: `tests/test_vscode.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `main(argv: list[str] | None = None) -> int`; `_parser()`;
+  `_confirm(question: str, assume_yes: bool) -> bool`;
+  `cmd_status`, `cmd_install`, `cmd_update`, `cmd_uninstall` (each
+  `(args) -> int`); `_dotted(version: tuple[int, ...]) -> str`.
+  Subcommand grammar (also consumed by Task 7):
+  `status|setup|on [--workspace] [--editor] [--yes] [--adopt|--replace]`,
+  `off [--workspace]`, `install|update|uninstall [--editor] [--yes]`
+  (`status` takes `--workspace`/`--editor` but not `--yes`; `on` and
+  `setup` take all five; exact wiring in the code below).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def _machine_env(case, installed=None, listing=""):
+    """Patch discovery + subprocess + network for machine-half tests.
+    Returns the mock recording _run calls."""
+    editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+    case.enterContext(mock.patch.object(
+        vscode, "discover_editors", return_value=[editor]))
+    shown = (f"{vscode.EXTENSION_ID}@{installed}\n" if installed else "")
+    run = case.enterContext(mock.patch.object(
+        vscode, "_run",
+        return_value=_proc(shown + listing)))
+    case.enterContext(mock.patch.object(
+        vscode, "latest_release",
+        return_value=vscode.latest_release(fetch=lambda url: RELEASE_JSON)))
+    tmp = Path(case.enterContext(tempfile.TemporaryDirectory()))
+    case.enterContext(mock.patch.object(
+        vscode, "obtain_vsix",
+        return_value=tmp / "v0.2.0-x.vsix"))
+    return run
+
+
+class TestInstallUpdate(unittest.TestCase):
+
+    def test_install_refuses_without_yes_when_not_a_tty(self):
+        _machine_env(self)
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            with contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(io.StringIO()) as err:
+                rc = vscode.main(["install"])
+        self.assertEqual(rc, 1)
+        self.assertIn("--yes", err.getvalue())
+
+    def test_install_prints_provenance_and_installs(self):
+        run = _machine_env(self)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["install", "--yes"])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn(vscode.EXTENSION_REPO, text)   # pinned source, shown
+        self.assertIn("v0.2.0", text)
+        install_call = run.call_args_list[-1].args[0]
+        self.assertEqual(install_call[:2], ["/u/code", "--install-extension"])
+        self.assertIn("--force", install_call)
+
+    def test_install_is_idempotent_at_the_current_version(self):
+        run = _machine_env(self, installed="0.2.0")
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["install", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to do", out.getvalue())
+        for call in run.call_args_list:
+            self.assertNotIn("--install-extension", call.args[0])
+
+    def test_update_requires_an_existing_install(self):
+        _machine_env(self)   # nothing installed
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["update", "--yes"])
+        self.assertEqual(rc, 1)
+        self.assertIn("vscode install", err.getvalue())
+
+    def test_update_upgrades_an_older_install(self):
+        run = _machine_env(self, installed="0.1.0")
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["update", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("--install-extension",
+                      run.call_args_list[-1].args[0])
+
+
+class TestUninstall(unittest.TestCase):
+
+    def test_uninstall_runs_the_editor_cli(self):
+        run = _machine_env(self, installed="0.2.0")
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["uninstall", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(run.call_args_list[-1].args[0],
+                         ["/u/code", "--uninstall-extension",
+                          vscode.EXTENSION_ID])
+
+    def test_uninstall_when_absent_is_a_no_op(self):
+        run = _machine_env(self)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["uninstall", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to do", out.getvalue())
+        for call in run.call_args_list:
+            self.assertNotIn("--uninstall-extension", call.args[0])
+
+
+class TestStatus(unittest.TestCase):
+
+    def test_status_without_a_workspace_says_so_and_exits_zero(self):
+        _machine_env(self, installed="0.1.0")
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("0.1.0", text)          # installed
+        self.assertIn("0.2.0", text)          # available
+        self.assertIn("none found", text)     # the workspace half, plainly
+
+    def test_status_reports_colouring_state_in_a_workspace(self):
+        _machine_env(self, installed="0.2.0")
+        ws = Path(self.enterContext(tempfile.TemporaryDirectory())).resolve()
+        (ws / "campaign.toml").write_text(
+            '[campaign]\nnamespace = "probe"\n', encoding="utf-8")
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_bytes(
+            init.packaged_bytes("vscode/settings.json"))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertIn("off", out.getvalue())
+
+    def test_status_degrades_when_github_is_unreachable(self):
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        self.enterContext(mock.patch.object(vscode, "_run",
+                                            return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "latest_release",
+            side_effect=vscode.VscodeError("couldn't reach GitHub")))
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)               # status reports; never fails
+        self.assertIn("unknown", out.getvalue())
+```
+
+Also add `import os` to the test module's imports.
+
+- [ ] **Step 2: Run to verify failure**, then **Step 3: Implement**
+
+```python
+# ── Confirmation ────────────────────────────────────────────────────────
+
+def _confirm(question: str, assume_yes: bool) -> bool:
+    """The trust gate: this command installs code into the user's editor,
+    so the interactive path confirms and automation opts in explicitly."""
+    if assume_yes:
+        return True
+    if not _interactive():
+        raise VscodeError(
+            "standard input is not a terminal — pass --yes to confirm "
+            "non-interactively")
+    return _ask(f"{question} [y/N] ").strip().lower() in ("y", "yes")
+
+
+def _dotted(version: tuple[int, ...]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+# ── Machine-half subcommands ────────────────────────────────────────────
+
+def cmd_install(args) -> int:
+    return _ensure(args, update_only=False)
+
+
+def cmd_update(args) -> int:
+    return _ensure(args, update_only=True)
+
+
+def _ensure(args, update_only: bool) -> int:
+    editor = pick_editor(discover_editors(), args.editor)
+    installed = installed_version(editor)
+    if update_only and installed is None:
+        raise VscodeError(
+            f"{EXTENSION_ID} is not installed in {editor.label} — run: "
+            f"bunnyforge vscode install")
+    release = latest_release()
+    if installed == release.version:
+        print(f"{EXTENSION_ID} {_dotted(installed)} is current in "
+              f"{editor.label} — nothing to do")
+        return 0
+    if installed and installed > release.version:
+        print(f"installed {_dotted(installed)} is newer than the latest "
+              f"release {release.tag} — nothing to do")
+        return 0
+    vsix = obtain_vsix(release)
+    print(f"about to install {EXTENSION_ID} {release.tag}")
+    print(f"  from  https://github.com/{EXTENSION_REPO} (pinned source)")
+    print(f"  file  {vsix}")
+    print(f"  into  {editor.label} ({editor.path})")
+    if not editor.supported:
+        print("  note  only Visual Studio Code is tested; this editor is "
+              "offered unsupported and may have bugs")
+    if not _confirm("proceed?", args.yes):
+        print("cancelled — nothing installed")
+        return 1
+    proc = _run([editor.path, "--install-extension", str(vsix), "--force"])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --install-extension failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    verb = "updated to" if installed else "installed at"
+    print(f"{EXTENSION_ID} {verb} {release.tag} in {editor.label}")
+    print("note: sideloaded extensions never auto-update — run "
+          "`bunnyforge vscode update` when a release lands")
+    return 0
+
+
+def cmd_uninstall(args) -> int:
+    editor = pick_editor(discover_editors(), args.editor)
+    if installed_version(editor) is None:
+        print(f"{EXTENSION_ID} is not installed in {editor.label} — "
+              f"nothing to do")
+        return 0
+    if not _confirm(f"remove {EXTENSION_ID} from {editor.label}?", args.yes):
+        print("cancelled")
+        return 1
+    proc = _run([editor.path, "--uninstall-extension", EXTENSION_ID])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --uninstall-extension failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    print(f"removed {EXTENSION_ID} from {editor.label}")
+    return 0
+
+
+def _has_extension(editor: Editor, extension_id: str) -> bool:
+    proc = _run([editor.path, "--list-extensions"])
+    return proc.returncode == 0 and extension_id in proc.stdout.split()
+
+
+def cmd_status(args) -> int:
+    # Machine half: unconditional (decision 5).
+    editors = discover_editors()
+    if not editors:
+        print("editor         none found (searched PATH and known "
+              "locations)")
+    else:
+        try:
+            editor = pick_editor(editors, args.editor)
+        except VscodeError:
+            editor = editors[0]
+        print(f"editor         {editor.label} ({editor.path})")
+        installed = installed_version(editor)
+        try:
+            release = latest_release()
+            available = f"{_dotted(release.version)} available"
+        except VscodeError as exc:
+            release = None
+            available = f"latest unknown ({exc})"
+        if installed is None:
+            print(f"preview ext    not installed; {available}")
+        elif release and installed < release.version:
+            print(f"preview ext    {_dotted(installed)} installed; "
+                  f"{available} — run: bunnyforge vscode update")
+        else:
+            print(f"preview ext    {_dotted(installed)} installed; "
+                  f"{available}")
+        if _has_extension(editor, HIGHLIGHT_ID):
+            print("highlight ext  installed")
+        else:
+            print("highlight ext  not installed — source-view rules will "
+                  "not render")
+    # Workspace half: only when one is found; say plainly when not.
+    try:
+        root = _config.resolve_workspace(args.workspace).root
+    except (_config.ConfigError, _workspace.WorkspaceError):
+        print("workspace      none found — `on`/`off` need one")
+        return 0
+    print(f"workspace      {root}")
+    path = root / SETTINGS_REL
+    if not path.is_file():
+        print(f"colouring      no {SETTINGS_REL} — `bunnyforge vscode on` "
+              f"creates it")
+        return 0
+    lines = path.read_text(encoding="utf-8").split("\n")
+    try:
+        region = maybe_region(lines)
+    except VscodeError:
+        print("colouring      managed markers unbalanced — restore the "
+              "marker pair by hand")
+        return 0
+    if region is None:
+        print("colouring      no managed block — `bunnyforge vscode on` "
+              "adds one")
+    else:
+        print(f"colouring      {region_state(lines, *region)}")
+    if not any(l.strip().startswith('"markdown.preview.frontMatter"')
+               for l in lines):
+        print('frontMatter    not pinned — add '
+              '"markdown.preview.frontMatter": "table" so the preview '
+              'renders the table the extension decorates')
+    return 0
+
+
+# ── The front door ──────────────────────────────────────────────────────
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bunnyforge vscode",
+        description=(
+            "Install the bunnyforge-visibility-preview extension and "
+            "toggle the source-view colouring. Subcommands differ in what "
+            "they need: install/update/uninstall act on this machine's "
+            "editor and need no workspace; on/off edit the workspace's "
+            ".vscode/settings.json and require one; status and setup "
+            "cover the workspace half only when a workspace is found."))
+    sub = parser.add_subparsers(dest="subcommand", required=True,
+                                metavar="subcommand")
+
+    def add(name, func, help_text, *, workspace=False, editor=True,
+            yes=True, conflict=False):
+        p = sub.add_parser(name, help=help_text)
+        p.set_defaults(func=func)
+        if workspace:
+            p.add_argument("--workspace", metavar="PATH",
+                           help="campaign workspace (default: search "
+                                "upward from the current directory)")
+        if editor:
+            p.add_argument("--editor", metavar="CLI",
+                           help="editor CLI to target: "
+                                "code|code-insiders|codium|cursor "
+                                "(only code is tested)")
+        if yes:
+            p.add_argument("--yes", action="store_true",
+                           help="answer yes to every confirmation "
+                                "(for automation)")
+        if conflict:
+            group = p.add_mutually_exclusive_group()
+            group.add_argument("--adopt", action="store_true",
+                               help="bring an existing highlight.regexes "
+                                    "under management, content untouched")
+            group.add_argument("--replace", action="store_true",
+                               help="reset the managed block to the "
+                                    "packaged rules, discarding tuning")
+        return p
+
+    add("status", cmd_status, "report both halves and their versions",
+        workspace=True, yes=False)
+    add("setup", cmd_setup, "install or update, then offer to turn "
+        "colouring on", workspace=True, conflict=True)
+    add("install", cmd_install, "install the preview extension into the "
+        "editor")
+    add("update", cmd_update, "update an installed preview extension")
+    add("uninstall", cmd_uninstall, "remove the preview extension — the "
+        "only real off for the preview half")
+    add("on", cmd_on, "enable source-view colouring in the workspace",
+        workspace=True, conflict=True)
+    add("off", cmd_off, "disable source-view colouring in the workspace",
+        workspace=True, editor=False, yes=False)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except (VscodeError, _config.ConfigError,
+            _workspace.WorkspaceError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BrokenPipeError:
+        sys.stderr.close()
+        raise SystemExit(0)
+```
+
+`cmd_setup`, `cmd_on`, `cmd_off` do not exist yet — add placeholders so the
+module imports (they are Task 7's deliverable, TDD'd there):
+
+```python
+def cmd_setup(args) -> int:
+    raise VscodeError("not implemented yet")  # Task 7
+
+
+def cmd_on(args) -> int:
+    raise VscodeError("not implemented yet")  # Task 7
+
+
+def cmd_off(args) -> int:
+    raise VscodeError("not implemented yet")  # Task 7
+```
+
+(Define them ABOVE `_parser`. These three placeholders are the one sanctioned
+deviation from no-placeholders: the parser references the names, Task 7
+replaces the bodies, and the suite stays green in between because no Task 6
+test calls them.)
+
+- [ ] **Step 4: Run to verify green, then commit**
+
+Run: `python3 -m unittest tests.test_vscode -v` — Expected: PASS.
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: vscode status/install/update/uninstall and the front door (#33)"
+```
+
+---
+
+### Task 7: `on`, `off`, and `setup`
+
+**Files:**
+- Modify: `src/bunnyforge/vscode.py` (replace the three placeholders; add
+  helpers)
+- Test: `tests/test_vscode.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: real `cmd_on`, `cmd_off`, `cmd_setup`;
+  `_resolve_conflict(args) -> str` (`"adopt" | "replace" | "cancel"`);
+  `_offer_highlight(args) -> None`;
+  `_read_lines(path) -> list[str]`, `_write_lines(path, lines) -> None`,
+  `_packaged_settings_lines() -> list[str]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def _ws(case) -> Path:
+    ws = Path(case.enterContext(tempfile.TemporaryDirectory())).resolve()
+    (ws / "campaign.toml").write_text(
+        '[campaign]\nnamespace = "probe"\n', encoding="utf-8")
+    return ws
+
+
+def _settings_of(ws: Path) -> list[str]:
+    return (ws / ".vscode" / "settings.json").read_text("utf-8").split("\n")
+
+
+class TestOnOff(unittest.TestCase):
+
+    def _on(self, ws, *flags):
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["on", "--workspace", str(ws), *flags])
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_on_creates_the_file_enabled_when_absent(self):
+        ws = _ws(self)
+        rc, _, _ = self._on(ws)
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+        # strict JSON once comments drop — the whole point of the layout
+        json.loads("\n".join(
+            l for l in lines if not l.strip().startswith("//")))
+
+    def test_on_enables_a_scaffolded_off_file(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_bytes(
+            init.packaged_bytes("vscode/settings.json"))
+        rc, _, _ = self._on(ws)
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+
+    def test_on_is_idempotent(self):
+        ws = _ws(self)
+        self._on(ws)
+        before = _settings_of(ws)
+        rc, out, _ = self._on(ws)
+        self.assertEqual(rc, 0)
+        self.assertIn("already on", out)
+        self.assertEqual(_settings_of(ws), before)
+
+    def test_on_replace_resets_hand_tuning(self):
+        ws = _ws(self)
+        self._on(ws)
+        lines = _settings_of(ws)
+        begin, _ = vscode.maybe_region(lines)
+        # hand-tune a colour inside the region
+        idx = next(i for i, l in enumerate(lines) if "#ff3333" in l)
+        lines[idx] = lines[idx].replace("#ff3333", "#123456")
+        (ws / ".vscode" / "settings.json").write_text(
+            "\n".join(lines), encoding="utf-8")
+        rc, _, _ = self._on(ws, "--replace")
+        self.assertEqual(rc, 0)
+        text = "\n".join(_settings_of(ws))
+        self.assertNotIn("#123456", text)
+        self.assertIn("#ff3333", text)
+
+    def test_on_without_replace_preserves_hand_tuning(self):
+        ws = _ws(self)
+        self._on(ws)
+        lines = _settings_of(ws)
+        idx = next(i for i, l in enumerate(lines) if "#ff3333" in l)
+        lines[idx] = lines[idx].replace("#ff3333", "#123456")
+        (ws / ".vscode" / "settings.json").write_text(
+            "\n".join(lines), encoding="utf-8")
+        rc, _, _ = self._on(ws)   # already on; must not touch content
+        self.assertEqual(rc, 0)
+        self.assertIn("#123456", "\n".join(_settings_of(ws)))
+
+    def test_off_disables_and_hints_at_uninstall(self):
+        ws = _ws(self)
+        self._on(ws)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["off", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "off")
+        self.assertIn("bunnyforge vscode uninstall", out.getvalue())
+        # the pin survives off — it belongs to the preview half
+        self.assertIn('"markdown.preview.frontMatter": "table"',
+                      "\n".join(lines))
+
+    def test_off_with_no_file_is_a_named_error(self):
+        ws = _ws(self)
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["off", "--workspace", str(ws)])
+        self.assertEqual(rc, 1)
+        self.assertIn("error: ", err.getvalue())
+
+    def test_on_refuses_unbalanced_markers(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        broken = [l for l in init.packaged_bytes("vscode/settings.json")
+                  .decode("utf-8").split("\n")
+                  if l.strip() != vscode.MARKER_END]
+        (ws / ".vscode" / "settings.json").write_text(
+            "\n".join(broken), encoding="utf-8")
+        rc, _, err = self._on(ws)
+        self.assertEqual(rc, 1)
+        self.assertIn("unbalanced", err)
+
+
+class TestOnConflict(unittest.TestCase):
+    """The duplicate-key hazard: a hand-rolled highlight.regexes outside
+    any markers. Never append; ask, recommending adopt (decision 6)."""
+
+    def _handrolled(self) -> Path:
+        ws = Path(self.enterContext(tempfile.TemporaryDirectory())).resolve()
+        (ws / "campaign.toml").write_text(
+            '[campaign]\nnamespace = "probe"\n', encoding="utf-8")
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_text(
+            '{\n'
+            '  // tuned by hand, years of care\n'
+            '  "highlight.regexes": {\n'
+            '    "^tuned$": { "regexFlags": "gm" }\n'
+            '  },\n'
+            '  "editor.rulers": [80]\n'
+            '}\n', encoding="utf-8")
+        return ws
+
+    def _on(self, ws, *flags):
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["on", "--workspace", str(ws), *flags])
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_no_tty_and_no_flag_fails_naming_both_flags(self):
+        ws = self._handrolled()
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            rc, _, err = self._on(ws)
+        self.assertEqual(rc, 1)
+        self.assertIn("--adopt", err)
+        self.assertIn("--replace", err)
+        self.assertIn("tuned", (ws / ".vscode" / "settings.json")
+                      .read_text("utf-8"))   # untouched
+
+    def test_adopt_brackets_the_users_rules_untouched(self):
+        ws = self._handrolled()
+        rc, _, _ = self._on(ws, "--adopt")
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+        self.assertIn("^tuned$", "\n".join(lines[begin:end]))
+        self.assertIn("years of care", "\n".join(lines))   # comment kept
+
+    def test_replace_discards_the_users_rules_for_packaged(self):
+        ws = self._handrolled()
+        rc, _, _ = self._on(ws, "--replace")
+        self.assertEqual(rc, 0)
+        text = "\n".join(_settings_of(ws))
+        self.assertNotIn("^tuned$", text)
+        self.assertIn("visibility:", text)
+        self.assertIn('"editor.rulers": [80]', text)   # rest of file kept
+
+    def test_interactive_cancel_changes_nothing_and_exits_nonzero(self):
+        ws = self._handrolled()
+        before = (ws / ".vscode" / "settings.json").read_text("utf-8")
+        with mock.patch.object(vscode, "_interactive", return_value=True), \
+             mock.patch.object(vscode, "_ask", return_value="c"):
+            rc, _, _ = self._on(ws)
+        self.assertEqual(rc, 1)
+        self.assertEqual((ws / ".vscode" / "settings.json")
+                         .read_text("utf-8"), before)
+
+
+class TestOfferHighlight(unittest.TestCase):
+
+    def test_on_offers_the_highlight_extension_when_missing(self):
+        ws = _ws(self)
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        run = self.enterContext(mock.patch.object(
+            vscode, "_run", return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=True))
+        self.enterContext(mock.patch.object(
+            vscode, "_ask", return_value="y"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            ["/u/code", "--install-extension", vscode.HIGHLIGHT_ID],
+            [c.args[0] for c in run.call_args_list])
+
+    def test_non_interactive_on_prints_a_hint_instead(self):
+        ws = _ws(self)
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        run = self.enterContext(mock.patch.object(
+            vscode, "_run", return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=False))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)               # the toggle itself succeeded
+        self.assertIn(vscode.HIGHLIGHT_ID, out.getvalue())
+        self.assertNotIn(
+            ["/u/code", "--install-extension", vscode.HIGHLIGHT_ID],
+            [c.args[0] for c in run.call_args_list])
+
+
+class TestSetup(unittest.TestCase):
+
+    def test_setup_installs_then_offers_on_in_a_workspace(self):
+        ws = _ws(self)
+        _machine_env(self)
+        self.enterContext(mock.patch.object(
+            vscode, "_offer_highlight"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["setup", "--workspace", str(ws), "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertTrue((ws / ".vscode" / "settings.json").is_file())
+
+    def test_setup_without_a_workspace_still_installs(self):
+        _machine_env(self)
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["setup", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("no campaign workspace", out.getvalue())
+```
+
+- [ ] **Step 2: Run to verify failure**, then **Step 3: Implement**
+
+Replace the three placeholders with:
+
+```python
+# ── Workspace-half subcommands ──────────────────────────────────────────
+
+def _read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").split("\n")
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _packaged_settings_lines() -> list[str]:
+    return (init.packaged_bytes("vscode/settings.json")
+            .decode("utf-8").split("\n"))
+
+
+def _resolve_conflict(args) -> str:
+    """Decision 6: an unmanaged highlight.regexes is never appended to and
+    never overwritten unasked. Adopt is the recommendation: rules already
+    in a workspace almost certainly came from this colour language, so
+    what differs is more likely deliberate tuning than drift."""
+    if args.adopt:
+        return "adopt"
+    if args.replace:
+        return "replace"
+    if not _interactive():
+        raise VscodeError(
+            f'{SETTINGS_REL} already defines "highlight.regexes" outside '
+            f"the managed markers — pass --adopt to bring it under "
+            f"management, content untouched (recommended), or --replace "
+            f"to overwrite it with the packaged rules")
+    print(f'{SETTINGS_REL} already defines "highlight.regexes" outside '
+          f"the managed markers.")
+    print("  [a] adopt (recommended) — bracket the existing rules with "
+          "the markers, content untouched")
+    print("  [r] replace — discard them and write the packaged rules")
+    print("  [c] cancel — change nothing")
+    answer = _ask("choice [a/r/c]: ").strip().lower()
+    return {"a": "adopt", "r": "replace"}.get(answer, "cancel")
+
+
+def _offer_highlight(args) -> None:
+    """Decision 1: the rules are inert without the highlight extension,
+    so detect and offer — but the toggle already succeeded, so nothing
+    here may fail the command."""
+    try:
+        editor = pick_editor(discover_editors(), args.editor)
+    except VscodeError as exc:
+        print(f"note: {exc}")
+        print(f"note: the rules render only once {HIGHLIGHT_ID} is "
+              f"installed")
+        return
+    if _has_extension(editor, HIGHLIGHT_ID):
+        return
+    if not args.yes and not _interactive():
+        print(f"note: {HIGHLIGHT_ID} is not installed in {editor.label}; "
+              f"the rules render only once it is — install it with: "
+              f"{editor.cli_id} --install-extension {HIGHLIGHT_ID}")
+        return
+    if not _confirm(f"install {HIGHLIGHT_ID} into {editor.label} "
+                    f"(it renders these rules)?", args.yes):
+        return
+    proc = _run([editor.path, "--install-extension", HIGHLIGHT_ID])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --install-extension {HIGHLIGHT_ID} failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    print(f"installed {HIGHLIGHT_ID} (newest release) into {editor.label}")
+
+
+def cmd_on(args) -> int:
+    root = _config.resolve_workspace(args.workspace).root
+    path = root / SETTINGS_REL
+    if not path.is_file():
+        # Decision 4's easy case: absent — write the packaged file (the
+        # scaffold and this path can never drift apart) and enable it.
+        lines = _packaged_settings_lines()
+        begin, end = maybe_region(lines)
+        _write_lines(path, enable_region(lines, begin, end))
+        print(f"created {SETTINGS_REL} with source-view colouring on")
+    else:
+        lines = _read_lines(path)
+        region = maybe_region(lines)          # raises on unbalanced
+        if region is None:
+            key = find_unmanaged_key(lines, None)
+            if key is None:
+                lines = splice_region(lines)
+            else:
+                choice = _resolve_conflict(args)
+                if choice == "cancel":
+                    print("cancelled — nothing written")
+                    return 1
+                if choice == "adopt":
+                    lines = adopt_key(lines, key)
+                else:
+                    end_idx = key_span(lines, key)
+                    lines = splice_region(lines[:key]
+                                          + lines[end_idx + 1:])
+            begin, end = maybe_region(lines)
+            _write_lines(path, enable_region(lines, begin, end))
+            print(f"source-view colouring on ({SETTINGS_REL})")
+        elif args.replace:
+            # The region-level reset: packaged rules, enabled — the one
+            # deliberate way local tuning is discarded.
+            lines = replace_region(lines, *region)
+            begin, end = maybe_region(lines)
+            _write_lines(path, enable_region(lines, begin, end))
+            print("managed block reset to the packaged rules and enabled")
+        else:
+            state = region_state(lines, *region)
+            if state == "on":
+                print("source-view colouring is already on")
+            elif state == "empty":
+                raise VscodeError(
+                    "the managed block has nothing to enable — re-run "
+                    "with --replace to restore the packaged rules")
+            else:
+                _write_lines(path, enable_region(lines, *region))
+                print(f"source-view colouring on ({SETTINGS_REL})")
+    _offer_highlight(args)
+    return 0
+
+
+def cmd_off(args) -> int:
+    root = _config.resolve_workspace(args.workspace).root
+    path = root / SETTINGS_REL
+    if not path.is_file():
+        raise VscodeError(
+            f"no {SETTINGS_REL} in this workspace — nothing to turn off")
+    lines = _read_lines(path)
+    region = maybe_region(lines)
+    if region is None:
+        raise VscodeError(
+            f"no managed block in {SETTINGS_REL} — nothing this tool "
+            f"turned on; if colouring is enabled outside bunnyforge's "
+            f"markers, edit the file by hand (or run `bunnyforge vscode "
+            f"on` first to bring it under management)")
+    if region_state(lines, *region) == "off":
+        print("source-view colouring is already off")
+    else:
+        _write_lines(path, disable_region(lines, *region))
+        print(f"source-view colouring off ({SETTINGS_REL})")
+    # Toggling the setting is what was asked; uninstalling is a bigger
+    # action reached for deliberately, so hint rather than infer.
+    print("the markdown-preview half is a separate extension — to remove "
+          "it too: bunnyforge vscode uninstall")
+    return 0
+
+
+def cmd_setup(args) -> int:
+    rc = _ensure(args, update_only=False)
+    if rc != 0:
+        return rc
+    try:
+        _config.resolve_workspace(args.workspace)
+    except (_config.ConfigError, _workspace.WorkspaceError):
+        print("no campaign workspace here — run `bunnyforge vscode on` "
+              "inside one to enable source-view colouring")
+        return 0
+    if not args.yes and not _interactive():
+        print("hint: `bunnyforge vscode on` enables source-view "
+              "colouring in this workspace")
+        return 0
+    if _confirm("turn source-view colouring on in this workspace?",
+                args.yes):
+        return cmd_on(args)
+    return 0
+```
+
+Delete the three placeholder definitions.
+
+- [ ] **Step 4: Run to verify green, then commit**
+
+Run: `python3 -m unittest tests.test_vscode -v` — Expected: PASS (all tasks').
+
+```bash
+git add src/bunnyforge/vscode.py tests/test_vscode.py
+git commit -m "feat: vscode on/off/setup with adopt-replace-cancel (#33)"
+```
+
+---
+
+### Task 8: Wire into the CLI; name the command in the scaffold; README
+
+**Files:**
+- Modify: `src/bunnyforge/cli.py` (import, `_COMMANDS`, `_SUMMARIES`)
+- Modify: `tests/test_cli.py` (the exact-dict assertion)
+- Modify: `src/bunnyforge/init.py` (the Optional line)
+- Modify: `src/bunnyforge/data/vscode/settings.json` (header prose only)
+- Modify: `src/bunnyforge/data/vscode/extensions.json` (comment prose only)
+- Modify: `tests/test_init.py` (the Optional-line test)
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `vscode.main`. #34 deliberately shipped command-neutral wording;
+  this task is where the command gets named, everywhere at once.
+
+- [ ] **Step 1: Update the failing dispatcher test first**
+
+In `tests/test_cli.py`: add `vscode` to the `from bunnyforge import (…)`
+list and add `"vscode": vscode.main,` to the expected dict in
+`test_every_subcommand_maps_to_its_modules_main` (after `"names"`, before
+`"test"`, mirroring the table order below).
+
+Run: `python3 -m unittest tests.test_cli.TestDispatchTable -v`
+Expected: FAIL — cli does not know `vscode` yet.
+
+- [ ] **Step 2: Wire `cli.py`**
+
+Add `vscode` to `cli.py`'s `from bunnyforge import (…)` import list. In
+`_COMMANDS`, after `"names"`: `"vscode": vscode.main,`. In `_SUMMARIES`:
+`"vscode": "install the preview extension and toggle editor colouring",`.
+
+Run: `python3 -m unittest tests.test_cli -v` — Expected: PASS.
+
+- [ ] **Step 3: Name the command in init's output**
+
+In `src/bunnyforge/init.py` replace the #34 line:
+
+```python
+    print("Optional: VS Code colouring by visibility ships off — "
+          "run 'bunnyforge vscode setup'.")
+```
+
+In `tests/test_init.py`, `test_points_at_the_inert_vscode_scaffold_once`
+becomes:
+
+```python
+    def test_points_at_the_vscode_command_once(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory())).resolve()
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(
+                init.main([str(tmp / "new"), "--name", "X"]), 0)
+        pointing = [l for l in out.getvalue().splitlines()
+                    if "bunnyforge vscode" in l]
+        self.assertEqual(len(pointing), 1, out.getvalue())
+```
+
+- [ ] **Step 4: Name the command in the two data files (prose only)**
+
+In `data/vscode/settings.json`, change only the header sentence
+`// on, delete every "//- " prefix. ACTIVE LEVEL: high; to` (and its
+neighbours) so the paragraph reads:
+
+```jsonc
+  // reserved for the toggle; ordinary comments use plain "//". Turn
+  // colouring on with `bunnyforge vscode on` (or delete every "//- "
+  // prefix by hand); `bunnyforge vscode off` re-disables it. ACTIVE
+  // LEVEL: high; to switch, re-disable the high block and enable one
+  // alternate below.
+```
+
+In `data/vscode/extensions.json`, change
+`// Install it from its GitHub releases instead —` to
+`// Install it with \`bunnyforge vscode setup\`, or by hand —`.
+
+Do **not** touch marker lines, `//- ` lines, or any live JSON — the
+contract tests prove it: run
+`python3 -m unittest tests.test_init.TestVscodeScaffold tests.test_vscode.TestPackagedContract -v`
+Expected: PASS unchanged.
+
+- [ ] **Step 5: README section**
+
+Add to `README.md`, after the existing command documentation:
+
+```markdown
+## VS Code integration
+
+`bunnyforge init` scaffolds `.vscode/settings.json` and
+`.vscode/extensions.json` with a visibility colour language for the editor —
+every `.md` file coloured by its front-matter `visibility`, the `## GM notes`
+boundary marked. It ships off; `bunnyforge vscode` manages it:
+
+    bunnyforge vscode status      # both halves: installed, available, on/off
+    bunnyforge vscode setup       # install/update, then offer to enable
+    bunnyforge vscode on|off      # toggle the source-view block
+    bunnyforge vscode install|update|uninstall   # the preview extension
+
+The source-view half is rendered by the Marketplace extension
+`fabiospampinato.vscode-highlight`. The markdown-preview half,
+[`dcltdw.bunnyforge-visibility-preview`](https://github.com/dcltdw/bunnyforge-visibility-preview),
+is not on the Marketplace; it sideloads as a `.vsix` from GitHub releases,
+and sideloaded extensions never auto-update — `bunnyforge vscode update`
+checks the release feed. Only Visual Studio Code is tested; VS Code
+Insiders, VSCodium and Cursor are offered but unsupported. `on`/`off`
+rewrite only the marked managed block in `.vscode/settings.json`; the rest
+of the file — including its comments — is yours.
+```
+
+- [ ] **Step 6: Run everything, then commit**
+
+Run: `python3 -m unittest discover -s tests -t . -v` — Expected: PASS.
+
+```bash
+git add src/bunnyforge/cli.py src/bunnyforge/init.py \
+        src/bunnyforge/data/vscode/ tests/ README.md
+git commit -m "feat: wire bunnyforge vscode into the CLI and name it in the scaffold (#33)"
+```
+
+---
+
+### Task 9: Verification and PR
+
+- [ ] **Step 1: Full suite, fresh**
+
+Run: `python3 -m unittest discover -s tests -t . -v`
+Expected: PASS, portability checks included. Report real counts.
+
+- [ ] **Step 2: End-to-end smoke against the real release (network, no install)**
+
+```bash
+python3 -m bunnyforge.vscode status || true
+```
+Expected: machine-half lines print; available version resolves to the real
+v0.1.0 release (or a clean "latest unknown" line if offline). This is the
+one deliberate live-network check; it installs nothing.
+
+- [ ] **Step 3: Help surfaces**
+
+```bash
+python3 -m bunnyforge --help          # lists vscode with its summary
+python3 -m bunnyforge vscode --help   # per-subcommand workspace sentence
+```
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/33-vscode-command
+```
+
+PR **based on `main`** (state this explicitly). Title: `Add bunnyforge
+vscode: install/update the preview extension, toggle colouring (#33)`.
+Body per AGENTS.md: **Files changed** (`src/bunnyforge/vscode.py` new;
+`tests/test_vscode.py` new; `cli.py`, `init.py`, both `data/vscode/*.json`,
+`tests/test_cli.py`, `tests/test_init.py`, `README.md` modified; this plan
+new), **Work breakdown** (region engine / trust path / per-subcommand
+workspace rules / the settled decisions honoured), **Test expectations**
+(none expected to fail), **Provenance** (`Agent:`, `Model / version:`).
+
+Then **stop and wait for review** — do not merge.
+
+## Out of scope (resist)
+
+- Touching existing workspaces' `extensions.json`, or adding the
+  `frontMatter` pin to a pre-existing settings file (`status` advises
+  instead — approved design call).
+- Windows/Linux app-bundle path tables (PATH covers them; macOS is the
+  exception and is covered).
+- Any second managed region; #32's doctrine-adopt problem.
+- Marketplace publication, Open VSX, auto-update.
+- Version bump/release timing — the maintainer's call.

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -70,8 +70,9 @@ The `.vscode/` pair ships **inert**: `settings.json` carries a colouring block
 that tints `.md` files by their front-matter `visibility`, disabled line by line
 behind a reserved `//- ` prefix between two `bunnyforge:` marker comments, and
 `extensions.json` recommends the extension that renders it. A scaffolded
-workspace therefore looks exactly like one without the files until someone
-deletes the prefixes. The markers and the off-prefix are a frozen format —
+workspace therefore looks exactly like one without the files until
+`bunnyforge vscode on` rewrites the marked block (or someone deletes the
+prefixes by hand). The markers and the off-prefix are a frozen format —
 `tests/test_init.py::TestVscodeScaffold` pins them, and parses the file as
 strict JSON in both toggle states.
 

--- a/src/bunnyforge/cli.py
+++ b/src/bunnyforge/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cli.py — the `bunnyforge` front door: one command, eight subcommands.
+cli.py — the `bunnyforge` front door: one command, nine subcommands.
 
 Only the first token is parsed here; everything after it passes to the
 target module's main(argv) verbatim. This parser never mirrors a tool's
@@ -36,6 +36,7 @@ from bunnyforge import (
     init,
     review,
     run_tests,
+    vscode,
 )
 
 # Subcommand -> the module main(argv) it forwards to, in the order --help
@@ -48,6 +49,7 @@ _COMMANDS = {
     "import-perceptions": import_perceptions.main,
     "build-sheets": build_sheets.main,
     "names": generate_names.main,
+    "vscode": vscode.main,
     "test": run_tests.main,
 }
 
@@ -61,6 +63,7 @@ _SUMMARIES = {
     "import-perceptions": "import player-authored wiki pages into Perceptions/",
     "build-sheets": "build one-page HTML reference sheets for a session",
     "names": "generate culture-appropriate names",
+    "vscode": "install the preview extension and toggle editor colouring",
     "test": "run the workspace test suite",
 }
 

--- a/src/bunnyforge/data/vscode/extensions.json
+++ b/src/bunnyforge/data/vscode/extensions.json
@@ -7,7 +7,7 @@
   // below: it is not on the VS Code Marketplace (publishing there now
   // requires an Azure DevOps org linked to an active Azure
   // subscription), so a recommendation entry could never resolve.
-  // Install it from its GitHub releases instead —
+  // Install it with `bunnyforge vscode setup`, or by hand —
   //   https://github.com/dcltdw/bunnyforge-visibility-preview/releases/latest
   //   code --install-extension <downloaded .vsix file>
   // It is optional: absent, the preview renders the plain front-matter

--- a/src/bunnyforge/data/vscode/settings.json
+++ b/src/bunnyforge/data/vscode/settings.json
@@ -16,9 +16,11 @@
   // The block between the two bunnyforge marker comments below is
   // managed; the marker lines themselves must not be edited. The block
   // ships OFF: every disabled line starts with "//- " — a prefix
-  // reserved for the toggle; ordinary comments use plain "//". To turn
-  // colouring on, delete every "//- " prefix. ACTIVE LEVEL: high; to
-  // switch, re-disable the high block and enable one alternate below.
+  // reserved for the toggle; ordinary comments use plain "//". Turn
+  // colouring on with `bunnyforge vscode on` (or delete every "//- "
+  // prefix by hand); `bunnyforge vscode off` re-disables it. ACTIVE
+  // LEVEL: high; to switch, re-disable the high block and enable one
+  // alternate below.
   // bunnyforge:begin visibility-colouring
   //- "highlight.regexes": {
     //- "^(visibility:\\s*gm-only\\s*)$": {

--- a/src/bunnyforge/data/vscode/settings.json
+++ b/src/bunnyforge/data/vscode/settings.json
@@ -18,9 +18,15 @@
   // ships OFF: every disabled line starts with "//- " — a prefix
   // reserved for the toggle; ordinary comments use plain "//". Turn
   // colouring on with `bunnyforge vscode on` (or delete every "//- "
-  // prefix by hand); `bunnyforge vscode off` re-disables it. ACTIVE
-  // LEVEL: high; to switch, re-disable the high block and enable one
-  // alternate below.
+  // prefix by hand); `bunnyforge vscode off` re-disables it.
+  //
+  // ACTIVE PALETTE: high. Switching is a hand edit: comment every line
+  // of the palette you are leaving out with plain "//" — never "//- ",
+  // which belongs to the toggle and would re-enable the old palette
+  // alongside the new one — then uncomment one alternate below,
+  // matching the commas of the block you replaced (a live palette needs
+  // a trailing comma when a setting follows it). `bunnyforge vscode on
+  // --replace` restores the packaged high palette.
   // bunnyforge:begin visibility-colouring
   //- "highlight.regexes": {
     //- "^(visibility:\\s*gm-only\\s*)$": {

--- a/src/bunnyforge/init.py
+++ b/src/bunnyforge/init.py
@@ -227,7 +227,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Created campaign workspace {path} — {len(written)} files "
           f"(name {args.name!r}, namespace {namespace!r}).")
     print("Optional: VS Code colouring by visibility ships off — "
-          "see .vscode/settings.json.")
+          "run 'bunnyforge vscode setup'.")
     print(f"Next: cd {path} && bunnyforge review checkup")
     return 0
 

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -450,3 +450,245 @@ def obtain_vsix(release: Release, fetch=_fetch) -> Path:
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_bytes(data)
     return dest
+
+
+# ── Confirmation ────────────────────────────────────────────────────────
+
+def _confirm(question: str, assume_yes: bool) -> bool:
+    """The trust gate: this command installs code into the user's editor,
+    so the interactive path confirms and automation opts in explicitly."""
+    if assume_yes:
+        return True
+    if not _interactive():
+        raise VscodeError(
+            "standard input is not a terminal — pass --yes to confirm "
+            "non-interactively")
+    return _ask(f"{question} [y/N] ").strip().lower() in ("y", "yes")
+
+
+def _dotted(version: tuple[int, ...]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+# ── Machine-half subcommands ────────────────────────────────────────────
+
+def cmd_install(args) -> int:
+    return _ensure(args, update_only=False)
+
+
+def cmd_update(args) -> int:
+    return _ensure(args, update_only=True)
+
+
+def _ensure(args, update_only: bool) -> int:
+    editor = pick_editor(discover_editors(), args.editor)
+    installed = installed_version(editor)
+    if update_only and installed is None:
+        raise VscodeError(
+            f"{EXTENSION_ID} is not installed in {editor.label} — run: "
+            f"bunnyforge vscode install")
+    release = latest_release()
+    if installed == release.version:
+        print(f"{EXTENSION_ID} {_dotted(installed)} is current in "
+              f"{editor.label} — nothing to do")
+        return 0
+    if installed and installed > release.version:
+        print(f"installed {_dotted(installed)} is newer than the latest "
+              f"release {release.tag} — nothing to do")
+        return 0
+    vsix = obtain_vsix(release)
+    print(f"about to install {EXTENSION_ID} {release.tag}")
+    print(f"  from  https://github.com/{EXTENSION_REPO} (pinned source)")
+    print(f"  file  {vsix}")
+    print(f"  into  {editor.label} ({editor.path})")
+    if not editor.supported:
+        print("  note  only Visual Studio Code is tested; this editor is "
+              "offered unsupported and may have bugs")
+    if not _confirm("proceed?", args.yes):
+        print("cancelled — nothing installed")
+        return 1
+    proc = _run([editor.path, "--install-extension", str(vsix), "--force"])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --install-extension failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    verb = "updated to" if installed else "installed at"
+    print(f"{EXTENSION_ID} {verb} {release.tag} in {editor.label}")
+    print("note: sideloaded extensions never auto-update — run "
+          "`bunnyforge vscode update` when a release lands")
+    return 0
+
+
+def cmd_uninstall(args) -> int:
+    editor = pick_editor(discover_editors(), args.editor)
+    if installed_version(editor) is None:
+        print(f"{EXTENSION_ID} is not installed in {editor.label} — "
+              f"nothing to do")
+        return 0
+    if not _confirm(f"remove {EXTENSION_ID} from {editor.label}?", args.yes):
+        print("cancelled")
+        return 1
+    proc = _run([editor.path, "--uninstall-extension", EXTENSION_ID])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --uninstall-extension failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    print(f"removed {EXTENSION_ID} from {editor.label}")
+    return 0
+
+
+def _has_extension(editor: Editor, extension_id: str) -> bool:
+    proc = _run([editor.path, "--list-extensions"])
+    return proc.returncode == 0 and extension_id in proc.stdout.split()
+
+
+def cmd_status(args) -> int:
+    # Machine half: unconditional (decision 5).
+    editors = discover_editors()
+    if not editors:
+        print("editor         none found (searched PATH and known "
+              "locations)")
+    else:
+        try:
+            editor = pick_editor(editors, args.editor)
+        except VscodeError:
+            editor = editors[0]
+        print(f"editor         {editor.label} ({editor.path})")
+        installed = installed_version(editor)
+        try:
+            release = latest_release()
+            available = f"{_dotted(release.version)} available"
+        except VscodeError as exc:
+            release = None
+            available = f"latest unknown ({exc})"
+        if installed is None:
+            print(f"preview ext    not installed; {available}")
+        elif release and installed < release.version:
+            print(f"preview ext    {_dotted(installed)} installed; "
+                  f"{available} — run: bunnyforge vscode update")
+        else:
+            print(f"preview ext    {_dotted(installed)} installed; "
+                  f"{available}")
+        if _has_extension(editor, HIGHLIGHT_ID):
+            print("highlight ext  installed")
+        else:
+            print("highlight ext  not installed — source-view rules will "
+                  "not render")
+    # Workspace half: only when one is found; say plainly when not.
+    try:
+        root = _config.resolve_workspace(args.workspace).root
+    except (_config.ConfigError, _workspace.WorkspaceError):
+        print("workspace      none found — `on`/`off` need one")
+        return 0
+    print(f"workspace      {root}")
+    path = root / SETTINGS_REL
+    if not path.is_file():
+        print(f"colouring      no {SETTINGS_REL} — `bunnyforge vscode on` "
+              f"creates it")
+        return 0
+    lines = path.read_text(encoding="utf-8").split("\n")
+    try:
+        region = maybe_region(lines)
+    except VscodeError:
+        print("colouring      managed markers unbalanced — restore the "
+              "marker pair by hand")
+        return 0
+    if region is None:
+        print("colouring      no managed block — `bunnyforge vscode on` "
+              "adds one")
+    else:
+        print(f"colouring      {region_state(lines, *region)}")
+    if not any(l.strip().startswith('"markdown.preview.frontMatter"')
+               for l in lines):
+        print('frontMatter    not pinned — add '
+              '"markdown.preview.frontMatter": "table" so the preview '
+              'renders the table the extension decorates')
+    return 0
+
+
+def cmd_setup(args) -> int:
+    raise VscodeError("not implemented yet")  # Task 7
+
+
+def cmd_on(args) -> int:
+    raise VscodeError("not implemented yet")  # Task 7
+
+
+def cmd_off(args) -> int:
+    raise VscodeError("not implemented yet")  # Task 7
+
+
+# ── The front door ──────────────────────────────────────────────────────
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bunnyforge vscode",
+        description=(
+            "Install the bunnyforge-visibility-preview extension and "
+            "toggle the source-view colouring. Subcommands differ in what "
+            "they need: install/update/uninstall act on this machine's "
+            "editor and need no workspace; on/off edit the workspace's "
+            ".vscode/settings.json and require one; status and setup "
+            "cover the workspace half only when a workspace is found."))
+    sub = parser.add_subparsers(dest="subcommand", required=True,
+                                metavar="subcommand")
+
+    def add(name, func, help_text, *, workspace=False, editor=True,
+            yes=True, conflict=False):
+        p = sub.add_parser(name, help=help_text)
+        p.set_defaults(func=func)
+        if workspace:
+            p.add_argument("--workspace", metavar="PATH",
+                           help="campaign workspace (default: search "
+                                "upward from the current directory)")
+        if editor:
+            p.add_argument("--editor", metavar="CLI",
+                           help="editor CLI to target: "
+                                "code|code-insiders|codium|cursor "
+                                "(only code is tested)")
+        if yes:
+            p.add_argument("--yes", action="store_true",
+                           help="answer yes to every confirmation "
+                                "(for automation)")
+        if conflict:
+            group = p.add_mutually_exclusive_group()
+            group.add_argument("--adopt", action="store_true",
+                               help="bring an existing highlight.regexes "
+                                    "under management, content untouched")
+            group.add_argument("--replace", action="store_true",
+                               help="reset the managed block to the "
+                                    "packaged rules, discarding tuning")
+        return p
+
+    add("status", cmd_status, "report both halves and their versions",
+        workspace=True, yes=False)
+    add("setup", cmd_setup, "install or update, then offer to turn "
+        "colouring on", workspace=True, conflict=True)
+    add("install", cmd_install, "install the preview extension into the "
+        "editor")
+    add("update", cmd_update, "update an installed preview extension")
+    add("uninstall", cmd_uninstall, "remove the preview extension — the "
+        "only real off for the preview half")
+    add("on", cmd_on, "enable source-view colouring in the workspace",
+        workspace=True, conflict=True)
+    add("off", cmd_off, "disable source-view colouring in the workspace",
+        workspace=True, editor=False, yes=False)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except (VscodeError, _config.ConfigError,
+            _workspace.WorkspaceError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BrokenPipeError:
+        sys.stderr.close()
+        raise SystemExit(0)

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -32,6 +32,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -473,30 +474,56 @@ def latest_release(fetch=_fetch) -> Release:
 
     Unauthenticated: 60 requests/hour is ample for a human-driven command,
     but offline or rate-limited must degrade to a clear error the caller
-    can choose to swallow (status) or surface (install)."""
+    can choose to swallow (status) or surface (install).
+
+    A 200 is not a promise of a release object: a proxy's HTML error page
+    and `{"message": "Not Found"}` both arrive that way. Every parse and
+    every key lookup here is therefore a VscodeError, not a traceback.
+    """
     try:
         raw = fetch(RELEASES_URL)
     except OSError as exc:
         raise VscodeError(
             f"couldn't reach GitHub for the latest release ({exc}) — "
             f"check the network and retry") from exc
-    data = json.loads(raw)
-    asset = next((a for a in data.get("assets", [])
-                  if a.get("name", "").endswith(".vsix")), None)
+    try:
+        data = json.loads(raw)
+    except ValueError as exc:
+        raise VscodeError(
+            f"GitHub's answer for the latest release of {EXTENSION_REPO} "
+            f"is not JSON ({exc}) — retry, or open {RELEASES_URL} in a "
+            f"browser to see what it is saying") from exc
+    if not isinstance(data, dict):
+        raise VscodeError(
+            f"GitHub's answer for the latest release of {EXTENSION_REPO} "
+            f"is not a release object — retry, or open {RELEASES_URL} in "
+            f"a browser to see what it is saying")
+    assets = data.get("assets")
+    asset = next((a for a in assets
+                  if isinstance(a, dict)
+                  and str(a.get("name", "")).endswith(".vsix")),
+                 None) if isinstance(assets, list) else None
     if asset is None:
         raise VscodeError(
             f"release {data.get('tag_name', '?')} of {EXTENSION_REPO} has "
             f"no .vsix asset — report it at "
             f"https://github.com/{EXTENSION_REPO}/issues")
-    digest = asset.get("digest") or ""
-    return Release(
-        version=parse_version(data["tag_name"]),
-        tag=data["tag_name"],
-        vsix_name=asset["name"],
-        url=asset["browser_download_url"],
-        size=asset["size"],
-        sha256=digest.removeprefix("sha256:") if digest.startswith("sha256:")
-               else None)
+    digest = str(asset.get("digest") or "")
+    try:
+        tag = str(data["tag_name"])
+        return Release(
+            version=parse_version(tag),
+            tag=tag,
+            vsix_name=str(asset["name"]),
+            url=str(asset["browser_download_url"]),
+            size=int(asset["size"]),
+            sha256=(digest.removeprefix("sha256:")
+                    if digest.startswith("sha256:") else None))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise VscodeError(
+            f"GitHub's answer for the latest release of {EXTENSION_REPO} "
+            f"is missing or malformed ({exc!r}) — report it at "
+            f"https://github.com/{EXTENSION_REPO}/issues") from exc
 
 
 def cache_dir(platform=sys.platform, environ=os.environ) -> Path:
@@ -519,11 +546,23 @@ def _matches(data: bytes, release: Release) -> bool:
     return hashlib.sha256(data).hexdigest() == release.sha256
 
 
+def _cache_name(release: Release) -> str:
+    """A single safe filename component. Both halves come from the release
+    JSON — untrusted input on its way into a path that gets
+    mkdir(parents=True) — so anything outside the allowed set becomes an
+    underscore. The "-" join means the result can never be "." or ".."."""
+    return re.sub(r"[^A-Za-z0-9._-]", "_",
+                  f"{release.tag}-{release.vsix_name}")
+
+
 def obtain_vsix(release: Release, fetch=_fetch) -> Path:
     """A verified .vsix on disk: the cache if it checks out, else a fresh
-    download — verified BEFORE it lands in the cache, so a truncated or
-    tampered file is never present to be installed later."""
-    dest = cache_dir() / f"{release.tag}-{release.vsix_name}"
+    download — verified BEFORE it lands in the cache, so a truncated file
+    (or, when the release publishes a digest, a tampered one) is never
+    present to be installed later. A release without a digest can only be
+    checked by length, which is why the consent block says which of the
+    two happened."""
+    dest = cache_dir() / _cache_name(release)
     if dest.is_file() and _matches(dest.read_bytes(), release):
         return dest
     try:
@@ -591,11 +630,18 @@ def _ensure(args, update_only: bool) -> int:
         return 0
     vsix = obtain_vsix(release)
     print(f"about to install {EXTENSION_ID} {release.tag}")
-    print(f"  from  https://github.com/{EXTENSION_REPO} (pinned source)")
-    print(f"  file  {vsix}")
-    print(f"  into  {editor.label} ({editor.path})")
+    print(f"  from    https://github.com/{EXTENSION_REPO} (pinned source)")
+    print(f"  file    {vsix}")
+    # Consent has to say WHICH check ran: without a published digest the
+    # verification degrades to length only, and saying nothing would let
+    # that read as tamper-proof.
+    if release.sha256:
+        print(f"  digest  sha256:{release.sha256} (verified)")
+    else:
+        print("  digest  none published by the release — size only")
+    print(f"  into    {editor.label} ({editor.path})")
     if not editor.supported:
-        print("  note  only Visual Studio Code is tested; this editor is "
+        print("  note    only Visual Studio Code is tested; this editor is "
               "offered unsupported and may have bugs")
     if not _confirm("proceed?", args.yes):
         print("cancelled — nothing installed")

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -353,3 +353,100 @@ def installed_version(editor: Editor,
         if name.strip().lower() == extension_id:
             return parse_version(version)
     return None
+
+
+# ── The release feed and the .vsix cache ────────────────────────────────
+
+class Release(NamedTuple):
+    version: tuple[int, ...]
+    tag: str
+    vsix_name: str
+    url: str
+    size: int
+    sha256: str | None      # release assets predating GitHub digests: None
+
+
+def _fetch(url: str) -> bytes:
+    request = urllib.request.Request(url, headers={
+        "User-Agent": "bunnyforge",
+        "Accept": "application/vnd.github+json",
+    })
+    with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+        return response.read()
+
+
+def latest_release(fetch=_fetch) -> Release:
+    """The newest release (decision 2: no pinning) from the pinned repo.
+
+    Unauthenticated: 60 requests/hour is ample for a human-driven command,
+    but offline or rate-limited must degrade to a clear error the caller
+    can choose to swallow (status) or surface (install)."""
+    try:
+        raw = fetch(RELEASES_URL)
+    except OSError as exc:
+        raise VscodeError(
+            f"couldn't reach GitHub for the latest release ({exc}) — "
+            f"check the network and retry") from exc
+    data = json.loads(raw)
+    asset = next((a for a in data.get("assets", [])
+                  if a.get("name", "").endswith(".vsix")), None)
+    if asset is None:
+        raise VscodeError(
+            f"release {data.get('tag_name', '?')} of {EXTENSION_REPO} has "
+            f"no .vsix asset — report it at "
+            f"https://github.com/{EXTENSION_REPO}/issues")
+    digest = asset.get("digest") or ""
+    return Release(
+        version=parse_version(data["tag_name"]),
+        tag=data["tag_name"],
+        vsix_name=asset["name"],
+        url=asset["browser_download_url"],
+        size=asset["size"],
+        sha256=digest.removeprefix("sha256:") if digest.startswith("sha256:")
+               else None)
+
+
+def cache_dir(platform=sys.platform, environ=os.environ) -> Path:
+    if platform == "darwin":
+        base = Path.home() / "Library" / "Caches"
+    elif platform.startswith("win"):
+        base = Path(environ.get("LOCALAPPDATA")
+                    or Path.home() / "AppData" / "Local")
+    else:
+        base = Path(environ.get("XDG_CACHE_HOME")
+                    or Path.home() / ".cache")
+    return base / "bunnyforge" / "vsix"
+
+
+def _matches(data: bytes, release: Release) -> bool:
+    if len(data) != release.size:
+        return False
+    if release.sha256 is None:
+        return True
+    return hashlib.sha256(data).hexdigest() == release.sha256
+
+
+def obtain_vsix(release: Release, fetch=_fetch) -> Path:
+    """A verified .vsix on disk: the cache if it checks out, else a fresh
+    download — verified BEFORE it lands in the cache, so a truncated or
+    tampered file is never present to be installed later."""
+    dest = cache_dir() / f"{release.tag}-{release.vsix_name}"
+    if dest.is_file() and _matches(dest.read_bytes(), release):
+        return dest
+    try:
+        data = fetch(release.url)
+    except OSError as exc:
+        raise VscodeError(
+            f"downloading {release.vsix_name} failed ({exc}) — check the "
+            f"network and retry") from exc
+    if len(data) != release.size:
+        raise VscodeError(
+            f"download of {release.vsix_name} is {len(data)} bytes; the "
+            f"release says {release.size} — truncated, not installing")
+    if release.sha256 and hashlib.sha256(data).hexdigest() != release.sha256:
+        raise VscodeError(
+            f"download of {release.vsix_name} does not match the release "
+            f"digest — not installing")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+    return dest

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -35,6 +35,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import urllib.request
 from pathlib import Path
 from typing import NamedTuple
@@ -211,7 +212,8 @@ def normalise_commas(lines: list[str]) -> list[str]:
         out[preceding[-1]] = _drop_comma(out[preceding[-1]])
         indent = _split_indent(out[begin])[0]
         off = region_state(out, begin, end) == "off"
-        out.insert(begin + 1, indent + (OFF_PREFIX if off else "") + ",")
+        separator = indent + (OFF_PREFIX if off else "") + ","
+        out.insert(begin + 1, _with_endings_of([separator], out)[0])
     return out
 
 
@@ -264,6 +266,15 @@ def find_unmanaged_key(lines: list[str],
     return None
 
 
+def _with_endings_of(new: list[str], model: list[str]) -> list[str]:
+    """`new` lines given the line ending `model` uses. Lines read with
+    newline="" keep their own terminator, so inserting package lines (LF)
+    into a CRLF file would leave it half-translated."""
+    if not any(l.endswith("\r") for l in model):
+        return new
+    return [l if l.endswith("\r") else l + "\r" for l in new]
+
+
 def packaged_region_lines() -> list[str]:
     lines = (init.packaged_bytes("vscode/settings.json")
              .decode("utf-8").split("\n"))
@@ -286,7 +297,7 @@ def splice_region(lines: list[str]) -> list[str]:
             f"(no opening or closing brace on a line of its own) — fix or "
             f"remove the file, then re-run")
     opens, _ = bounds
-    region = packaged_region_lines()
+    region = _with_endings_of(packaged_region_lines(), lines)
     return normalise_commas(lines[:opens + 1] + region + lines[opens + 1:])
 
 
@@ -299,9 +310,11 @@ def adopt_key(lines: list[str], key_idx: int) -> list[str]:
     before it with a comma that dangles as soon as `off` runs."""
     end = key_span(lines, key_idx)
     indent = _split_indent(lines[key_idx])[0]
+    begin_line, end_line = _with_endings_of(
+        [indent + MARKER_BEGIN, indent + MARKER_END], lines)
     out = list(lines)
-    out.insert(end + 1, indent + MARKER_END)
-    out.insert(key_idx, indent + MARKER_BEGIN)
+    out.insert(end + 1, end_line)
+    out.insert(key_idx, begin_line)
     return normalise_commas(out)
 
 
@@ -309,8 +322,8 @@ def replace_region(lines: list[str], begin: int, end: int) -> list[str]:
     """The packaged region in place of the current one, commas normalised:
     the packaged region ends `//- },`, which is a dangling comma when the
     region is the object's last (or only) member."""
-    return normalise_commas(
-        lines[:begin] + packaged_region_lines() + lines[end + 1:])
+    region = _with_endings_of(packaged_region_lines(), lines)
+    return normalise_commas(lines[:begin] + region + lines[end + 1:])
 
 
 # ── Editors ─────────────────────────────────────────────────────────────
@@ -699,12 +712,38 @@ def cmd_status(args) -> int:
 # ── Workspace-half subcommands ──────────────────────────────────────────
 
 def _read_lines(path: Path) -> list[str]:
-    return path.read_text(encoding="utf-8").split("\n")
+    # newline="" keeps the file's own line endings inside the strings.
+    # Translating them would rewrite every line of a file this tool
+    # promises to touch only between the markers.
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return handle.read().split("\n")
 
 
 def _write_lines(path: Path, lines: list[str]) -> None:
+    """Write through a temp file in the SAME directory, then os.replace.
+
+    A truncating write that dies partway — full disk, SIGINT, crash —
+    would leave the user's hand-edited, hand-commented settings.json
+    empty, and there is no backup. os.replace is atomic only within one
+    filesystem, hence the sibling temp file rather than /tmp.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines), encoding="utf-8")
+    fd, name = tempfile.mkstemp(dir=path.parent,
+                                prefix=path.name + ".", suffix=".tmp")
+    tmp = Path(name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write("\n".join(lines))
+        # mkstemp is 0600; the file the user had (or a plain new one)
+        # should not silently change mode.
+        if path.exists():
+            shutil.copymode(path, tmp)
+        else:
+            tmp.chmod(0o644)
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def _packaged_settings_lines() -> list[str]:

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -237,3 +237,119 @@ def adopt_key(lines: list[str], key_idx: int) -> list[str]:
 
 def replace_region(lines: list[str], begin: int, end: int) -> list[str]:
     return lines[:begin] + packaged_region_lines() + lines[end + 1:]
+
+
+# ── Editors ─────────────────────────────────────────────────────────────
+# Stable first: it is the tested editor and every default resolves to it.
+# The rest are offered because sideloading a .vsix is exactly how the
+# non-Marketplace editors install things (decision 3) — but they are
+# untested, and every mention of them says so.
+_EDITORS = (
+    ("code", "Visual Studio Code", True),
+    ("code-insiders", "VS Code Insiders", False),
+    ("codium", "VSCodium", False),
+    ("cursor", "Cursor", False),
+)
+
+# PATH is searched first everywhere; these app-bundle paths cover the one
+# platform whose installer does NOT put the CLI on PATH (macOS — the
+# machine this was developed on had `which code` fail with the binary at
+# this exact path). Windows and Linux installers put the CLI on PATH by
+# default, so PATH is their discovery.
+_MAC_APPS = {
+    "code": ("/Applications/Visual Studio Code.app"
+             "/Contents/Resources/app/bin/code"),
+    "code-insiders": ("/Applications/Visual Studio Code - Insiders.app"
+                      "/Contents/Resources/app/bin/code-insiders"),
+    "codium": "/Applications/VSCodium.app/Contents/Resources/app/bin/codium",
+    "cursor": "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+}
+
+
+class Editor(NamedTuple):
+    cli_id: str
+    label: str
+    path: str
+    supported: bool
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def _interactive() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _ask(prompt: str) -> str:
+    return input(prompt)
+
+
+def discover_editors(which=shutil.which, platform=sys.platform,
+                     exists=lambda p: Path(p).is_file()) -> list[Editor]:
+    found = []
+    for cli_id, label, supported in _EDITORS:
+        path = which(cli_id)
+        if path is None and platform == "darwin" and exists(_MAC_APPS[cli_id]):
+            path = _MAC_APPS[cli_id]
+        if path:
+            found.append(Editor(cli_id, label, path, supported))
+    return found
+
+
+def pick_editor(editors: list[Editor], wanted: str | None) -> Editor:
+    if wanted:
+        match = next((e for e in editors if e.cli_id == wanted), None)
+        if match is None:
+            raise VscodeError(
+                f"--editor {wanted}: not found (found: "
+                f"{', '.join(e.cli_id for e in editors) or 'none'})")
+        return match
+    if not editors:
+        raise VscodeError(
+            "no editor CLI found on PATH or in known locations — in VS "
+            "Code, run \"Shell Command: Install 'code' command in PATH\" "
+            "from the Command Palette, then re-run")
+    if len(editors) == 1:
+        return editors[0]
+    stable = next((e for e in editors if e.cli_id == "code"), None)
+    if not _interactive():
+        if stable:
+            return stable
+        raise VscodeError(
+            "several editors found and no terminal to ask — pass "
+            "--editor " + "|".join(e.cli_id for e in editors))
+    print("several editors found:")
+    for n, e in enumerate(editors, 1):
+        note = "" if e.supported else "  (untested — may have bugs)"
+        print(f"  [{n}] {e.label}{note}")
+    default = editors.index(stable) + 1 if stable else 1
+    answer = _ask(f"install into [{default}]: ").strip()
+    if answer.isdigit() and 1 <= int(answer) <= len(editors):
+        return editors[int(answer) - 1]
+    return editors[default - 1]
+
+
+# ── Versions ────────────────────────────────────────────────────────────
+
+def parse_version(text: str) -> tuple[int, ...]:
+    body = text.strip().removeprefix("v")
+    try:
+        return tuple(int(part) for part in body.split("."))
+    except ValueError:
+        raise VscodeError(f"unparseable version {text!r}") from None
+
+
+def installed_version(editor: Editor,
+                      extension_id: str = EXTENSION_ID
+                      ) -> tuple[int, ...] | None:
+    proc = _run([editor.path, "--list-extensions", "--show-versions"])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --list-extensions failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    for line in proc.stdout.splitlines():
+        name, _, version = line.partition("@")
+        if name.strip().lower() == extension_id:
+            return parse_version(version)
+    return None

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -129,6 +129,92 @@ def disable_region(lines: list[str], begin: int, end: int) -> list[str]:
 
 # ── Structural edits: create, adopt, replace ────────────────────────────
 
+def _is_live(line: str) -> bool:
+    """A line carrying JSON the parser sees — not blank, not a comment."""
+    body = line.strip()
+    return bool(body) and not body.startswith("//")
+
+
+def _drop_comma(line: str) -> str:
+    """The same line without its trailing comma, indent, OFF_PREFIX and
+    any line-ending kept exactly as they were."""
+    indent, body = _split_indent(line)
+    prefix = ""
+    if body.startswith(OFF_PREFIX):
+        prefix, body = OFF_PREFIX, body[len(OFF_PREFIX):]
+    stripped = body.rstrip()
+    if stripped.endswith(","):
+        body = stripped[:-1] + body[len(stripped):]
+    return indent + prefix + body
+
+
+def _last_member_line(lines: list[str], begin: int, end: int) -> int | None:
+    """The region's last line that is a JSON member in SOME toggle state —
+    live or OFF_PREFIX-disabled. Plain `//` prose (the alternates) is not a
+    member and never carries the region's separator."""
+    for i in range(end - 1, begin, -1):
+        body = lines[i].strip()
+        if body.startswith(OFF_PREFIX) or _is_live(lines[i]):
+            return i
+    return None
+
+
+def _object_bounds(lines: list[str]) -> tuple[int, int] | None:
+    """(opening, closing) line indices of the settings object, or None.
+
+    The opener is the first NON-COMMENT line ending in `{`: a file headed
+    by a `// {`-shaped comment would otherwise have the region spliced
+    outside the object entirely.
+    """
+    opens = next((i for i, l in enumerate(lines)
+                  if _is_live(l) and l.strip().endswith("{")), None)
+    close = next((i for i in range(len(lines) - 1, -1, -1)
+                  if lines[i].strip() == "}"), None)
+    if opens is None or close is None or close <= opens:
+        return None
+    return opens, close
+
+
+def normalise_commas(lines: list[str]) -> list[str]:
+    """Repair the commas either side of the managed region so the file is
+    valid JSON in BOTH toggle states — the one sanctioned edit outside the
+    markers, made only by the structural edits, never by the toggle.
+
+    The region's separator has to live INSIDE the markers, because a comma
+    outside them is a separator in one state and a dangling comma in the
+    other. Region-first (splice's placement) gets that for free: the
+    region's last member line carries the trailing comma, commented out
+    along with everything else when `off` runs. A region that ends up LAST
+    instead — `adopt` of a last-member key — needs the mirror image: the
+    member before it gives up the comma it can no longer justify once the
+    region is commented out, and the separator moves inside the markers on
+    a line of its own.
+    """
+    region = maybe_region(lines)
+    bounds = _object_bounds(lines)
+    if region is None or bounds is None:
+        return lines
+    begin, end = region
+    opens, close = bounds
+    if not opens < begin or not end < close:
+        return lines
+    out = list(lines)
+    following = [i for i in range(end + 1, close) if _is_live(out[i])]
+    if following:
+        out[following[-1]] = _drop_comma(out[following[-1]])
+        return out
+    last = _last_member_line(out, begin, end)
+    if last is not None:
+        out[last] = _drop_comma(out[last])
+    preceding = [i for i in range(opens + 1, begin) if _is_live(out[i])]
+    if preceding:
+        out[preceding[-1]] = _drop_comma(out[preceding[-1]])
+        indent = _split_indent(out[begin])[0]
+        off = region_state(out, begin, end) == "off"
+        out.insert(begin + 1, indent + (OFF_PREFIX if off else "") + ",")
+    return out
+
+
 def key_span(lines: list[str], start: int) -> int:
     """Last line index of the JSON value opened on lines[start].
 
@@ -190,53 +276,41 @@ def splice_region(lines: list[str]) -> list[str]:
 
     Region-first is the contract's own placement (#34 item 3): the packaged
     region ends `//- },` because a member follows it there, so splicing it
-    last would leave a trailing comma and invalid JSON. Comma normalisation
-    either side of the region is the one sanctioned edit outside the markers,
-    and it happens only here, at creation.
+    last would leave a trailing comma and invalid JSON. `normalise_commas`
+    then repairs the joins either side of it.
     """
-    opens = next((i for i, l in enumerate(lines)
-                  if l.strip().endswith("{")), None)
-    close = next((i for i in range(len(lines) - 1, -1, -1)
-                  if lines[i].strip() == "}"), None)
-    if opens is None or close is None or close <= opens:
+    bounds = _object_bounds(lines)
+    if bounds is None:
         raise VscodeError(
             f"{SETTINGS_REL} is not a settings object this tool can edit "
             f"(no opening or closing brace on a line of its own) — fix or "
             f"remove the file, then re-run")
+    opens, _ = bounds
     region = packaged_region_lines()
-    out = lines[:opens + 1] + region + lines[opens + 1:]
-    region_end = opens + len(region)
-    close += len(region)
-    following = [i for i in range(region_end + 1, close)
-                 if out[i].strip() and not out[i].strip().startswith("//")]
-    if following:
-        last = following[-1]
-        if out[last].rstrip().endswith(","):
-            out[last] = out[last].rstrip()[:-1]
-    else:
-        for i in range(region_end - 1, opens, -1):
-            indent, body = _split_indent(out[i])
-            if body.startswith(OFF_PREFIX) and body.rstrip().endswith(","):
-                out[i] = indent + body.rstrip()[:-1]
-                break
-    return out
+    return normalise_commas(lines[:opens + 1] + region + lines[opens + 1:])
 
 
 def adopt_key(lines: list[str], key_idx: int) -> list[str]:
     """Bracket the existing rules with the markers, content untouched —
     the minimum span, key line through its closing brace. Nearby
     commented-out blocks stay outside: they are comments, and `off` never
-    needs to touch them."""
+    needs to touch them. Only the commas either side are normalised —
+    without that, adopting the object's LAST member leaves the member
+    before it with a comma that dangles as soon as `off` runs."""
     end = key_span(lines, key_idx)
     indent = _split_indent(lines[key_idx])[0]
     out = list(lines)
     out.insert(end + 1, indent + MARKER_END)
     out.insert(key_idx, indent + MARKER_BEGIN)
-    return out
+    return normalise_commas(out)
 
 
 def replace_region(lines: list[str], begin: int, end: int) -> list[str]:
-    return lines[:begin] + packaged_region_lines() + lines[end + 1:]
+    """The packaged region in place of the current one, commas normalised:
+    the packaged region ends `//- },`, which is a dangling comma when the
+    region is the object's last (or only) member."""
+    return normalise_commas(
+        lines[:begin] + packaged_region_lines() + lines[end + 1:])
 
 
 # ── Editors ─────────────────────────────────────────────────────────────
@@ -297,7 +371,11 @@ def discover_editors(which=shutil.which, platform=sys.platform,
     return found
 
 
-def pick_editor(editors: list[Editor], wanted: str | None) -> Editor:
+def pick_editor(editors: list[Editor], wanted: str | None, *,
+                prompt: bool = True) -> Editor:
+    """The editor to act on. `prompt=False` is for read-only callers
+    (status): resolve stable-else-first and never ask — "install into"
+    is both a block and a lie in a command that installs nothing."""
     if wanted:
         match = next((e for e in editors if e.cli_id == wanted), None)
         if match is None:
@@ -313,6 +391,8 @@ def pick_editor(editors: list[Editor], wanted: str | None) -> Editor:
     if len(editors) == 1:
         return editors[0]
     stable = next((e for e in editors if e.cli_id == "code"), None)
+    if not prompt:
+        return stable or editors[0]
     if not _interactive():
         if stable:
             return stable
@@ -550,9 +630,12 @@ def cmd_status(args) -> int:
               "locations)")
     else:
         try:
-            editor = pick_editor(editors, args.editor)
-        except VscodeError:
+            editor = pick_editor(editors, args.editor, prompt=False)
+        except VscodeError as exc:
+            # An unmatched --editor must not silently become a report
+            # about a different editor.
             editor = editors[0]
+            print(f"note           {exc}; reporting on {editor.cli_id}")
         print(f"editor         {editor.label} ({editor.path})")
         try:
             installed = installed_version(editor)
@@ -677,9 +760,13 @@ def _offer_highlight(args) -> None:
         return
     proc = _run([editor.path, "--install-extension", HIGHLIGHT_ID])
     if proc.returncode != 0:
-        raise VscodeError(
-            f"{editor.cli_id} --install-extension {HIGHLIGHT_ID} failed: "
-            f"{proc.stderr.strip() or proc.returncode}")
+        # A note, not an error: the toggle is already on disk, and failing
+        # the command here would report the write as unsuccessful.
+        print(f"note: {editor.cli_id} --install-extension {HIGHLIGHT_ID} "
+              f"failed: {proc.stderr.strip() or proc.returncode}")
+        print(f"note: the rules render only once {HIGHLIGHT_ID} is "
+              f"installed")
+        return
     print(f"installed {HIGHLIGHT_ID} (newest release) into {editor.label}")
 
 

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -613,16 +613,173 @@ def cmd_status(args) -> int:
     return 0
 
 
-def cmd_setup(args) -> int:
-    raise VscodeError("not implemented yet")  # Task 7
+# ── Workspace-half subcommands ──────────────────────────────────────────
+
+def _read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").split("\n")
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _packaged_settings_lines() -> list[str]:
+    return (init.packaged_bytes("vscode/settings.json")
+            .decode("utf-8").split("\n"))
+
+
+def _resolve_conflict(args) -> str:
+    """Decision 6: an unmanaged highlight.regexes is never appended to and
+    never overwritten unasked. Adopt is the recommendation: rules already
+    in a workspace almost certainly came from this colour language, so
+    what differs is more likely deliberate tuning than drift."""
+    if args.adopt:
+        return "adopt"
+    if args.replace:
+        return "replace"
+    if not _interactive():
+        raise VscodeError(
+            f'{SETTINGS_REL} already defines "highlight.regexes" outside '
+            f"the managed markers — pass --adopt to bring it under "
+            f"management, content untouched (recommended), or --replace "
+            f"to overwrite it with the packaged rules")
+    print(f'{SETTINGS_REL} already defines "highlight.regexes" outside '
+          f"the managed markers.")
+    print("  [a] adopt (recommended) — bracket the existing rules with "
+          "the markers, content untouched")
+    print("  [r] replace — discard them and write the packaged rules")
+    print("  [c] cancel — change nothing")
+    answer = _ask("choice [a/r/c]: ").strip().lower()
+    return {"a": "adopt", "r": "replace"}.get(answer, "cancel")
+
+
+def _offer_highlight(args) -> None:
+    """Decision 1: the rules are inert without the highlight extension,
+    so detect and offer — but the toggle already succeeded, so nothing
+    here may fail the command."""
+    try:
+        editor = pick_editor(discover_editors(), args.editor)
+    except VscodeError as exc:
+        print(f"note: {exc}")
+        print(f"note: the rules render only once {HIGHLIGHT_ID} is "
+              f"installed")
+        return
+    if _has_extension(editor, HIGHLIGHT_ID):
+        return
+    if not args.yes and not _interactive():
+        print(f"note: {HIGHLIGHT_ID} is not installed in {editor.label}; "
+              f"the rules render only once it is — install it with: "
+              f"{editor.cli_id} --install-extension {HIGHLIGHT_ID}")
+        return
+    if not _confirm(f"install {HIGHLIGHT_ID} into {editor.label} "
+                    f"(it renders these rules)?", args.yes):
+        return
+    proc = _run([editor.path, "--install-extension", HIGHLIGHT_ID])
+    if proc.returncode != 0:
+        raise VscodeError(
+            f"{editor.cli_id} --install-extension {HIGHLIGHT_ID} failed: "
+            f"{proc.stderr.strip() or proc.returncode}")
+    print(f"installed {HIGHLIGHT_ID} (newest release) into {editor.label}")
 
 
 def cmd_on(args) -> int:
-    raise VscodeError("not implemented yet")  # Task 7
+    root = _config.resolve_workspace(args.workspace).root
+    path = root / SETTINGS_REL
+    if not path.is_file():
+        # Decision 4's easy case: absent — write the packaged file (the
+        # scaffold and this path can never drift apart) and enable it.
+        lines = _packaged_settings_lines()
+        begin, end = maybe_region(lines)
+        _write_lines(path, enable_region(lines, begin, end))
+        print(f"created {SETTINGS_REL} with source-view colouring on")
+    else:
+        lines = _read_lines(path)
+        region = maybe_region(lines)          # raises on unbalanced
+        if region is None:
+            key = find_unmanaged_key(lines, None)
+            if key is None:
+                lines = splice_region(lines)
+            else:
+                choice = _resolve_conflict(args)
+                if choice == "cancel":
+                    print("cancelled — nothing written")
+                    return 1
+                if choice == "adopt":
+                    lines = adopt_key(lines, key)
+                else:
+                    end_idx = key_span(lines, key)
+                    lines = splice_region(lines[:key]
+                                          + lines[end_idx + 1:])
+            begin, end = maybe_region(lines)
+            _write_lines(path, enable_region(lines, begin, end))
+            print(f"source-view colouring on ({SETTINGS_REL})")
+        elif args.replace:
+            # The region-level reset: packaged rules, enabled — the one
+            # deliberate way local tuning is discarded.
+            lines = replace_region(lines, *region)
+            begin, end = maybe_region(lines)
+            _write_lines(path, enable_region(lines, begin, end))
+            print("managed block reset to the packaged rules and enabled")
+        else:
+            state = region_state(lines, *region)
+            if state == "on":
+                print("source-view colouring is already on")
+            elif state == "empty":
+                raise VscodeError(
+                    "the managed block has nothing to enable — re-run "
+                    "with --replace to restore the packaged rules")
+            else:
+                _write_lines(path, enable_region(lines, *region))
+                print(f"source-view colouring on ({SETTINGS_REL})")
+    _offer_highlight(args)
+    return 0
 
 
 def cmd_off(args) -> int:
-    raise VscodeError("not implemented yet")  # Task 7
+    root = _config.resolve_workspace(args.workspace).root
+    path = root / SETTINGS_REL
+    if not path.is_file():
+        raise VscodeError(
+            f"no {SETTINGS_REL} in this workspace — nothing to turn off")
+    lines = _read_lines(path)
+    region = maybe_region(lines)
+    if region is None:
+        raise VscodeError(
+            f"no managed block in {SETTINGS_REL} — nothing this tool "
+            f"turned on; if colouring is enabled outside bunnyforge's "
+            f"markers, edit the file by hand (or run `bunnyforge vscode "
+            f"on` first to bring it under management)")
+    if region_state(lines, *region) == "off":
+        print("source-view colouring is already off")
+    else:
+        _write_lines(path, disable_region(lines, *region))
+        print(f"source-view colouring off ({SETTINGS_REL})")
+    # Toggling the setting is what was asked; uninstalling is a bigger
+    # action reached for deliberately, so hint rather than infer.
+    print("the markdown-preview half is a separate extension — to remove "
+          "it too: bunnyforge vscode uninstall")
+    return 0
+
+
+def cmd_setup(args) -> int:
+    rc = _ensure(args, update_only=False)
+    if rc != 0:
+        return rc
+    try:
+        _config.resolve_workspace(args.workspace)
+    except (_config.ConfigError, _workspace.WorkspaceError):
+        print("no campaign workspace here — run `bunnyforge vscode on` "
+              "inside one to enable source-view colouring")
+        return 0
+    if not args.yes and not _interactive():
+        print("hint: `bunnyforge vscode on` enables source-view "
+              "colouring in this workspace")
+        return 0
+    if _confirm("turn source-view colouring on in this workspace?",
+                args.yes):
+        return cmd_on(args)
+    return 0
 
 
 # ── The front door ──────────────────────────────────────────────────────

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -65,3 +65,63 @@ OFF_PREFIX = "//- "
 
 SETTINGS_REL = ".vscode/settings.json"
 TIMEOUT = 10  # seconds, every network call
+
+
+# ── The marker-region engine ────────────────────────────────────────────
+# Pure text -> text. State is always DERIVED from the region's content,
+# never stored anywhere it could disagree with reality.
+
+def _split_indent(line: str) -> tuple[str, str]:
+    body = line.lstrip(" \t")
+    return line[:len(line) - len(body)], body
+
+
+def maybe_region(lines: list[str]) -> tuple[int, int] | None:
+    """The (begin, end) marker line indices, or None when neither marker
+    exists (the create-the-block case). A lone, duplicated, or reversed
+    marker raises: rewriting between markers that cannot be trusted would
+    destroy a file the user hand-edited, so refuse and say why.
+    """
+    begins = [i for i, l in enumerate(lines) if l.strip() == MARKER_BEGIN]
+    ends = [i for i, l in enumerate(lines) if l.strip() == MARKER_END]
+    if not begins and not ends:
+        return None
+    if len(begins) != 1 or len(ends) != 1 or ends[0] < begins[0]:
+        raise VscodeError(
+            f"the managed markers in {SETTINGS_REL} are unbalanced "
+            f"({len(begins)} begin, {len(ends)} end) — refusing to guess "
+            f"which lines are managed; restore the single marker pair by "
+            f"hand, then re-run")
+    return begins[0], ends[0]
+
+
+def region_state(lines: list[str], begin: int, end: int) -> str:
+    """"off" outranks "on": a region holding both disabled and live lines
+    was hand-mangled, and reporting it off lets `on` heal it (enabling
+    strips every prefix, converging the region to fully live)."""
+    live = False
+    for line in lines[begin + 1:end]:
+        body = line.strip()
+        if body.startswith(OFF_PREFIX):
+            return "off"
+        if body and not body.startswith("//"):
+            live = True
+    return "on" if live else "empty"
+
+
+def enable_region(lines: list[str], begin: int, end: int) -> list[str]:
+    out = list(lines)
+    for i in range(begin + 1, end):
+        indent, body = _split_indent(out[i])
+        if body.startswith(OFF_PREFIX):
+            out[i] = indent + body[len(OFF_PREFIX):]
+    return out
+
+
+def disable_region(lines: list[str], begin: int, end: int) -> list[str]:
+    out = list(lines)
+    for i in range(begin + 1, end):
+        indent, body = _split_indent(out[i])
+        if body and not body.startswith("//"):
+            out[i] = indent + OFF_PREFIX + body
+    return out

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -554,14 +554,21 @@ def cmd_status(args) -> int:
         except VscodeError:
             editor = editors[0]
         print(f"editor         {editor.label} ({editor.path})")
-        installed = installed_version(editor)
+        try:
+            installed = installed_version(editor)
+            installed_error = None
+        except VscodeError as exc:
+            installed = None
+            installed_error = exc
         try:
             release = latest_release()
             available = f"{_dotted(release.version)} available"
         except VscodeError as exc:
             release = None
             available = f"latest unknown ({exc})"
-        if installed is None:
+        if installed_error is not None:
+            print(f"preview ext    unknown ({installed_error}); {available}")
+        elif installed is None:
             print(f"preview ext    not installed; {available}")
         elif release and installed < release.version:
             print(f"preview ext    {_dotted(installed)} installed; "

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+vscode.py — install/update the visibility-preview extension and toggle the
+source-view colouring.
+
+The extension (dcltdw.bunnyforge-visibility-preview) is not on the VS Code
+Marketplace and will not be (publishing needs an Azure DevOps org linked to
+an active Azure subscription); it sideloads as a .vsix from GitHub releases,
+and sideloaded extensions never auto-update — which is why version detection
+is the feature here rather than a nicety. It also has no runtime on/off
+switch and cannot be given one (static preview contributions cannot read
+extension configuration): for the preview half, "off" means "not installed".
+
+The source-view half is a "highlight.regexes" block in the workspace's
+.vscode/settings.json, delimited by marker comments that `bunnyforge init`
+ships (inert) since #34. Python has no stdlib JSONC round-tripper and the
+file's comments carry real documentation, so this module never parses the
+file as JSON: it rewrites lines between the markers and refuses when the
+markers are missing where required, or unbalanced anywhere.
+
+Workspace requirements differ per subcommand (the first command in the
+package where that is true): install/update/uninstall act on the machine's
+editor and never resolve a workspace; on/off always do; status and setup
+resolve one opportunistically and say plainly when there is none.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from typing import NamedTuple
+
+from bunnyforge import _config, _workspace, init
+
+
+class VscodeError(Exception):
+    """The command cannot proceed. The message is user-facing."""
+
+
+# The extension and its pinned source. Never read from config: this module
+# downloads and installs code, so the source is a constant an auditor can
+# read, not a value a workspace can redirect.
+EXTENSION_ID = "dcltdw.bunnyforge-visibility-preview"
+EXTENSION_REPO = "dcltdw/bunnyforge-visibility-preview"
+RELEASES_URL = ("https://api.github.com/repos/"
+                + EXTENSION_REPO + "/releases/latest")
+HIGHLIGHT_ID = "fabiospampinato.vscode-highlight"
+
+# The managed-region contract, frozen by #34: data/vscode/settings.json
+# ships these exact marker lines, and the disabled form of a line is
+# indent + OFF_PREFIX + body. tests/test_vscode.py pins the packaged file
+# to these constants so neither can drift alone.
+MARKER_BEGIN = "// bunnyforge:begin visibility-colouring"
+MARKER_END = "// bunnyforge:end visibility-colouring"
+OFF_PREFIX = "//- "
+
+SETTINGS_REL = ".vscode/settings.json"
+TIMEOUT = 10  # seconds, every network call

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -125,3 +125,115 @@ def disable_region(lines: list[str], begin: int, end: int) -> list[str]:
         if body and not body.startswith("//"):
             out[i] = indent + OFF_PREFIX + body
     return out
+
+
+# ── Structural edits: create, adopt, replace ────────────────────────────
+
+def key_span(lines: list[str], start: int) -> int:
+    """Last line index of the JSON value opened on lines[start].
+
+    A character scan tracking string state (so braces inside regex keys
+    and string values don't count) and line comments, balancing {}/[].
+    """
+    depth = 0
+    opened = False
+    for i in range(start, len(lines)):
+        line = lines[i]
+        in_string = False
+        j = 0
+        while j < len(line):
+            ch = line[j]
+            if in_string:
+                if ch == "\\":
+                    j += 1
+                elif ch == '"':
+                    in_string = False
+            elif ch == '"':
+                in_string = True
+            elif line[j:j + 2] == "//":
+                break
+            elif ch in "{[":
+                depth += 1
+                opened = True
+            elif ch in "}]":
+                depth -= 1
+            j += 1
+        if opened and depth <= 0:
+            return i
+    raise VscodeError(
+        f'the "highlight.regexes" value in {SETTINGS_REL} never closes '
+        f"its braces — fix the file by hand, then re-run")
+
+
+def find_unmanaged_key(lines: list[str],
+                       region: tuple[int, int] | None) -> int | None:
+    """A live top-level "highlight.regexes" outside the managed region —
+    the duplicate-key hazard: appending a second copy would be a silent
+    last-one-wins that clobbers whatever the user tuned."""
+    for i, line in enumerate(lines):
+        if region and region[0] <= i <= region[1]:
+            continue
+        if line.strip().startswith('"highlight.regexes"'):
+            return i
+    return None
+
+
+def packaged_region_lines() -> list[str]:
+    lines = (init.packaged_bytes("vscode/settings.json")
+             .decode("utf-8").split("\n"))
+    begin, end = maybe_region(lines)  # never None: the drift test pins it
+    return lines[begin:end + 1]
+
+
+def splice_region(lines: list[str]) -> list[str]:
+    """Insert the packaged managed region as the object's FIRST member.
+
+    Region-first is the contract's own placement (#34 item 3): the packaged
+    region ends `//- },` because a member follows it there, so splicing it
+    last would leave a trailing comma and invalid JSON. Comma normalisation
+    either side of the region is the one sanctioned edit outside the markers,
+    and it happens only here, at creation.
+    """
+    opens = next((i for i, l in enumerate(lines)
+                  if l.strip().endswith("{")), None)
+    close = next((i for i in range(len(lines) - 1, -1, -1)
+                  if lines[i].strip() == "}"), None)
+    if opens is None or close is None or close <= opens:
+        raise VscodeError(
+            f"{SETTINGS_REL} is not a settings object this tool can edit "
+            f"(no opening or closing brace on a line of its own) — fix or "
+            f"remove the file, then re-run")
+    region = packaged_region_lines()
+    out = lines[:opens + 1] + region + lines[opens + 1:]
+    region_end = opens + len(region)
+    close += len(region)
+    following = [i for i in range(region_end + 1, close)
+                 if out[i].strip() and not out[i].strip().startswith("//")]
+    if following:
+        last = following[-1]
+        if out[last].rstrip().endswith(","):
+            out[last] = out[last].rstrip()[:-1]
+    else:
+        for i in range(region_end - 1, opens, -1):
+            indent, body = _split_indent(out[i])
+            if body.startswith(OFF_PREFIX) and body.rstrip().endswith(","):
+                out[i] = indent + body.rstrip()[:-1]
+                break
+    return out
+
+
+def adopt_key(lines: list[str], key_idx: int) -> list[str]:
+    """Bracket the existing rules with the markers, content untouched —
+    the minimum span, key line through its closing brace. Nearby
+    commented-out blocks stay outside: they are comments, and `off` never
+    needs to touch them."""
+    end = key_span(lines, key_idx)
+    indent = _split_indent(lines[key_idx])[0]
+    out = list(lines)
+    out.insert(end + 1, indent + MARKER_END)
+    out.insert(key_idx, indent + MARKER_BEGIN)
+    return out
+
+
+def replace_region(lines: list[str], begin: int, end: int) -> list[str]:
+    return lines[:begin] + packaged_region_lines() + lines[end + 1:]

--- a/src/bunnyforge/vscode.py
+++ b/src/bunnyforge/vscode.py
@@ -131,6 +131,15 @@ def disable_region(lines: list[str], begin: int, end: int) -> list[str]:
 
 # ── Structural edits: create, adopt, replace ────────────────────────────
 
+def _with_endings_of(new: list[str], model: list[str]) -> list[str]:
+    """`new` lines given the line ending `model` uses. Lines read with
+    newline="" keep their own terminator, so inserting package lines (LF)
+    into a CRLF file would leave it half-translated."""
+    if not any(l.endswith("\r") for l in model):
+        return new
+    return [l if l.endswith("\r") else l + "\r" for l in new]
+
+
 def _is_live(line: str) -> bool:
     """A line carrying JSON the parser sees — not blank, not a comment."""
     body = line.strip()
@@ -138,8 +147,8 @@ def _is_live(line: str) -> bool:
 
 
 def _drop_comma(line: str) -> str:
-    """The same line without its trailing comma, indent, OFF_PREFIX and
-    any line-ending kept exactly as they were."""
+    """The line with its trailing comma removed; indent, OFF_PREFIX and
+    any line ending kept exactly as they were."""
     indent, body = _split_indent(line)
     prefix = ""
     if body.startswith(OFF_PREFIX):
@@ -198,7 +207,7 @@ def normalise_commas(lines: list[str]) -> list[str]:
         return lines
     begin, end = region
     opens, close = bounds
-    if not opens < begin or not end < close:
+    if not opens < begin < end < close:
         return lines
     out = list(lines)
     following = [i for i in range(end + 1, close) if _is_live(out[i])]
@@ -265,15 +274,6 @@ def find_unmanaged_key(lines: list[str],
         if line.strip().startswith('"highlight.regexes"'):
             return i
     return None
-
-
-def _with_endings_of(new: list[str], model: list[str]) -> list[str]:
-    """`new` lines given the line ending `model` uses. Lines read with
-    newline="" keep their own terminator, so inserting package lines (LF)
-    into a CRLF file would leave it half-translated."""
-    if not any(l.endswith("\r") for l in model):
-        return new
-    return [l if l.endswith("\r") else l + "\r" for l in new]
 
 
 def packaged_region_lines() -> list[str]:
@@ -677,8 +677,13 @@ def cmd_uninstall(args) -> int:
 
 
 def _has_extension(editor: Editor, extension_id: str) -> bool:
+    # Case-insensitively, like installed_version: editors print an
+    # extension's publisher and name in the casing the marketplace has,
+    # and a case-sensitive miss re-offers an install on every run.
     proc = _run([editor.path, "--list-extensions"])
-    return proc.returncode == 0 and extension_id in proc.stdout.split()
+    return (proc.returncode == 0
+            and extension_id.lower() in
+            [name.lower() for name in proc.stdout.split()])
 
 
 def cmd_status(args) -> int:
@@ -935,9 +940,13 @@ def cmd_off(args) -> int:
 
 
 def cmd_setup(args) -> int:
-    rc = _ensure(args, update_only=False)
-    if rc != 0:
-        return rc
+    # A declined install is the one non-zero _ensure returns (everything
+    # else raises). The sideloaded preview extension is optional and
+    # init.py sends every new user here, so declining it must not cost
+    # them the workspace half — or exit 1.
+    if _ensure(args, update_only=False) != 0:
+        print("skipping the preview extension — carrying on with the "
+              "source-view colouring")
     try:
         _config.resolve_workspace(args.workspace)
     except (_config.ConfigError, _workspace.WorkspaceError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from bunnyforge import (
     init,
     review,
     run_tests,
+    vscode,
 )
 
 REPO = Path(__file__).resolve().parent.parent
@@ -46,6 +47,7 @@ class TestDispatchTable(unittest.TestCase):
             "import-perceptions": import_perceptions.main,
             "build-sheets": build_sheets.main,
             "names": generate_names.main,
+            "vscode": vscode.main,
             "test": run_tests.main,
         })
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -531,9 +531,10 @@ class TestFreshWorkspacePassesTheGate(unittest.TestCase):
 
 
 # The cross-ticket contract with the `bunnyforge vscode` command (#33):
-# these strings are frozen — #33 parses them. Hardcoded here because the
-# constants live in vscode.py, which does not exist until #33; that ticket
-# adds a drift test binding its constants to these packaged bytes.
+# these strings are frozen — that command parses them. Hardcoded rather
+# than imported from vscode.py, which holds the same constants; the drift
+# test in tests/test_vscode.py (TestPackagedContract) binds those to these
+# packaged bytes, so neither side can move alone.
 VSCODE_MARKER_BEGIN = "// bunnyforge:begin visibility-colouring"
 VSCODE_MARKER_END = "// bunnyforge:end visibility-colouring"
 VSCODE_OFF_PREFIX = "//- "
@@ -543,9 +544,9 @@ class TestVscodeScaffold(unittest.TestCase):
     """The packaged .vscode/ files: inert on arrival, valid JSONC in both
     toggle states, and never recommending an extension that cannot resolve.
 
-    These tests deliberately do NOT pin the comment prose — #33 rewords the
-    headers to name the `bunnyforge vscode` command once it exists, and that
-    must not break this suite.
+    These tests deliberately do NOT pin the comment prose — #33 reworded
+    the headers to name the `bunnyforge vscode` command, and further
+    rewording must not break this suite.
     """
 
     def _settings_lines(self) -> list[str]:
@@ -574,7 +575,8 @@ class TestVscodeScaffold(unittest.TestCase):
 
     def _as_json(self, *, enabled: bool):
         """The file as strict JSON: comments dropped, //-  lines optionally
-        re-enabled first — simulating exactly what #33's toggle does."""
+        re-enabled first — simulating exactly what the `bunnyforge vscode`
+        toggle does."""
         kept = []
         for raw in self._settings_lines():
             indent = raw[:len(raw) - len(raw.lstrip())]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -407,16 +407,14 @@ class TestWhatInitWrites(unittest.TestCase):
             self.assertIn(pointer, result.stdout)
             self.assertTrue((target / pointer).is_file())
 
-    def test_points_at_the_inert_vscode_scaffold_once(self):
-        # One line, not a paragraph (#34) — and command-neutral: the
-        # `bunnyforge vscode` command does not exist until #33.
+    def test_points_at_the_vscode_command_once(self):
         tmp = Path(self.enterContext(tempfile.TemporaryDirectory())).resolve()
         out = io.StringIO()
         with contextlib.redirect_stdout(out):
             self.assertEqual(
                 init.main([str(tmp / "new"), "--name", "X"]), 0)
         pointing = [l for l in out.getvalue().splitlines()
-                    if ".vscode/settings.json" in l]
+                    if "bunnyforge vscode" in l]
         self.assertEqual(len(pointing), 1, out.getvalue())
 
     def test_does_not_write_reanchor_txt(self):

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -290,3 +290,109 @@ class TestVersions(unittest.TestCase):
                                return_value=_proc("", 1, "boom")):
             with self.assertRaises(vscode.VscodeError):
                 vscode.installed_version(editor)
+
+
+RELEASE_JSON = json.dumps({
+    "tag_name": "v0.2.0",
+    "assets": [
+        {"name": "notes.txt", "browser_download_url": "u1", "size": 1},
+        {"name": "bunnyforge-visibility-preview-0.2.0.vsix",
+         "browser_download_url": "https://example.invalid/x.vsix",
+         "size": 4,
+         "digest": "sha256:" + __import__("hashlib")
+             .sha256(b"vsix").hexdigest()},
+    ],
+}).encode("utf-8")
+
+
+class TestReleaseClient(unittest.TestCase):
+
+    def test_parses_tag_asset_size_and_digest(self):
+        release = vscode.latest_release(fetch=lambda url: RELEASE_JSON)
+        self.assertEqual(release.version, (0, 2, 0))
+        self.assertEqual(release.tag, "v0.2.0")
+        self.assertEqual(release.vsix_name,
+                         "bunnyforge-visibility-preview-0.2.0.vsix")
+        self.assertEqual(release.size, 4)
+        self.assertEqual(len(release.sha256), 64)
+
+    def test_a_missing_digest_is_tolerated(self):
+        data = json.loads(RELEASE_JSON)
+        del data["assets"][1]["digest"]
+        release = vscode.latest_release(
+            fetch=lambda url: json.dumps(data).encode())
+        self.assertIsNone(release.sha256)
+
+    def test_no_vsix_asset_is_an_error(self):
+        data = json.loads(RELEASE_JSON)
+        data["assets"] = data["assets"][:1]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.latest_release(fetch=lambda url: json.dumps(data).encode())
+
+    def test_network_failure_degrades_to_a_named_error(self):
+        def down(url):
+            raise OSError("no route to host")
+        with self.assertRaises(vscode.VscodeError) as ctx:
+            vscode.latest_release(fetch=down)
+        self.assertIn("GitHub", str(ctx.exception))
+
+
+class TestCache(unittest.TestCase):
+
+    def test_cache_dir_per_platform(self):
+        home = Path.home()
+        self.assertEqual(
+            vscode.cache_dir(platform="darwin", environ={}),
+            home / "Library" / "Caches" / "bunnyforge" / "vsix")
+        self.assertEqual(
+            vscode.cache_dir(platform="linux",
+                             environ={"XDG_CACHE_HOME": "/xdg"}),
+            Path("/xdg") / "bunnyforge" / "vsix")
+        self.assertEqual(
+            vscode.cache_dir(platform="linux", environ={}),
+            home / ".cache" / "bunnyforge" / "vsix")
+        self.assertEqual(
+            vscode.cache_dir(platform="win32",
+                             environ={"LOCALAPPDATA": r"C:\U\l"}),
+            Path(r"C:\U\l") / "bunnyforge" / "vsix")
+
+    def _release(self):
+        return vscode.latest_release(fetch=lambda url: RELEASE_JSON)
+
+    def test_downloads_verifies_and_caches(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        calls = []
+
+        def fetch(url):
+            calls.append(url)
+            return b"vsix"
+
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            path = vscode.obtain_vsix(self._release(), fetch=fetch)
+            self.assertEqual(path.read_bytes(), b"vsix")
+            # second run: cache hit, no re-download
+            vscode.obtain_vsix(self._release(), fetch=fetch)
+        self.assertEqual(calls, ["https://example.invalid/x.vsix"])
+
+    def test_a_truncated_download_never_lands_in_the_cache(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            with self.assertRaises(vscode.VscodeError):
+                vscode.obtain_vsix(self._release(), fetch=lambda url: b"vs")
+        self.assertEqual(list(tmp.iterdir()), [])
+
+    def test_a_digest_mismatch_never_lands_in_the_cache(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            with self.assertRaises(vscode.VscodeError):
+                vscode.obtain_vsix(self._release(), fetch=lambda url: b"eviL")
+        self.assertEqual(list(tmp.iterdir()), [])
+
+    def test_a_corrupt_cached_file_is_re_downloaded(self):
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        release = self._release()
+        stale = tmp / f"{release.tag}-{release.vsix_name}"
+        stale.write_bytes(b"junk-of-wrong-size")
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            path = vscode.obtain_vsix(release, fetch=lambda url: b"vsix")
+        self.assertEqual(path.read_bytes(), b"vsix")

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -453,6 +453,28 @@ class TestReleaseClient(unittest.TestCase):
         with self.assertRaises(vscode.VscodeError):
             vscode.latest_release(fetch=lambda url: json.dumps(data).encode())
 
+    def test_a_malformed_body_is_a_named_error_not_a_traceback(self):
+        # A 200 carrying an HTML error page, a bare API message, or a
+        # release object missing the fields we read: all VscodeError,
+        # because main() only catches those (and OSError).
+        bodies = {
+            "html": b"<html>404 not found</html>",
+            "not an object": b'"nope"',
+            "api message": b'{"message": "Not Found"}',
+            "no tag_name": json.dumps(
+                {"assets": [{"name": "x.vsix",
+                             "browser_download_url": "u", "size": 1}]}
+            ).encode(),
+            "no download url": json.dumps(
+                {"tag_name": "v1.0.0", "assets": [{"name": "x.vsix"}]}
+            ).encode(),
+            "assets not a list": b'{"tag_name": "v1.0.0", "assets": 3}',
+        }
+        for label, body in bodies.items():
+            with self.subTest(label):
+                with self.assertRaises(vscode.VscodeError):
+                    vscode.latest_release(fetch=lambda url, b=body: b)
+
     def test_network_failure_degrades_to_a_named_error(self):
         def down(url):
             raise OSError("no route to host")
@@ -512,6 +534,18 @@ class TestCache(unittest.TestCase):
                 vscode.obtain_vsix(self._release(), fetch=lambda url: b"eviL")
         self.assertEqual(list(tmp.iterdir()), [])
 
+    def test_a_hostile_tag_cannot_escape_the_cache_directory(self):
+        # tag and asset name are API-supplied strings on their way into a
+        # path that gets mkdir(parents=True).
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        release = self._release()._replace(
+            tag="../../../../tmp/pwned", vsix_name="../x.vsix")
+        with mock.patch.object(vscode, "cache_dir", return_value=tmp):
+            path = vscode.obtain_vsix(release, fetch=lambda url: b"vsix")
+        self.assertEqual(path.parent, tmp)
+        self.assertNotIn("/", path.name)
+        self.assertEqual(path.read_bytes(), b"vsix")
+
     def test_a_corrupt_cached_file_is_re_downloaded(self):
         tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
         release = self._release()
@@ -564,6 +598,29 @@ class TestInstallUpdate(unittest.TestCase):
         install_call = run.call_args_list[-1].args[0]
         self.assertEqual(install_call[:2], ["/u/code", "--install-extension"])
         self.assertIn("--force", install_call)
+
+    def test_the_consent_block_says_the_digest_was_verified(self):
+        _machine_env(self)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            vscode.main(["install", "--yes"])
+        self.assertIn("digest", out.getvalue())
+        self.assertIn("(verified)", out.getvalue())
+
+    def test_the_consent_block_says_when_no_digest_was_published(self):
+        # Without a digest the check degrades to length only; consent has
+        # to say so rather than imply a tamper-proof download.
+        real = vscode.latest_release
+        _machine_env(self)
+        data = json.loads(RELEASE_JSON)
+        del data["assets"][1]["digest"]
+        self.enterContext(mock.patch.object(
+            vscode, "latest_release",
+            return_value=real(fetch=lambda url: json.dumps(data).encode())))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["install", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("none published", out.getvalue())
+        self.assertIn("size only", out.getvalue())
 
     def test_install_is_idempotent_at_the_current_version(self):
         run = _machine_env(self, installed="0.2.0")
@@ -683,6 +740,19 @@ class TestStatus(unittest.TestCase):
         text = out.getvalue()
         self.assertIn("bogus", text)                  # the filter, named
         self.assertIn("Visual Studio Code", text)     # what it reports on
+
+    def test_status_survives_a_malformed_release_body(self):
+        real = vscode.latest_release
+        self._status_env([
+            vscode.Editor("code", "Visual Studio Code", "/u/code", True)])
+        self.enterContext(mock.patch.object(
+            vscode, "latest_release",
+            side_effect=lambda: real(
+                fetch=lambda url: b"<html>rate limited</html>")))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)                    # reports; never crashes
+        self.assertIn("latest unknown", out.getvalue())
 
     def test_status_degrades_when_github_is_unreachable(self):
         editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -881,6 +881,58 @@ class TestOnOff(unittest.TestCase):
         self.assertIn("unbalanced", err)
 
 
+class TestWriting(unittest.TestCase):
+    """The workspace file is hand-edited and hand-commented, and there is
+    no backup: how it is written matters as much as what is written."""
+
+    def test_a_failed_write_leaves_the_original_file_intact(self):
+        # A lone surrogate cannot be encoded as UTF-8, so the write dies
+        # partway — exactly where a full disk or a SIGINT would.
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        path = tmp / ".vscode" / "settings.json"
+        path.parent.mkdir()
+        original = '{\n  // years of hand-written notes\n  "a": 1\n}\n'
+        path.write_text(original, encoding="utf-8")
+        with self.assertRaises(UnicodeEncodeError):
+            vscode._write_lines(path, ["{", "  \ud800", "}"])
+        self.assertEqual(path.read_text("utf-8"), original)
+        self.assertEqual(sorted(p.name for p in path.parent.iterdir()),
+                         ["settings.json"])        # and no temp litter
+
+    def test_a_crlf_file_keeps_its_crlf_line_endings(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        packaged = (init.packaged_bytes("vscode/settings.json")
+                    .decode("utf-8"))
+        (ws / ".vscode" / "settings.json").write_bytes(
+            packaged.replace("\n", "\r\n").encode("utf-8"))
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        raw = (ws / ".vscode" / "settings.json").read_bytes()
+        self.assertNotIn(b"\n", raw.replace(b"\r\n", b""))   # every LF
+        lines = _settings_of(ws)                             # is a CRLF
+        self.assertEqual(
+            vscode.region_state(lines, *vscode.maybe_region(lines)), "on")
+
+
+    def test_a_spliced_region_takes_the_files_line_endings(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_bytes(
+            b'{\r\n  "editor.rulers": [80]\r\n}\r\n')
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        raw = (ws / ".vscode" / "settings.json").read_bytes()
+        self.assertNotIn(b"\n", raw.replace(b"\r\n", b""))
+        lines = _settings_of(ws)
+        self.assertEqual(
+            vscode.region_state(lines, *vscode.maybe_region(lines)), "on")
+
+
 class TestOnConflict(unittest.TestCase):
     """The duplicate-key hazard: a hand-rolled highlight.regexes outside
     any markers. Never append; ask, recommending adopt (decision 6)."""

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -537,3 +537,30 @@ class TestStatus(unittest.TestCase):
             rc = vscode.main(["status"])
         self.assertEqual(rc, 0)               # status reports; never fails
         self.assertIn("unknown", out.getvalue())
+
+    def test_status_degrades_when_the_editor_cli_fails(self):
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        self.enterContext(mock.patch.object(
+            vscode, "installed_version",
+            side_effect=vscode.VscodeError("code --list-extensions failed: "
+                                           "permission denied")))
+        self.enterContext(mock.patch.object(vscode, "_run",
+                                            return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "latest_release",
+            return_value=vscode.latest_release(fetch=lambda url: RELEASE_JSON)))
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)               # status reports; never fails
+        text = out.getvalue()
+        self.assertEqual(text.count("preview ext"), 1)  # exactly one line
+        self.assertIn("unknown", text)
+        self.assertIn("permission denied", text)
+        self.assertIn("none found", text)     # workspace half still runs

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -39,3 +39,73 @@ class TestPackagedContract(unittest.TestCase):
         on = vscode.enable_region(lines, begin, end)
         self.assertEqual(vscode.region_state(on, begin, end), "on")
         self.assertEqual(vscode.disable_region(on, begin, end), lines)
+
+
+SAMPLE_OFF = """\
+{
+  // prose above the marker — never load-bearing
+  // bunnyforge:begin visibility-colouring
+  //- "highlight.regexes": {
+    //- "^x$": { "a": 1 }
+  //- },
+  // ── ALTERNATE ──
+  // "highlight.regexes": { "alt": true }
+  // bunnyforge:end visibility-colouring
+  "markdown.preview.frontMatter": "table"
+}
+""".split("\n")
+
+
+class TestRegionEngine(unittest.TestCase):
+
+    def test_finds_the_marker_pair(self):
+        self.assertEqual(vscode.maybe_region(SAMPLE_OFF), (2, 8))
+
+    def test_no_markers_at_all_is_none_not_an_error(self):
+        self.assertIsNone(vscode.maybe_region(["{", "}"]))
+
+    def test_a_lone_or_duplicated_marker_is_a_refusal(self):
+        lone = [l for l in SAMPLE_OFF if l.strip() != vscode.MARKER_END]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.maybe_region(lone)
+        doubled = SAMPLE_OFF + ["  " + vscode.MARKER_BEGIN]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.maybe_region(doubled)
+
+    def test_end_before_begin_is_a_refusal(self):
+        swapped = ["  " + vscode.MARKER_END, "x", "  " + vscode.MARKER_BEGIN]
+        with self.assertRaises(vscode.VscodeError):
+            vscode.maybe_region(swapped)
+
+    def test_state_off_then_on(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        self.assertEqual(vscode.region_state(SAMPLE_OFF, begin, end), "off")
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(vscode.region_state(on, begin, end), "on")
+
+    def test_enable_preserves_indentation_and_plain_comments(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(on[3], '  "highlight.regexes": {')
+        self.assertEqual(on[4], '    "^x$": { "a": 1 }')
+        self.assertEqual(on[6], "  // ── ALTERNATE ──")   # untouched
+        self.assertEqual(on[7], '  // "highlight.regexes": { "alt": true }')
+        self.assertEqual(on[9], '  "markdown.preview.frontMatter": "table"')
+
+    def test_disable_prefixes_only_live_lines(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(vscode.disable_region(on, begin, end), SAMPLE_OFF)
+
+    def test_both_transforms_are_idempotent(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        off2 = vscode.disable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(off2, SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(vscode.enable_region(on, begin, end), on)
+
+    def test_transforms_do_not_mutate_their_input(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        copy = list(SAMPLE_OFF)
+        vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertEqual(SAMPLE_OFF, copy)

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -8,6 +8,7 @@ real editor.
 import contextlib
 import io
 import json
+import os
 import subprocess
 import tempfile
 import unittest
@@ -396,3 +397,143 @@ class TestCache(unittest.TestCase):
         with mock.patch.object(vscode, "cache_dir", return_value=tmp):
             path = vscode.obtain_vsix(release, fetch=lambda url: b"vsix")
         self.assertEqual(path.read_bytes(), b"vsix")
+
+
+def _machine_env(case, installed=None, listing=""):
+    """Patch discovery + subprocess + network for machine-half tests.
+    Returns the mock recording _run calls."""
+    editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+    case.enterContext(mock.patch.object(
+        vscode, "discover_editors", return_value=[editor]))
+    shown = (f"{vscode.EXTENSION_ID}@{installed}\n" if installed else "")
+    run = case.enterContext(mock.patch.object(
+        vscode, "_run",
+        return_value=_proc(shown + listing)))
+    case.enterContext(mock.patch.object(
+        vscode, "latest_release",
+        return_value=vscode.latest_release(fetch=lambda url: RELEASE_JSON)))
+    tmp = Path(case.enterContext(tempfile.TemporaryDirectory()))
+    case.enterContext(mock.patch.object(
+        vscode, "obtain_vsix",
+        return_value=tmp / "v0.2.0-x.vsix"))
+    return run
+
+
+class TestInstallUpdate(unittest.TestCase):
+
+    def test_install_refuses_without_yes_when_not_a_tty(self):
+        _machine_env(self)
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            with contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(io.StringIO()) as err:
+                rc = vscode.main(["install"])
+        self.assertEqual(rc, 1)
+        self.assertIn("--yes", err.getvalue())
+
+    def test_install_prints_provenance_and_installs(self):
+        run = _machine_env(self)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["install", "--yes"])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn(vscode.EXTENSION_REPO, text)   # pinned source, shown
+        self.assertIn("v0.2.0", text)
+        install_call = run.call_args_list[-1].args[0]
+        self.assertEqual(install_call[:2], ["/u/code", "--install-extension"])
+        self.assertIn("--force", install_call)
+
+    def test_install_is_idempotent_at_the_current_version(self):
+        run = _machine_env(self, installed="0.2.0")
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["install", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to do", out.getvalue())
+        for call in run.call_args_list:
+            self.assertNotIn("--install-extension", call.args[0])
+
+    def test_update_requires_an_existing_install(self):
+        _machine_env(self)   # nothing installed
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["update", "--yes"])
+        self.assertEqual(rc, 1)
+        self.assertIn("vscode install", err.getvalue())
+
+    def test_update_upgrades_an_older_install(self):
+        run = _machine_env(self, installed="0.1.0")
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["update", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("--install-extension",
+                      run.call_args_list[-1].args[0])
+
+
+class TestUninstall(unittest.TestCase):
+
+    def test_uninstall_runs_the_editor_cli(self):
+        run = _machine_env(self, installed="0.2.0")
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["uninstall", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(run.call_args_list[-1].args[0],
+                         ["/u/code", "--uninstall-extension",
+                          vscode.EXTENSION_ID])
+
+    def test_uninstall_when_absent_is_a_no_op(self):
+        run = _machine_env(self)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["uninstall", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to do", out.getvalue())
+        for call in run.call_args_list:
+            self.assertNotIn("--uninstall-extension", call.args[0])
+
+
+class TestStatus(unittest.TestCase):
+
+    def test_status_without_a_workspace_says_so_and_exits_zero(self):
+        _machine_env(self, installed="0.1.0")
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("0.1.0", text)          # installed
+        self.assertIn("0.2.0", text)          # available
+        self.assertIn("none found", text)     # the workspace half, plainly
+
+    def test_status_reports_colouring_state_in_a_workspace(self):
+        _machine_env(self, installed="0.2.0")
+        ws = Path(self.enterContext(tempfile.TemporaryDirectory())).resolve()
+        (ws / "campaign.toml").write_text(
+            '[campaign]\nnamespace = "probe"\n', encoding="utf-8")
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_bytes(
+            init.packaged_bytes("vscode/settings.json"))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertIn("off", out.getvalue())
+
+    def test_status_degrades_when_github_is_unreachable(self):
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        self.enterContext(mock.patch.object(vscode, "_run",
+                                            return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "latest_release",
+            side_effect=vscode.VscodeError("couldn't reach GitHub")))
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)               # status reports; never fails
+        self.assertIn("unknown", out.getvalue())

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -564,3 +564,245 @@ class TestStatus(unittest.TestCase):
         self.assertIn("unknown", text)
         self.assertIn("permission denied", text)
         self.assertIn("none found", text)     # workspace half still runs
+
+
+def _ws(case) -> Path:
+    ws = Path(case.enterContext(tempfile.TemporaryDirectory())).resolve()
+    (ws / "campaign.toml").write_text(
+        '[campaign]\nnamespace = "probe"\n', encoding="utf-8")
+    return ws
+
+
+def _settings_of(ws: Path) -> list[str]:
+    return (ws / ".vscode" / "settings.json").read_text("utf-8").split("\n")
+
+
+class TestOnOff(unittest.TestCase):
+
+    def _on(self, ws, *flags):
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["on", "--workspace", str(ws), *flags])
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_on_creates_the_file_enabled_when_absent(self):
+        ws = _ws(self)
+        rc, _, _ = self._on(ws)
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+        # strict JSON once comments drop — the whole point of the layout
+        json.loads("\n".join(
+            l for l in lines if not l.strip().startswith("//")))
+
+    def test_on_enables_a_scaffolded_off_file(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_bytes(
+            init.packaged_bytes("vscode/settings.json"))
+        rc, _, _ = self._on(ws)
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+
+    def test_on_is_idempotent(self):
+        ws = _ws(self)
+        self._on(ws)
+        before = _settings_of(ws)
+        rc, out, _ = self._on(ws)
+        self.assertEqual(rc, 0)
+        self.assertIn("already on", out)
+        self.assertEqual(_settings_of(ws), before)
+
+    def test_on_replace_resets_hand_tuning(self):
+        ws = _ws(self)
+        self._on(ws)
+        lines = _settings_of(ws)
+        begin, _ = vscode.maybe_region(lines)
+        # hand-tune a colour inside the region
+        idx = next(i for i, l in enumerate(lines) if "#ff3333" in l)
+        lines[idx] = lines[idx].replace("#ff3333", "#123456")
+        (ws / ".vscode" / "settings.json").write_text(
+            "\n".join(lines), encoding="utf-8")
+        rc, _, _ = self._on(ws, "--replace")
+        self.assertEqual(rc, 0)
+        text = "\n".join(_settings_of(ws))
+        self.assertNotIn("#123456", text)
+        self.assertIn("#ff3333", text)
+
+    def test_on_without_replace_preserves_hand_tuning(self):
+        ws = _ws(self)
+        self._on(ws)
+        lines = _settings_of(ws)
+        idx = next(i for i, l in enumerate(lines) if "#ff3333" in l)
+        lines[idx] = lines[idx].replace("#ff3333", "#123456")
+        (ws / ".vscode" / "settings.json").write_text(
+            "\n".join(lines), encoding="utf-8")
+        rc, _, _ = self._on(ws)   # already on; must not touch content
+        self.assertEqual(rc, 0)
+        self.assertIn("#123456", "\n".join(_settings_of(ws)))
+
+    def test_off_disables_and_hints_at_uninstall(self):
+        ws = _ws(self)
+        self._on(ws)
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["off", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "off")
+        self.assertIn("bunnyforge vscode uninstall", out.getvalue())
+        # the pin survives off — it belongs to the preview half
+        self.assertIn('"markdown.preview.frontMatter": "table"',
+                      "\n".join(lines))
+
+    def test_off_with_no_file_is_a_named_error(self):
+        ws = _ws(self)
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["off", "--workspace", str(ws)])
+        self.assertEqual(rc, 1)
+        self.assertIn("error: ", err.getvalue())
+
+    def test_on_refuses_unbalanced_markers(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        broken = [l for l in init.packaged_bytes("vscode/settings.json")
+                  .decode("utf-8").split("\n")
+                  if l.strip() != vscode.MARKER_END]
+        (ws / ".vscode" / "settings.json").write_text(
+            "\n".join(broken), encoding="utf-8")
+        rc, _, err = self._on(ws)
+        self.assertEqual(rc, 1)
+        self.assertIn("unbalanced", err)
+
+
+class TestOnConflict(unittest.TestCase):
+    """The duplicate-key hazard: a hand-rolled highlight.regexes outside
+    any markers. Never append; ask, recommending adopt (decision 6)."""
+
+    def _handrolled(self) -> Path:
+        ws = Path(self.enterContext(tempfile.TemporaryDirectory())).resolve()
+        (ws / "campaign.toml").write_text(
+            '[campaign]\nnamespace = "probe"\n', encoding="utf-8")
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_text(
+            '{\n'
+            '  // tuned by hand, years of care\n'
+            '  "highlight.regexes": {\n'
+            '    "^tuned$": { "regexFlags": "gm" }\n'
+            '  },\n'
+            '  "editor.rulers": [80]\n'
+            '}\n', encoding="utf-8")
+        return ws
+
+    def _on(self, ws, *flags):
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["on", "--workspace", str(ws), *flags])
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_no_tty_and_no_flag_fails_naming_both_flags(self):
+        ws = self._handrolled()
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            rc, _, err = self._on(ws)
+        self.assertEqual(rc, 1)
+        self.assertIn("--adopt", err)
+        self.assertIn("--replace", err)
+        self.assertIn("tuned", (ws / ".vscode" / "settings.json")
+                      .read_text("utf-8"))   # untouched
+
+    def test_adopt_brackets_the_users_rules_untouched(self):
+        ws = self._handrolled()
+        rc, _, _ = self._on(ws, "--adopt")
+        self.assertEqual(rc, 0)
+        lines = _settings_of(ws)
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+        self.assertIn("^tuned$", "\n".join(lines[begin:end]))
+        self.assertIn("years of care", "\n".join(lines))   # comment kept
+
+    def test_replace_discards_the_users_rules_for_packaged(self):
+        ws = self._handrolled()
+        rc, _, _ = self._on(ws, "--replace")
+        self.assertEqual(rc, 0)
+        text = "\n".join(_settings_of(ws))
+        self.assertNotIn("^tuned$", text)
+        self.assertIn("visibility:", text)
+        self.assertIn('"editor.rulers": [80]', text)   # rest of file kept
+
+    def test_interactive_cancel_changes_nothing_and_exits_nonzero(self):
+        ws = self._handrolled()
+        before = (ws / ".vscode" / "settings.json").read_text("utf-8")
+        with mock.patch.object(vscode, "_interactive", return_value=True), \
+             mock.patch.object(vscode, "_ask", return_value="c"):
+            rc, _, _ = self._on(ws)
+        self.assertEqual(rc, 1)
+        self.assertEqual((ws / ".vscode" / "settings.json")
+                         .read_text("utf-8"), before)
+
+
+class TestOfferHighlight(unittest.TestCase):
+
+    def test_on_offers_the_highlight_extension_when_missing(self):
+        ws = _ws(self)
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        run = self.enterContext(mock.patch.object(
+            vscode, "_run", return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=True))
+        self.enterContext(mock.patch.object(
+            vscode, "_ask", return_value="y"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            ["/u/code", "--install-extension", vscode.HIGHLIGHT_ID],
+            [c.args[0] for c in run.call_args_list])
+
+    def test_non_interactive_on_prints_a_hint_instead(self):
+        ws = _ws(self)
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        run = self.enterContext(mock.patch.object(
+            vscode, "_run", return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=False))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)               # the toggle itself succeeded
+        self.assertIn(vscode.HIGHLIGHT_ID, out.getvalue())
+        self.assertNotIn(
+            ["/u/code", "--install-extension", vscode.HIGHLIGHT_ID],
+            [c.args[0] for c in run.call_args_list])
+
+
+class TestSetup(unittest.TestCase):
+
+    def test_setup_installs_then_offers_on_in_a_workspace(self):
+        ws = _ws(self)
+        _machine_env(self)
+        self.enterContext(mock.patch.object(
+            vscode, "_offer_highlight"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["setup", "--workspace", str(ws), "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertTrue((ws / ".vscode" / "settings.json").is_file())
+
+    def test_setup_without_a_workspace_still_installs(self):
+        _machine_env(self)
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(Path, "cwd", return_value=tmp), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["setup", "--yes"])
+        self.assertEqual(rc, 0)
+        self.assertIn("no campaign workspace", out.getvalue())

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -109,3 +109,102 @@ class TestRegionEngine(unittest.TestCase):
         copy = list(SAMPLE_OFF)
         vscode.enable_region(SAMPLE_OFF, begin, end)
         self.assertEqual(SAMPLE_OFF, copy)
+
+
+UNMANAGED = """\
+{
+  "editor.rulers": [80],
+  "highlight.regexes": {
+    "^(## GM notes{2}\\\\s*)$": {
+      "decorations": [{ "quote": "}" }]
+    }
+  },
+  "markdown.preview.frontMatter": "table"
+}
+""".split("\n")
+
+
+class TestStructuralEdits(unittest.TestCase):
+
+    def test_key_span_ignores_braces_in_strings_and_comments(self):
+        # The value spans lines 2..6; "{2}" and the "}" string literal and
+        # any // comment must not confuse the scan.
+        self.assertEqual(vscode.key_span(UNMANAGED, 2), 6)
+
+    def test_key_span_on_a_single_line_value(self):
+        doc = ['{', '  "highlight.regexes": {},', '}']
+        self.assertEqual(vscode.key_span(doc, 1), 1)
+
+    def test_key_span_refuses_unbalanced_braces(self):
+        with self.assertRaises(vscode.VscodeError):
+            vscode.key_span(['{', '  "highlight.regexes": {', ''], 1)
+
+    def test_finds_the_unmanaged_key_and_skips_comments(self):
+        self.assertEqual(vscode.find_unmanaged_key(UNMANAGED, None), 2)
+        commented = ['{', '  // "highlight.regexes": {}', '}']
+        self.assertIsNone(vscode.find_unmanaged_key(commented, None))
+
+    def test_the_managed_region_is_not_reported_as_unmanaged(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        on = vscode.enable_region(SAMPLE_OFF, begin, end)
+        self.assertIsNone(vscode.find_unmanaged_key(on, (begin, end)))
+
+    def test_packaged_region_lines_are_marker_delimited(self):
+        region = vscode.packaged_region_lines()
+        self.assertEqual(region[0].strip(), vscode.MARKER_BEGIN)
+        self.assertEqual(region[-1].strip(), vscode.MARKER_END)
+
+    def _spliced_json(self, doc, *, enabled=True):
+        """Splice, optionally enable, then parse as strict JSON — the
+        property that actually matters in both toggle states."""
+        out = vscode.splice_region(doc)
+        begin, end = vscode.maybe_region(out)
+        lines = vscode.enable_region(out, begin, end) if enabled else out
+        return out, json.loads("\n".join(
+            l for l in lines if not l.strip().startswith("//")))
+
+    def test_splice_puts_the_region_first_and_keeps_the_file_valid(self):
+        doc = ['{', '  // a comment', '  "editor.rulers": [80]', '}', '']
+        out, data = self._spliced_json(doc)
+        begin, _ = vscode.maybe_region(out)
+        self.assertEqual(begin, 1)                  # first member, not last
+        self.assertIn("highlight.regexes", data)
+        self.assertEqual(data["editor.rulers"], [80])
+        # and the off state parses too — the region is all comments there
+        self.assertEqual(self._spliced_json(doc, enabled=False)[1],
+                         {"editor.rulers": [80]})
+
+    def test_splice_into_an_empty_object_needs_no_comma(self):
+        # Sole member: the region's own trailing comma has to go, or the
+        # enabled file ends `},}`.
+        _, data = self._spliced_json(['{', '}'])
+        self.assertEqual(list(data), ["highlight.regexes"])
+
+    def test_splice_drops_a_dangling_comma_from_the_last_member(self):
+        # cmd_on's replace path deletes the unmanaged key before splicing;
+        # if that key was last, the member before it keeps its comma.
+        _, data = self._spliced_json(['{', '  "editor.rulers": [80],', '}'])
+        self.assertEqual(data["editor.rulers"], [80])
+        self.assertIn("highlight.regexes", data)
+
+    def test_splice_refuses_a_file_with_no_closing_brace(self):
+        with self.assertRaises(vscode.VscodeError):
+            vscode.splice_region(['not a settings object'])
+
+    def test_adopt_brackets_the_minimum_span(self):
+        out = vscode.adopt_key(UNMANAGED, 2)
+        begin, end = vscode.maybe_region(out)
+        self.assertEqual(out[begin].strip(), vscode.MARKER_BEGIN)
+        self.assertEqual(out[begin + 1], UNMANAGED[2])   # content untouched
+        self.assertEqual(out[end - 1], UNMANAGED[6])
+        self.assertEqual(vscode.region_state(out, begin, end), "on")
+        # everything outside the span is byte-identical
+        self.assertEqual(out[:begin], UNMANAGED[:2])
+        self.assertEqual(out[end + 1:], UNMANAGED[7:])
+
+    def test_replace_swaps_region_content_for_packaged(self):
+        begin, end = vscode.maybe_region(SAMPLE_OFF)
+        out = vscode.replace_region(SAMPLE_OFF, begin, end)
+        nbegin, nend = vscode.maybe_region(out)
+        self.assertEqual(out[nbegin:nend + 1], vscode.packaged_region_lines())
+        self.assertEqual(out[:nbegin], SAMPLE_OFF[:begin])   # outside kept

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -42,6 +42,73 @@ class TestPackagedContract(unittest.TestCase):
         self.assertEqual(vscode.disable_region(on, begin, end), lines)
 
 
+def _hand_switched_to_saturated() -> list[str]:
+    """The packaged file with the palette switched BY HAND, exactly as the
+    header comment describes: the active (high) palette commented out with
+    plain "//" — never "//- ", which the toggle owns — and the saturated
+    alternate uncommented, carrying the separator its new neighbours need.
+    """
+    lines = (init.packaged_bytes("vscode/settings.json")
+             .decode("utf-8").split("\n"))
+    begin, _ = vscode.maybe_region(lines)
+    sat = next(i for i, l in enumerate(lines)
+               if l.strip().startswith("// ── ALTERNATE: saturated"))
+    sub = next(i for i, l in enumerate(lines)
+               if l.strip().startswith("// ── ALTERNATE: subtle"))
+    out = list(lines)
+    for i in range(begin + 1, sat):
+        indent, body = vscode._split_indent(out[i])
+        if body.startswith(vscode.OFF_PREFIX):
+            out[i] = indent + "// " + body[len(vscode.OFF_PREFIX):]
+    live = []
+    for i in range(sat + 1, sub):
+        indent, body = vscode._split_indent(out[i])
+        if body.startswith("// "):
+            out[i] = indent + body[3:]
+            live.append(i)
+    out[live[-1]] += ","          # a live member now: "table" follows it
+    return out
+
+
+class TestPackagedPaletteSwitch(unittest.TestCase):
+    """Finding 1: the header's switch instructions have to be a procedure
+    the engine survives — "//- " is the toggle's prefix, not the user's."""
+
+    def _lines(self) -> list[str]:
+        return (init.packaged_bytes("vscode/settings.json")
+                .decode("utf-8").split("\n"))
+
+    def test_the_header_documents_the_plain_comment_switch(self):
+        lines = self._lines()
+        begin, _ = vscode.maybe_region(lines)
+        header = "\n".join(lines[:begin])
+        self.assertIn("--replace", header)       # the supported restore
+        self.assertIn('"//"', header)            # how to deactivate a palette
+
+    def test_a_hand_switched_palette_reports_on_and_is_valid_json(self):
+        lines = _hand_switched_to_saturated()
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "on")
+        data = json.loads("\n".join(
+            l for l in lines if not l.strip().startswith("//")))
+        self.assertIn("highlight.regexes", data)
+        self.assertIn("#ef4444",                 # the saturated palette, live
+                      json.dumps(data["highlight.regexes"]))
+
+    def test_vscode_on_is_a_no_op_on_a_hand_switched_palette(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        before = "\n".join(_hand_switched_to_saturated())
+        (ws / ".vscode" / "settings.json").write_text(before, encoding="utf-8")
+        with mock.patch.object(vscode, "_offer_highlight"), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertIn("already on", out.getvalue())
+        self.assertEqual((ws / ".vscode" / "settings.json")
+                         .read_text("utf-8"), before)
+
+
 SAMPLE_OFF = """\
 {
   // prose above the marker — never load-bearing
@@ -188,6 +255,20 @@ class TestStructuralEdits(unittest.TestCase):
         self.assertEqual(data["editor.rulers"], [80])
         self.assertIn("highlight.regexes", data)
 
+    def test_splice_ignores_a_comment_shaped_like_an_opening_brace(self):
+        # A header comment ending in `{` must not become the splice point:
+        # the region would land outside the settings object.
+        doc = ['// tuned for project {',
+               '{',
+               '  "editor.rulers": [80]',
+               '}',
+               '']
+        out, data = self._spliced_json(doc)
+        begin, _ = vscode.maybe_region(out)
+        self.assertEqual(out.index('{'), begin - 1)   # inside the object
+        self.assertIn("highlight.regexes", data)
+        self.assertEqual(data["editor.rulers"], [80])
+
     def test_splice_refuses_a_file_with_no_closing_brace(self):
         with self.assertRaises(vscode.VscodeError):
             vscode.splice_region(['not a settings object'])
@@ -202,6 +283,48 @@ class TestStructuralEdits(unittest.TestCase):
         # everything outside the span is byte-identical
         self.assertEqual(out[:begin], UNMANAGED[:2])
         self.assertEqual(out[end + 1:], UNMANAGED[7:])
+
+    def _both_states(self, lines):
+        """The file parsed as strict JSON in BOTH toggle states — the
+        property comma normalisation exists to hold."""
+        begin, end = vscode.maybe_region(lines)
+        return tuple(
+            json.loads("\n".join(l for l in state
+                                 if not l.strip().startswith("//")))
+            for state in (vscode.enable_region(lines, begin, end),
+                          vscode.disable_region(lines, begin, end)))
+
+    def test_adopt_of_a_last_member_key_is_valid_in_both_states(self):
+        # The member before a last-placed region keeps a comma that
+        # dangles the moment `off` comments the region out.
+        doc = ['{',
+               '  "editor.tabSize": 2,',
+               '  "highlight.regexes": {',
+               '    "^x$": { "a": 1 }',
+               '  }',
+               '}',
+               '']
+        out = vscode.adopt_key(doc, 2)
+        on, off = self._both_states(out)
+        self.assertEqual(on["editor.tabSize"], 2)
+        self.assertIn("highlight.regexes", on)
+        self.assertEqual(off, {"editor.tabSize": 2})
+        self.assertIn('    "^x$": { "a": 1 }', out)   # content untouched
+
+    def test_adopt_of_a_sole_key_is_valid_in_both_states(self):
+        doc = ['{', '  "highlight.regexes": {},', '}', '']
+        on, off = self._both_states(vscode.adopt_key(doc, 1))
+        self.assertEqual(list(on), ["highlight.regexes"])
+        self.assertEqual(off, {})
+
+    def test_replace_of_a_last_placed_region_is_valid_in_both_states(self):
+        # `on` into `{}` strips the region's trailing comma; `--replace`
+        # restores the packaged region, which still carries it.
+        doc = vscode.splice_region(['{', '}'])
+        begin, end = vscode.maybe_region(doc)
+        on, off = self._both_states(vscode.replace_region(doc, begin, end))
+        self.assertEqual(list(on), ["highlight.regexes"])
+        self.assertEqual(off, {})
 
     def test_replace_swaps_region_content_for_packaged(self):
         begin, end = vscode.maybe_region(SAMPLE_OFF)
@@ -519,6 +642,48 @@ class TestStatus(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("off", out.getvalue())
 
+    def _status_env(self, editors):
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=editors))
+        self.enterContext(mock.patch.object(vscode, "_run",
+                                            return_value=_proc("")))
+        self.enterContext(mock.patch.object(
+            vscode, "latest_release",
+            return_value=vscode.latest_release(
+                fetch=lambda url: RELEASE_JSON)))
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_WORKSPACE"}
+        self.enterContext(mock.patch.dict(os.environ, env, clear=True))
+        self.enterContext(mock.patch.object(Path, "cwd", return_value=tmp))
+
+    def test_status_never_prompts_when_several_editors_are_found(self):
+        # A read-only report must not block on "install into [1]:".
+        self._status_env([
+            vscode.Editor("code", "Visual Studio Code", "/u/code", True),
+            vscode.Editor("cursor", "Cursor", "/u/cursor", False),
+        ])
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=True))
+        ask = self.enterContext(mock.patch.object(
+            vscode, "_ask", side_effect=AssertionError("status prompted")))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status"])
+        self.assertEqual(rc, 0)
+        ask.assert_not_called()
+        self.assertIn("Visual Studio Code", out.getvalue())   # stable wins
+        self.assertNotIn("install into", out.getvalue())
+
+    def test_status_says_when_the_editor_filter_matched_nothing(self):
+        self._status_env([
+            vscode.Editor("code", "Visual Studio Code", "/u/code", True)])
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["status", "--editor", "bogus"])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("bogus", text)                  # the filter, named
+        self.assertIn("Visual Studio Code", text)     # what it reports on
+
     def test_status_degrades_when_github_is_unreachable(self):
         editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
         self.enterContext(mock.patch.object(
@@ -659,6 +824,43 @@ class TestOnOff(unittest.TestCase):
         self.assertIn('"markdown.preview.frontMatter": "table"',
                       "\n".join(lines))
 
+    def test_on_replace_after_on_into_an_empty_object(self):
+        # Two commands from a bare `{}`: the region is the sole member,
+        # so the packaged region's trailing comma must not come back.
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_text("{\n}\n",
+                                                      encoding="utf-8")
+        self.assertEqual(self._on(ws)[0], 0)
+        self.assertEqual(self._on(ws, "--replace")[0], 0)
+        json.loads("\n".join(l for l in _settings_of(ws)
+                             if not l.strip().startswith("//")))
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(vscode.main(["off", "--workspace", str(ws)]), 0)
+        self.assertEqual(json.loads("\n".join(
+            l for l in _settings_of(ws)
+            if not l.strip().startswith("//"))), {})
+
+    def test_adopt_then_off_leaves_valid_json(self):
+        ws = _ws(self)
+        (ws / ".vscode").mkdir()
+        (ws / ".vscode" / "settings.json").write_text(
+            '{\n'
+            '  "editor.tabSize": 2,\n'
+            '  "highlight.regexes": {\n'
+            '    "^tuned$": { "regexFlags": "gm" }\n'
+            '  }\n'
+            '}\n', encoding="utf-8")
+        self.assertEqual(self._on(ws, "--adopt")[0], 0)
+        data = json.loads("\n".join(l for l in _settings_of(ws)
+                                    if not l.strip().startswith("//")))
+        self.assertIn("^tuned$", json.dumps(data["highlight.regexes"]))
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(vscode.main(["off", "--workspace", str(ws)]), 0)
+        self.assertEqual(json.loads("\n".join(
+            l for l in _settings_of(ws)
+            if not l.strip().startswith("//"))), {"editor.tabSize": 2})
+
     def test_off_with_no_file_is_a_named_error(self):
         ws = _ws(self)
         with contextlib.redirect_stderr(io.StringIO()) as err:
@@ -764,6 +966,29 @@ class TestOfferHighlight(unittest.TestCase):
         self.assertIn(
             ["/u/code", "--install-extension", vscode.HIGHLIGHT_ID],
             [c.args[0] for c in run.call_args_list])
+
+    def test_a_failed_highlight_install_does_not_fail_the_toggle(self):
+        # The file was already written; the offer is a courtesy, so a
+        # non-zero editor CLI is a note, never the command's exit code.
+        ws = _ws(self)
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        self.enterContext(mock.patch.object(
+            vscode, "_run", return_value=_proc("", 1, "marketplace down")))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=True))
+        self.enterContext(mock.patch.object(vscode, "_ask", return_value="y"))
+        with contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertEqual(err.getvalue(), "")
+        self.assertIn("note:", out.getvalue())
+        self.assertIn("marketplace down", out.getvalue())
+        lines = _settings_of(ws)
+        self.assertEqual(vscode.region_state(
+            lines, *vscode.maybe_region(lines)), "on")
 
     def test_non_interactive_on_prints_a_hint_instead(self):
         ws = _ws(self)

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -408,6 +408,16 @@ class TestVersions(unittest.TestCase):
         with mock.patch.object(vscode, "_run", return_value=_proc("a@1\n")):
             self.assertIsNone(vscode.installed_version(editor))
 
+    def test_has_extension_matches_however_the_listing_cases_it(self):
+        # installed_version already lowercases; the two lookups must not
+        # disagree, or `on` re-offers an extension that is already there.
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        listing = "Other.Thing\nFabioSpampinato.vscode-highlight\n"
+        with mock.patch.object(vscode, "_run", return_value=_proc(listing)):
+            self.assertTrue(
+                vscode._has_extension(editor, vscode.HIGHLIGHT_ID))
+            self.assertFalse(vscode._has_extension(editor, "no.such"))
+
     def test_installed_version_surfaces_a_failing_cli(self):
         editor = vscode.Editor("code", "VS Code", "/u/code", True)
         with mock.patch.object(vscode, "_run",
@@ -1112,6 +1122,24 @@ class TestOfferHighlight(unittest.TestCase):
         self.assertEqual(vscode.region_state(
             lines, *vscode.maybe_region(lines)), "on")
 
+    def test_an_already_installed_extension_is_not_re_offered(self):
+        ws = _ws(self)
+        editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
+        self.enterContext(mock.patch.object(
+            vscode, "discover_editors", return_value=[editor]))
+        run = self.enterContext(mock.patch.object(
+            vscode, "_run",
+            return_value=_proc("FabioSpampinato.vscode-highlight\n")))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=True))
+        self.enterContext(mock.patch.object(
+            vscode, "_ask", side_effect=AssertionError("re-offered")))
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = vscode.main(["on", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        for call in run.call_args_list:
+            self.assertNotIn("--install-extension", call.args[0])
+
     def test_non_interactive_on_prints_a_hint_instead(self):
         ws = _ws(self)
         editor = vscode.Editor("code", "Visual Studio Code", "/u/code", True)
@@ -1140,6 +1168,23 @@ class TestSetup(unittest.TestCase):
         with contextlib.redirect_stdout(io.StringIO()):
             rc = vscode.main(["setup", "--workspace", str(ws), "--yes"])
         self.assertEqual(rc, 0)
+        self.assertTrue((ws / ".vscode" / "settings.json").is_file())
+
+    def test_setup_carries_on_when_the_install_is_declined(self):
+        # The sideloaded preview extension is optional; declining it must
+        # not cost the user the workspace half — `bunnyforge init` sends
+        # every new user here.
+        ws = _ws(self)
+        _machine_env(self)
+        self.enterContext(mock.patch.object(vscode, "_offer_highlight"))
+        self.enterContext(mock.patch.object(
+            vscode, "_interactive", return_value=True))
+        self.enterContext(mock.patch.object(
+            vscode, "_ask", side_effect=["n", "y"]))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = vscode.main(["setup", "--workspace", str(ws)])
+        self.assertEqual(rc, 0)
+        self.assertIn("skipping the preview extension", out.getvalue())
         self.assertTrue((ws / ".vscode" / "settings.json").is_file())
 
     def test_setup_without_a_workspace_still_installs(self):

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -208,3 +208,85 @@ class TestStructuralEdits(unittest.TestCase):
         nbegin, nend = vscode.maybe_region(out)
         self.assertEqual(out[nbegin:nend + 1], vscode.packaged_region_lines())
         self.assertEqual(out[:nbegin], SAMPLE_OFF[:begin])   # outside kept
+
+
+def _proc(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+class TestEditorDiscovery(unittest.TestCase):
+
+    def test_finds_editors_on_path_in_stable_first_order(self):
+        which = {"code": "/usr/bin/code", "cursor": "/usr/bin/cursor"}.get
+        found = vscode.discover_editors(which=which, platform="linux")
+        self.assertEqual([(e.cli_id, e.supported) for e in found],
+                         [("code", True), ("cursor", False)])
+
+    def test_falls_back_to_the_mac_app_bundle(self):
+        mac = ("/Applications/Visual Studio Code.app/Contents/Resources"
+               "/app/bin/code")
+        found = vscode.discover_editors(
+            which=lambda _: None, platform="darwin",
+            exists=lambda p: p == mac)
+        self.assertEqual([e.path for e in found], [mac])
+
+    def test_pick_honours_the_flag_and_rejects_unknown(self):
+        editors = [vscode.Editor("code", "Visual Studio Code",
+                                 "/usr/bin/code", True)]
+        self.assertEqual(vscode.pick_editor(editors, "code"), editors[0])
+        with self.assertRaises(vscode.VscodeError):
+            vscode.pick_editor(editors, "codium")
+
+    def test_pick_with_none_found_names_the_command_palette(self):
+        with self.assertRaises(vscode.VscodeError) as ctx:
+            vscode.pick_editor([], None)
+        self.assertIn("Shell Command", str(ctx.exception))
+
+    def test_pick_defaults_to_stable_without_a_tty(self):
+        editors = [
+            vscode.Editor("code", "Visual Studio Code", "/u/code", True),
+            vscode.Editor("cursor", "Cursor", "/u/cursor", False),
+        ]
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            self.assertEqual(vscode.pick_editor(editors, None).cli_id, "code")
+
+    def test_pick_without_stable_and_no_tty_names_the_flag(self):
+        editors = [vscode.Editor("cursor", "Cursor", "/u/cursor", False),
+                   vscode.Editor("codium", "VSCodium", "/u/codium", False)]
+        with mock.patch.object(vscode, "_interactive", return_value=False):
+            with self.assertRaises(vscode.VscodeError) as ctx:
+                vscode.pick_editor(editors, None)
+        self.assertIn("--editor", str(ctx.exception))
+
+
+class TestVersions(unittest.TestCase):
+
+    def test_parse_version_accepts_v_prefix(self):
+        self.assertEqual(vscode.parse_version("v0.1.0"), (0, 1, 0))
+        self.assertEqual(vscode.parse_version("0.10.2"), (0, 10, 2))
+
+    def test_parse_version_refuses_garbage(self):
+        with self.assertRaises(vscode.VscodeError):
+            vscode.parse_version("latest")
+
+    def test_installed_version_parses_the_listing(self):
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        listing = ("other.extension@9.9.9\n"
+                   "dcltdw.bunnyforge-visibility-preview@0.1.0\n")
+        with mock.patch.object(vscode, "_run",
+                               return_value=_proc(listing)) as run:
+            self.assertEqual(vscode.installed_version(editor), (0, 1, 0))
+        run.assert_called_once_with(
+            ["/u/code", "--list-extensions", "--show-versions"])
+
+    def test_installed_version_none_when_absent(self):
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        with mock.patch.object(vscode, "_run", return_value=_proc("a@1\n")):
+            self.assertIsNone(vscode.installed_version(editor))
+
+    def test_installed_version_surfaces_a_failing_cli(self):
+        editor = vscode.Editor("code", "VS Code", "/u/code", True)
+        with mock.patch.object(vscode, "_run",
+                               return_value=_proc("", 1, "boom")):
+            with self.assertRaises(vscode.VscodeError):
+                vscode.installed_version(editor)

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -1,0 +1,41 @@
+"""Tests for bunnyforge.vscode — the editor-integration command.
+
+Everything external is injected or mocked: `_fetch` (network), `_run`
+(subprocess), `_interactive`/`_ask` (TTY). No test touches GitHub or a
+real editor.
+"""
+
+import contextlib
+import io
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bunnyforge import init, vscode
+
+
+class TestPackagedContract(unittest.TestCase):
+    """vscode.py's constants and data/vscode/settings.json are two halves
+    of one contract (#34 froze it); drift between them is a red test."""
+
+    def _lines(self) -> list[str]:
+        return (init.packaged_bytes("vscode/settings.json")
+                .decode("utf-8").split("\n"))
+
+    def test_the_packaged_markers_match_the_constants(self):
+        stripped = [l.strip() for l in self._lines()]
+        self.assertEqual(stripped.count(vscode.MARKER_BEGIN), 1)
+        self.assertEqual(stripped.count(vscode.MARKER_END), 1)
+
+    def test_the_packaged_region_round_trips_through_the_toggle(self):
+        # disable(enable(x)) == x proves the packaged off-form is exactly
+        # what disable_region produces — the byte-level half of the contract.
+        lines = self._lines()
+        begin, end = vscode.maybe_region(lines)
+        self.assertEqual(vscode.region_state(lines, begin, end), "off")
+        on = vscode.enable_region(lines, begin, end)
+        self.assertEqual(vscode.region_state(on, begin, end), "on")
+        self.assertEqual(vscode.disable_region(on, begin, end), lines)


### PR DESCRIPTION
Closes #33. Builds on #34 (merged), which shipped the packaged `.vscode/` scaffold inert.

Base branch: **`main`** (not stacked on anything).

## Files changed
- `src/bunnyforge/vscode.py` (new) — the whole command: constants, marker-region engine, structural edits, editor discovery, release client and cache, seven subcommands, argparse front door.
- `tests/test_vscode.py` (new) — 78 tests. Network, subprocess, TTY and prompt are all injected or mocked; nothing touches a real editor or GitHub.
- `src/bunnyforge/cli.py` (modified) — `vscode` in the import list, `_COMMANDS`, `_SUMMARIES`.
- `src/bunnyforge/init.py` (modified) — the Optional line now names `bunnyforge vscode setup`.
- `src/bunnyforge/data/vscode/settings.json` (modified) — header comment prose only.
- `src/bunnyforge/data/vscode/extensions.json` (modified) — comment prose only.
- `tests/test_cli.py` (modified) — the exact-dispatch-dict assertion.
- `tests/test_init.py` (modified) — the Optional-line test, plus comment prose.
- `README.md` (modified) — new "VS Code integration" section; the older `.vscode/` paragraph trimmed to a pointer.
- `src/bunnyforge/README.md` (modified) — the `.vscode/` paragraph now names the command.
- `docs/superpowers/plans/2026-08-15-vscode-command.md` (new) — the implementation plan.

## Work breakdown

**The marker-region engine.** Python has no stdlib JSONC round-tripper, and `.vscode/settings.json` carries real documentation in its comments, so this module never parses the file as JSON. It rewrites lines between the two `bunnyforge:` marker comments and refuses when the markers are missing where required or unbalanced anywhere. State is always *derived* from the region's content — there is no stored flag that can disagree with the file. `off` outranks `on` when a region holds both, so `on` heals a hand-mangled region.

**The trust path.** The preview extension is not on the Marketplace and will not be, so it sideloads as a `.vsix` from GitHub releases. The repo and URL are module constants an auditor can read, never config. The command prints exactly what it will install and from where — now including whether a digest was published and verified — then confirms; `--yes` opts in for automation, and without a TTY and without `--yes` it refuses. Downloads are verified *before* they reach the cache, so a truncated or digest-mismatched file is never present to be installed later.

**Per-subcommand workspace rules** (settled decision 5): `install`/`update`/`uninstall` never resolve a workspace; `on`/`off` always do; `status` and `setup` resolve one opportunistically and say plainly when there is none. `status` reports and never fails — it degrades to "unknown" for both a network outage and a broken editor CLI, and never prompts.

**The duplicate-key hazard** (settled decision 6): an existing top-level `highlight.regexes` outside the markers is never appended to and never overwritten unasked. The prompt offers adopt (recommended — brackets the user's rules, content untouched), replace, or cancel; cancel writes nothing and exits non-zero; with no TTY and no flag it fails naming both `--adopt` and `--replace`. `on --replace` doubles as the region-level reset.

**The #34 contract is consumed, not redefined.** The marker strings and the `//- ` off-prefix are frozen; a drift test binds this module's constants to the packaged bytes so neither half can move alone.

**Writes are non-destructive.** The workspace file is written to a sibling temp file and `os.replace`d, preserving permissions, so an interrupted write cannot truncate a file the user hand-edited. Line endings are preserved end to end, including on lines the tool inserts, so `on`/`off` never produces a whole-file diff.

## Review notes

A whole-branch review found five Important issues that per-task reviews structurally could not see; all were fixed and re-verified. The most interesting was a cross-ticket seam: #34's packaged header told users to switch palettes by "re-disabling" the active block — but `//- ` is the prefix the toggle owns, so following the instruction literally made `status` report "off" while colouring was live, and made `on` enable two `highlight.regexes` keys at once. The header now says a deactivated palette uses plain `//`.

One design correction was made against the plan, approved by the maintainer before implementation: the plan spliced a newly created managed region in as the object's *last* member, which produced invalid JSON because the frozen region ends `},` with a comma. It now splices region-first, matching #34's contract, with comma normalisation shared across all three structural edits.

## Test expectations
None expected to fail.

## Verification
- `python3 -m unittest discover -s tests -t . -v` → **698 tests, OK**, re-run in a clean detached `git worktree` with its own venv, and again after the rebase.
- Live-network smoke (`python3 -m bunnyforge.vscode status`, installs nothing): resolved the real v0.1.0 release and reported both halves, exit 0 — exercising the macOS app-bundle fallback, since `code` is not on PATH on the dev machine.
- `python3 -m bunnyforge --help` lists `vscode`; `python3 -m bunnyforge vscode --help` shows all seven subcommands and the per-subcommand workspace sentence.
- Contract tests (`TestVscodeScaffold`, `TestPackagedContract`) pass unchanged throughout — the two data-file edits are comment prose only.
- CI green on Python **3.11, 3.12 and 3.13**. This is the load-bearing run: CI installs fresh, so unlike a local run it cannot be shadowed by an install that resolves somewhere other than the checkout.
- Secret scan over the branch diff: clean.

## Operational impact
The new subcommand is not available to an already-installed copy until it is reinstalled — after this merges, `pip install .` from `main`. No migration, and no existing workspace changes until a user runs `bunnyforge vscode on`; `init` already scaffolds the `.vscode/` files inert as of #34.

## Provenance
- Agent: Claude Code (VS Code extension), subagent-driven execution per `superpowers:subagent-driven-development` — 6 implementation dispatches, 8 task reviews, a whole-branch review and one fix wave
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`); implementers and task reviewers on Sonnet, the whole-branch review and fix wave on Opus
