### PR TITLE
Bind the README's scaffold inventory to MANIFEST (#37)

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,7 @@ import contextlib
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -232,6 +233,40 @@ class TestPackagedDataMatchesItsCanonical(unittest.TestCase):
         # overwrites the other.
         dests = [e.dest for e in init.MANIFEST]
         self.assertEqual(sorted(dests), sorted(set(dests)))
+
+    def test_the_readme_inventory_matches_the_manifest(self):
+        # The package README states what init writes as a count, and prose
+        # about the packaged files is embedded doctrine in miniature -- the
+        # exact thing this module's docstring says the manifest exists to
+        # stop drifting silently. It drifted twice before anyone noticed:
+        # it claimed all 16 _Templates/ files when init had written 12 since
+        # the skeletons stopped landing there, and it named neither the
+        # tests/ nor the .vscode/ scaffold. Discipline has now failed on this
+        # one sentence twice, which is the argument for a test rather than
+        # for trying harder (issue #37).
+        #
+        # The TOTAL only, deliberately: the per-group figures are woven
+        # through a prose sentence, so pinning each would tax every rewording
+        # while adding nothing -- the total is what a forgotten MANIFEST
+        # entry moves.
+        #
+        # Asserted unconditionally rather than if-present like the canonicals
+        # above: those are campaign-side files that do not survive the public
+        # cut, whereas this README ships in every repo, so its absence is a
+        # defect anywhere rather than an artefact of the cut.
+        readme = REPO / "src" / "bunnyforge" / "README.md"
+        stated = re.search(r"What it writes — (\d+) files",
+                           readme.read_text(encoding="utf-8"))
+        self.assertIsNotNone(
+            stated,
+            "src/bunnyforge/README.md's inventory sentence has been reworded "
+            "past the pattern this test reads -- restate the count or update "
+            "the pattern, because an unmatched regex would pass vacuously "
+            "and silently retire the guard")
+        self.assertEqual(
+            int(stated.group(1)), len(init.MANIFEST),
+            f"src/bunnyforge/README.md says init writes {stated.group(1)} "
+            f"files; MANIFEST has {len(init.MANIFEST)} entries")
 
 
 class TestSlugify(unittest.TestCase):


### PR DESCRIPTION
Closes #37. Test-only — no production code changes.

Base branch: **`main`** (not stacked on anything).

## Files changed
- `tests/test_init.py` (modified) — one test added to `TestPackagedDataMatchesItsCanonical`, plus `import re`.

## Work breakdown

`src/bunnyforge/README.md` states what `init` writes as a count, and nothing checked it. It drifted **twice** without anyone noticing:

- it claimed all **16** `_Templates/` files after the two doctrine skeletons stopped landing there and `init` began writing **12**;
- it named neither the `tests/` scaffold nor, later, the `.vscode/` pair.

Both were corrected in #36, which also added a total — one more number free to rot. Prose about the packaged files is embedded doctrine in miniature: exactly the failure [init.py's module docstring](src/bunnyforge/init.py#L16-L18) says the manifest exists to make *"a red test rather than a matter of discipline."* Discipline had failed on this one sentence twice, which is the argument for a test rather than for trying harder.

**Two deliberate scoping calls**, both flagged in the ticket as decisions rather than defaults:

- **The total only, not the per-group figures.** Those are woven through a prose sentence, so pinning each would tax every rewording while adding nothing — the total is what a forgotten `MANIFEST` entry actually moves.
- **Asserted unconditionally, not if-present.** The canonicals guarded in the same class use present-if-present semantics because they are campaign-side files that do not survive the public cut. This README ships in every repo, so its absence is a defect anywhere rather than an artefact of the cut, and an if-present guard would let the check go vacuous for no reason.

The `assertIsNotNone` is load-bearing, not decorative: if the sentence is reworded past the pattern, the regex stops matching and a bare `assertEqual` would never run — the guard would retire itself silently. It fails loudly instead, naming the fix.

## Test expectations
None expected to fail.

## Verification

The invariant already held (38 == 38), so a test written straight in would have passed on arrival and proved nothing. Instead the historical bug was **reproduced first** and the test written against it, then each remaining failure mode was proven by perturbation:

| what was broken | observed failure |
|---|---|
| README says 36, MANIFEST has 38 (the historical drift) | `AssertionError: 36 != 38 : … says init writes 36 files; MANIFEST has 38 entries` |
| a forgotten MANIFEST entry (39 entries, README unchanged) | `AssertionError: 38 != 39 : … says init writes 38 files; MANIFEST has 39 entries` |
| the sentence reworded past the pattern | `AssertionError: unexpectedly None : … reworded past the pattern this test reads …` |

Each perturbation was reverted and the suite returned to green. Every message names the real number, so the fix is a one-word edit.

- `python3 -m unittest discover -s tests -t .` → **699 tests, OK** (was 698), run under two independent interpreters — a worktree-local venv and the framework python with `PYTHONPATH=src` — each with `bunnyforge.__file__` asserted to be this checkout before the run was trusted.
- Re-run in a **clean detached worktree with its own venv** off the commit: 699, OK.
- Secret scan: clean.

## Operational impact
None. Test-only; nothing ships differently.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)