### PR TITLE
Add bunnyforge serve-mcp: serve the workspace to a remote AI agent over MCP (phase 1, read-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .venv/
 dist/
 build/
+.venv-mcp/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ entity files from the templates in `_Templates/`.
 | `build-sheets` | build one-page HTML reference sheets for a session |
 | `names` | generate culture-appropriate names |
 | `vscode` | install the preview extension and toggle editor colouring |
+| `serve-mcp` | serve the workspace to a remote AI agent over MCP (needs `bunnyforge[mcp]`) |
 | `test` | run the workspace test suite |
 
 Run `bunnyforge <command> --help` for a command's own options.

--- a/docs/superpowers/plans/2026-08-16-serve-mcp.md
+++ b/docs/superpowers/plans/2026-08-16-serve-mcp.md
@@ -1,0 +1,1272 @@
+# serve-mcp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `bunnyforge serve-mcp` subcommand that serves one campaign workspace to a remote AI agent (a claude.ai custom connector) over MCP: read tools, doctrine resources, name generation, and staged write-back.
+
+**Architecture:** All workspace access goes through a new `WorkspaceStore` class (`_store.py`, stdlib-only) that owns path guards and the staging/canonical boundary. `serve_mcp.py` is a thin MCP layer over the store, using the official `mcp` SDK via the optional extra `bunnyforge[mcp]`; the SDK is imported only inside function bodies so every other subcommand keeps working on a bare Python. Auth is a static bearer token enforced by a ~20-line pure-ASGI wrapper.
+
+**Tech Stack:** Python ≥3.11 stdlib; optional extra: `mcp` SDK (brings starlette/uvicorn/httpx); `unittest` (NOT pytest — this repo uses unittest exclusively).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-serve-mcp-design.md` — read it first; the plan argues from it.
+
+## Global Constraints
+
+- Core bunnyforge stays **stdlib-only**: `_store.py` must import cleanly on a bare Python 3.11; `serve_mcp.py` may import `mcp`/`uvicorn` **only inside function bodies**, never at module level (cli.py imports every module unconditionally).
+- Tests are **unittest**, live in `tests/test_<module>.py`, and must pass on a bare Python: MCP-layer tests skip themselves when the `mcp` package is absent (`@unittest.skipUnless`).
+- Run tests with `python3 -m unittest tests.<module> -v` from the repo root; full suite with `python3 -m unittest discover -s tests -v`.
+- Every `[workspace]` config key is optional with a default in `_config._DEFAULTS`.
+- Work on branch `feat/serve-mcp` (exists; spec + this plan are its first commits). **Never commit to `main`.** Run `git branch --show-current` before every commit.
+- Every commit message ends with a `Co-Authored-By: <current model> <noreply@anthropic.com>` trailer.
+- **PR boundary:** Tasks 1–5 are phase 1 (read-only server) → first PR. Tasks 6–8 are phase 2 (write-back) → second PR branched from the first. Keep the boundary; the user's rules prefer small PRs.
+- The one external unknown (spec §Deployment): the exact `mcp` SDK surface. Task 4 opens with a probe step; if a name has drifted, adapt from the installed SDK's README rather than pinning an older SDK.
+
+---
+
+### Task 1: `staging_dir` config key
+
+**Files:**
+- Modify: `src/bunnyforge/_config.py` (Config namedtuple ~line 34, `_DEFAULTS` ~line 111, `load()` return ~line 315)
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Consumes: existing `_config.load`, `_str` helper.
+- Produces: `Config.staging_dir: str` (default `"_ExtractInbound"`) — Tasks 6–7 rely on this exact attribute name.
+
+- [ ] **Step 1: Write the failing tests** — append inside `class TestConfigLoad` in `tests/test_config.py`:
+
+```python
+    def test_staging_dir_defaults(self):
+        cfg = _config.load(self._ws(MINIMAL))
+        self.assertEqual(cfg.staging_dir, "_ExtractInbound")
+
+    def test_staging_dir_override(self):
+        cfg = _config.load(self._ws(
+            MINIMAL + '\n[workspace]\nstaging_dir = "_Inbox"\n'))
+        self.assertEqual(cfg.staging_dir, "_Inbox")
+
+    def test_staging_dir_wrong_type_raises(self):
+        with self.assertRaises(_config.ConfigError) as ctx:
+            _config.load(self._ws(
+                MINIMAL + '\n[workspace]\nstaging_dir = ["x"]\n'))
+        self.assertIn("staging_dir", str(ctx.exception))
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python3 -m unittest tests.test_config -v`
+Expected: 3 failures/errors — `AttributeError: 'Config' object has no attribute 'staging_dir'` (and a KeyError from `_DEFAULTS` on the third).
+
+- [ ] **Step 3: Implement** in `src/bunnyforge/_config.py`:
+
+In the `Config` namedtuple field string, add `staging_dir` **immediately after `type_dirs`** (i.e. before `wiki_url`) — the `defaults=[...]` list binds to the LAST five fields, so inserting before `wiki_url` keeps it aligned:
+
+```python
+Config = namedtuple(
+    "Config",
+    "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
+    "exclude_dirs names_cultures names_official_culture names_spelling "
+    "briefs_dir sheets_dir perceptions_dir type_dirs staging_dir wiki_url "
+    "wiki_install_root accepted snapshot_max_age_days fetch_command",
+```
+
+In `_DEFAULTS`, add (note it is already in the default `exclude_dirs` — staged drafts are deliberately invisible to walks):
+
+```python
+    "staging_dir": "_ExtractInbound",
+```
+
+In `load()`'s `return Config(...)`, add after `type_dirs=_type_dirs(ws),`:
+
+```python
+        staging_dir=_str(ws, "staging_dir"),
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python3 -m unittest tests.test_config -v` → all pass.
+
+- [ ] **Step 5: Full suite, then commit**
+
+Run: `python3 -m unittest discover -s tests -v` → no regressions (other modules construct Config only through `load()`, so the new field is invisible to them).
+
+```bash
+git add src/bunnyforge/_config.py tests/test_config.py
+git commit -m "feat: staging_dir workspace config key (default _ExtractInbound)"
+```
+
+---
+
+### Task 2: `WorkspaceStore` read side
+
+**Files:**
+- Create: `src/bunnyforge/_store.py`
+- Test: `tests/test_store.py`
+
+**Interfaces:**
+- Consumes: `_config.Workspace`, `_common.iter_content_files`, `_common.split_front_matter`.
+- Produces (Tasks 4–7 call these exact signatures):
+  - `class StoreError(Exception)`
+  - `class WorkspaceStore: __init__(self, ws: Workspace)`
+  - `overview() -> dict` — keys `name`, `sections` (dir→count), `front_burner`, `open_questions` (str|None)
+  - `list_entities(section: str) -> list[dict]` — items `{"path","title","summary"}`
+  - `read_entity(path: str) -> str`
+  - `search(query: str, section: str | None = None) -> list[dict]` — items `{"path","snippet"}`
+  - internal `_canonical(path: str) -> Path` guard (Task 6 reuses it)
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_store.py`:
+
+```python
+import tempfile
+import unittest
+from pathlib import Path
+
+from bunnyforge import _config, _store
+
+MINIMAL = '[campaign]\nnamespace = "testwiki"\nname = "Testmere"\n'
+
+NPC = """---
+title: Kim Ha-eun
+summary: Kim Ha-eun is a ferry captain in Anjeong harbor.
+visibility: gm-only
+---
+She knows the tides and owes the Harbormasters a debt.
+"""
+
+
+class StoreCase(unittest.TestCase):
+    """A scaffolded temp workspace shared by the store tests."""
+
+    def make_ws(self, toml_extra: str = "") -> _config.Workspace:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "campaign.toml").write_text(
+            MINIMAL + toml_extra, encoding="utf-8")
+        (root / "NPCs").mkdir()
+        (root / "NPCs" / "kim-ha-eun.md").write_text(NPC, encoding="utf-8")
+        (root / "front-burner.md").write_text(
+            "- resolve the ferry plot\n", encoding="utf-8")
+        return _config.open_workspace(root)
+
+
+class TestOverview(StoreCase):
+    def test_reports_name_sections_and_burner(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        ov = store.overview()
+        self.assertEqual(ov["name"], "Testmere")
+        self.assertEqual(ov["sections"]["NPCs"], 1)
+        self.assertIn("ferry plot", ov["front_burner"])
+        self.assertIsNone(ov["open_questions"])
+
+
+class TestListEntities(StoreCase):
+    def test_lists_title_and_summary(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        items = store.list_entities("NPCs")
+        self.assertEqual(items, [{
+            "path": "NPCs/kim-ha-eun.md",
+            "title": "Kim Ha-eun",
+            "summary": "Kim Ha-eun is a ferry captain in Anjeong harbor.",
+        }])
+
+    def test_unknown_section_raises(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.list_entities("Nope")
+        self.assertIn("NPCs", str(ctx.exception))  # error lists valid sections
+
+
+class TestReadEntity(StoreCase):
+    def test_reads_full_file(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        text = store.read_entity("NPCs/kim-ha-eun.md")
+        self.assertIn("title: Kim Ha-eun", text)
+        self.assertIn("owes the Harbormasters", text)
+
+    def test_escape_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("../outside.md")
+
+    def test_excluded_dir_is_refused(self):
+        ws = self.make_ws()
+        hidden = ws.root / "_ExtractInbound"
+        hidden.mkdir()
+        (hidden / "secret.md").write_text("staged", encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("_ExtractInbound/secret.md")
+
+    def test_missing_file_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("NPCs/nobody.md")
+
+
+class TestSearch(StoreCase):
+    def test_hit_returns_path_and_snippet(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        hits = store.search("harbormasters")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["path"], "NPCs/kim-ha-eun.md")
+        self.assertIn("owes the Harbormasters", hits[0]["snippet"])
+
+    def test_section_filter(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.search("ferry", section="NPCs")[0]["path"],
+                         "NPCs/kim-ha-eun.md")
+
+    def test_bad_section_raises(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.search("ferry", section="Nope")
+
+    def test_empty_query_raises(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.search("   ")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python3 -m unittest tests.test_store -v`
+Expected: import error — `bunnyforge._store` does not exist.
+
+- [ ] **Step 3: Implement** — create `src/bunnyforge/_store.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+_store.py — the workspace-access layer behind `bunnyforge serve-mcp`.
+
+Every MCP tool call touches the workspace through WorkspaceStore, so path
+guards and (in phase 2) the staging/canonical boundary have exactly one
+home. Stdlib only, deliberately: the MCP SDK belongs to serve_mcp.py, and
+even there only inside function bodies — this module must import cleanly on
+a bare Python.
+
+The class is the phase-3 seam: a hosted deployment swaps in a
+git-clone-backed implementation with the same method surface, so behaviour
+belongs on the class, never in free functions serve_mcp.py calls directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bunnyforge import _common
+from bunnyforge._config import Workspace
+
+SEARCH_CAP = 50       # hits per search reply; the tool says when it truncates
+SNIPPET_RADIUS = 80   # characters of context on each side of a match
+
+
+class StoreError(Exception):
+    """A refusal the remote agent should see verbatim: unknown section, bad
+    path, unsafe write. Message text is the API — write it to be acted on."""
+
+
+class WorkspaceStore:
+    def __init__(self, ws: Workspace):
+        self.ws = ws
+
+    # -- guards -------------------------------------------------------------
+
+    def _sections(self) -> tuple[str, ...]:
+        cfg = self.ws.config
+        return cfg.entity_dirs + cfg.inherit_dirs
+
+    def _check_section(self, section: str) -> None:
+        if section not in self._sections():
+            raise StoreError(f"unknown section {section!r} — one of: "
+                             + ", ".join(self._sections()))
+
+    def _canonical(self, path: str) -> Path:
+        """Resolve a workspace-relative path, refusing escapes and excluded
+        directories. The staging directory is excluded by default, so staged
+        drafts are not readable back — canon is what read tools serve."""
+        root = self.ws.root
+        p = (root / path).resolve()
+        if not p.is_relative_to(root):
+            raise StoreError(f"path escapes the workspace: {path}")
+        if self.ws.config.exclude_dirs & set(p.relative_to(root).parts):
+            raise StoreError(f"path is in an excluded directory: {path}")
+        return p
+
+    # -- read side ----------------------------------------------------------
+
+    def overview(self) -> dict:
+        cfg = self.ws.config
+        sections = {}
+        for d in self._sections():
+            base = self.ws.root / d
+            if base.is_dir():
+                sections[d] = sum(1 for p in base.rglob("*.md")
+                                  if p.name.lower() != "readme.md")
+        out: dict = {"name": cfg.name, "sections": sections}
+        for key, fname in (("front_burner", "front-burner.md"),
+                           ("open_questions", "open-questions.md")):
+            p = self.ws.root / fname
+            out[key] = p.read_text(encoding="utf-8") if p.is_file() else None
+        return out
+
+    def list_entities(self, section: str) -> list[dict]:
+        self._check_section(section)
+        out = []
+        for rec in _common.iter_content_files(self.ws):
+            rel = rec.path.relative_to(self.ws.root)
+            if rel.parts[0] != section:
+                continue
+            out.append({"path": rel.as_posix(),
+                        "title": rec.fm.get("title") or rec.path.stem,
+                        "summary": rec.fm.get("summary", "")})
+        return out
+
+    def read_entity(self, path: str) -> str:
+        p = self._canonical(path)
+        if not p.is_file():
+            raise StoreError(f"no such file: {path}")
+        return p.read_text(encoding="utf-8")
+
+    def search(self, query: str, section: str | None = None) -> list[dict]:
+        q = query.strip().lower()
+        if not q:
+            raise StoreError("empty search query")
+        if section is not None:
+            self._check_section(section)
+        hits = []
+        for rec in _common.iter_content_files(self.ws):
+            rel = rec.path.relative_to(self.ws.root).as_posix()
+            if section is not None and not rel.startswith(section + "/"):
+                continue
+            text = rec.path.read_text(encoding="utf-8")
+            i = text.lower().find(q)
+            if i == -1:
+                continue
+            lo = max(0, i - SNIPPET_RADIUS)
+            hi = min(len(text), i + len(q) + SNIPPET_RADIUS)
+            hits.append({"path": rel, "snippet": text[lo:hi]})
+            if len(hits) >= SEARCH_CAP:
+                hits.append({"path": "", "snippet":
+                             f"(truncated at {SEARCH_CAP} hits — "
+                             "narrow the query)"})
+                break
+        return hits
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python3 -m unittest tests.test_store -v` → all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py tests/test_store.py
+git commit -m "feat: WorkspaceStore read layer for serve-mcp"
+```
+
+---
+
+### Task 3: name generation on the store
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py`
+- Test: `tests/test_store.py`
+
+**Interfaces:**
+- Consumes: `generate_names.load_inventory(ws)`, `.resolve(cultures, name)`, `.person_name(rng, inv, key, category)`, `.place_name(rng, inv, key)`, `.InventoryError`.
+- Produces: `WorkspaceStore.generate_names(culture: str, count: int) -> dict` with keys `culture`, `people` (list[str]), `places` (list[str]). Task 4's tool calls this exact signature.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_store.py`. The fixture copies a real packaged culture inventory (`src/bunnyforge/data/cultures/vashkand.toml`) rather than hand-rolling one, so inventory validation stays out of scope here:
+
+```python
+from importlib import resources
+import shutil
+
+
+class TestGenerateNames(StoreCase):
+    def make_names_ws(self) -> _config.Workspace:
+        ws = self.make_ws('\n[names]\ncultures = "cultures"\n')
+        cdir = ws.root / "cultures"
+        cdir.mkdir()
+        src = resources.files("bunnyforge") / "data" / "cultures" / "vashkand.toml"
+        shutil.copy(str(src), cdir / "vashkand.toml")
+        return _config.open_workspace(ws.root)  # reload: [names] now resolvable
+
+    def test_generates_people_and_places(self):
+        store = _store.WorkspaceStore(self.make_names_ws())
+        out = store.generate_names("vashkand", 5)
+        self.assertEqual(out["culture"], "vashkand")
+        self.assertEqual(len(out["people"]), 5)
+        self.assertEqual(len(out["places"]), 5)
+        self.assertTrue(all(isinstance(n, str) and n for n in out["people"]))
+
+    def test_unknown_culture_lists_available(self):
+        store = _store.WorkspaceStore(self.make_names_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.generate_names("martian", 3)
+        self.assertIn("vashkand", str(ctx.exception))
+
+    def test_unconfigured_names_is_a_store_error(self):
+        store = _store.WorkspaceStore(self.make_ws())  # no [names] at all
+        with self.assertRaises(_store.StoreError):
+            store.generate_names("vashkand", 3)
+
+    def test_count_is_clamped(self):
+        store = _store.WorkspaceStore(self.make_names_ws())
+        self.assertEqual(len(store.generate_names("vashkand", 999)["people"]),
+                         50)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python3 -m unittest tests.test_store -v`
+Expected: 4 errors — `AttributeError: 'WorkspaceStore' object has no attribute 'generate_names'`.
+
+- [ ] **Step 3: Implement** — in `_store.py`, add to the imports:
+
+```python
+import random
+
+from bunnyforge import generate_names as _names
+```
+
+and add to `WorkspaceStore`:
+
+```python
+    # -- generators ---------------------------------------------------------
+
+    def generate_names(self, culture: str, count: int) -> dict:
+        count = max(1, min(int(count), 50))
+        try:
+            inv = _names.load_inventory(self.ws)
+        except _names.InventoryError as exc:
+            raise StoreError(str(exc)) from exc
+        key = _names.resolve(inv.cultures, culture)
+        if not isinstance(key, str):   # None (unknown) or list (ambiguous)
+            raise StoreError(
+                f"unknown or ambiguous culture {culture!r} — available: "
+                + ", ".join(sorted(inv.cultures)))
+        rng = random.Random()
+        return {"culture": key,
+                "people": [_names.person_name(rng, inv, key, None)
+                           for _ in range(count)],
+                "places": [_names.place_name(rng, inv, key)
+                           for _ in range(count)]}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python3 -m unittest tests.test_store -v` → all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py tests/test_store.py
+git commit -m "feat: name generation on WorkspaceStore"
+```
+
+---
+
+### Task 4: `serve_mcp.py` — MCP layer, auth, main()
+
+**Files:**
+- Create: `src/bunnyforge/serve_mcp.py`
+- Test: `tests/test_serve_mcp.py`
+- Modify: `.gitignore` (add `.venv-mcp/`)
+
+**Interfaces:**
+- Consumes: `WorkspaceStore` read methods + `generate_names` (Tasks 2–3), `_config.resolve_workspace`.
+- Produces:
+  - `build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False)` → FastMCP instance (Task 7 extends it)
+  - `_BearerAuth(app, token: str)` — pure-ASGI auth wrapper
+  - `main(argv: list[str] | None = None) -> int` — cli.py registers this (Task 5)
+  - `TOKEN_ENV = "BUNNYFORGE_MCP_TOKEN"`
+
+- [ ] **Step 1: Set up the dev venv for the optional extra** (the repo itself stays zero-dep; this venv exists so the MCP-layer tests can actually run here):
+
+```bash
+python3 -m venv .venv-mcp
+./.venv-mcp/bin/pip install mcp
+echo '.venv-mcp/' >> .gitignore
+```
+
+- [ ] **Step 2: Probe the installed SDK** — the spec's one external unknown. Run:
+
+```bash
+./.venv-mcp/bin/python - <<'EOF'
+from mcp.server.fastmcp import FastMCP
+s = FastMCP("probe", stateless_http=True)
+print("streamable app:", type(s.streamable_http_app()).__name__)
+print("tool/resource decorators:", callable(s.tool), callable(s.resource))
+EOF
+```
+
+Expected: prints a Starlette app type and `True True`. **If any name errors**, read the installed SDK's docs (`./.venv-mcp/bin/python -c "import mcp; print(mcp.__file__)"`, then the package README) and adapt the code below to the current names — the plan's intent (FastMCP server, streamable HTTP app, tool/resource decorators) is stable across SDK versions even when spellings drift.
+
+- [ ] **Step 3: Write the failing tests** — create `tests/test_serve_mcp.py`:
+
+```python
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bunnyforge import _config, _store, serve_mcp
+
+HAVE_MCP = importlib.util.find_spec("mcp") is not None
+
+MINIMAL = '[campaign]\nnamespace = "testwiki"\nname = "Testmere"\n'
+
+NPC = """---
+title: Kim Ha-eun
+summary: Kim Ha-eun is a ferry captain.
+---
+Body.
+"""
+
+
+def scaffold(case: unittest.TestCase) -> _store.WorkspaceStore:
+    root = Path(case.enterContext(tempfile.TemporaryDirectory()))
+    (root / "campaign.toml").write_text(MINIMAL, encoding="utf-8")
+    (root / "NPCs").mkdir()
+    (root / "NPCs" / "kim-ha-eun.md").write_text(NPC, encoding="utf-8")
+    (root / "style-guide.md").write_text("# Style\nSpare prose.\n",
+                                         encoding="utf-8")
+    return _store.WorkspaceStore(_config.open_workspace(root))
+
+
+class TestBearerAuth(unittest.IsolatedAsyncioTestCase):
+    """Pure ASGI — runs without the mcp extra."""
+
+    async def _call(self, auth, headers):
+        sent = []
+        async def send(msg):
+            sent.append(msg)
+        await auth({"type": "http", "headers": headers}, None, send)
+        return sent
+
+    async def test_missing_token_is_401_and_never_reaches_the_app(self):
+        async def inner(scope, receive, send):
+            raise AssertionError("request reached the app")
+        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"), [])
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_wrong_token_is_401(self):
+        async def inner(scope, receive, send):
+            raise AssertionError("request reached the app")
+        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
+                                [(b"authorization", b"Bearer wrong")])
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_right_token_passes_through(self):
+        seen = []
+        async def inner(scope, receive, send):
+            seen.append(scope)
+        await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
+                         [(b"authorization", b"Bearer sekrit")])
+        self.assertEqual(len(seen), 1)
+
+
+class TestMainGuards(unittest.TestCase):
+    """argparse + refusals — also runs without the extra."""
+
+    def test_help_needs_no_extra(self):
+        with self.assertRaises(SystemExit) as ctx:
+            serve_mcp.main(["--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_refuses_to_start_without_token_or_no_auth(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "campaign.toml").write_text(MINIMAL, encoding="utf-8")
+        # A token in the invoking environment must not leak into the test.
+        with mock.patch.dict("os.environ", {serve_mcp.TOKEN_ENV: ""}):
+            self.assertEqual(serve_mcp.main(["--workspace", str(root)]), 1)
+
+
+@unittest.skipUnless(HAVE_MCP, "mcp extra not installed")
+class TestBuildServer(unittest.IsolatedAsyncioTestCase):
+
+    async def _payload(self, result):
+        # SDK >=1.10 returns (content, structured); older returns content.
+        if isinstance(result, tuple):
+            return json.dumps(result[1])
+        return "".join(c.text for c in result)
+
+    async def test_read_tools_are_registered(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual(
+            {"campaign_overview", "list_entities", "read_entity", "search",
+             "generate_names"}, names)
+
+    async def test_write_tools_absent_in_phase_1(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertFalse({"save_draft", "propose_revision", "write_entity"}
+                         & names)
+
+    async def test_campaign_overview_answers(self):
+        server = serve_mcp.build_server(scaffold(self))
+        payload = await self._payload(
+            await server.call_tool("campaign_overview", {}))
+        self.assertIn("Testmere", payload)
+        self.assertIn("NPCs", payload)
+
+    async def test_doctrine_resource_lists_and_reads(self):
+        server = serve_mcp.build_server(scaffold(self))
+        uris = {str(r.uri) for r in await server.list_resources()}
+        self.assertIn("bunnyforge://doctrine/style-guide.md", uris)
+        content = await server.read_resource(
+            "bunnyforge://doctrine/style-guide.md")
+        text = "".join(part.content for part in content)
+        self.assertIn("Spare prose", text)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 4: Run to verify they fail**
+
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
+Expected: import error — `bunnyforge.serve_mcp` does not exist.
+
+- [ ] **Step 5: Implement** — create `src/bunnyforge/serve_mcp.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+serve_mcp.py — `bunnyforge serve-mcp`: serve one workspace to a remote AI
+agent over MCP (a claude.ai custom connector).
+
+Design doc: docs/superpowers/specs/2026-08-16-serve-mcp-design.md.
+
+The `mcp` SDK and uvicorn are the package's only third-party imports, and
+they are optional (`pip install 'bunnyforge[mcp]'`) — so they are imported
+only INSIDE functions. cli.py imports this module unconditionally; a bare
+Python must be able to import it, print its --help, and get the friendly
+install hint, with every other subcommand unaffected.
+
+Auth is a static bearer token checked by _BearerAuth, a pure-ASGI wrapper
+(no starlette import needed). Default-deny: no token and no explicit
+--no-auth means the server refuses to start — everything served here is
+GM-eyes-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from bunnyforge import _config
+from bunnyforge._config import ConfigError, WorkspaceError
+from bunnyforge._store import WorkspaceStore
+
+TOKEN_ENV = "BUNNYFORGE_MCP_TOKEN"
+DOCTRINE_FILES = ("style-guide.md", "situation-design.md", "AGENTS.md")
+_INSTALL_HINT = ("serve-mcp needs its optional dependencies:\n"
+                 "  pip install 'bunnyforge[mcp]'")
+
+
+class _BearerAuth:
+    """Every HTTP request must carry `Authorization: Bearer <token>`."""
+
+    def __init__(self, app, token: str):
+        self._app = app
+        self._expected = f"Bearer {token}".encode()
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            headers = {k.lower(): v for k, v in scope.get("headers") or []}
+            if headers.get(b"authorization") != self._expected:
+                await send({"type": "http.response.start", "status": 401,
+                            "headers": [(b"content-type", b"text/plain"),
+                                        (b"www-authenticate", b"Bearer")]})
+                await send({"type": "http.response.body",
+                            "body": b"unauthorized"})
+                return
+        await self._app(scope, receive, send)
+
+
+def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False):
+    """Assemble the FastMCP server over one store. Imports the SDK, so a
+    caller without the extra gets ModuleNotFoundError — main() translates
+    that to the install hint."""
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("bunnyforge", stateless_http=True)
+
+    @server.tool()
+    def campaign_overview() -> dict:
+        """The campaign's name, its sections with entity counts, and the
+        current front-burner and open-questions docs. Call this first to
+        orient yourself."""
+        return store.overview()
+
+    @server.tool()
+    def list_entities(section: str) -> list[dict]:
+        """One section's files: workspace path, title, one-line summary."""
+        return store.list_entities(section)
+
+    @server.tool()
+    def read_entity(path: str) -> str:
+        """Full text of one workspace file, front matter included."""
+        return store.read_entity(path)
+
+    @server.tool()
+    def search(query: str, section: str | None = None) -> list[dict]:
+        """Case-insensitive text search across the workspace; returns path
+        and surrounding snippet per hit."""
+        return store.search(query, section)
+
+    @server.tool()
+    def generate_names(culture: str, count: int = 10) -> dict:
+        """Culture-appropriate person and place names from this setting's
+        name inventories."""
+        return store.generate_names(culture, count)
+
+    def _reader(p):
+        def _read() -> str:
+            return p.read_text(encoding="utf-8")
+        return _read
+
+    for fname in DOCTRINE_FILES:
+        path = store.ws.root / fname
+        if path.is_file():
+            server.resource(f"bunnyforge://doctrine/{fname}", name=fname,
+                            description=f"Workspace doctrine: {fname} — "
+                            "load before writing content.")(_reader(path))
+
+    return server
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="bunnyforge serve-mcp",
+        description="Serve the workspace to a remote AI agent over MCP.")
+    ap.add_argument("--workspace", help="path to the campaign workspace")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8765)
+    ap.add_argument("--token",
+                    help=f"bearer token (or set {TOKEN_ENV}); required "
+                         "unless --no-auth")
+    ap.add_argument("--no-auth", action="store_true",
+                    help="serve without auth — local testing only")
+    ap.add_argument("--allow-direct-edits", action="store_true",
+                    help="enable the write_entity tool: in-place edits of "
+                         "canonical files, each auto-committed to git")
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        ws = _config.resolve_workspace(args.workspace)
+    except (ConfigError, WorkspaceError) as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    token = (args.token or os.environ.get(TOKEN_ENV, "")).strip()
+    if not token and not args.no_auth:
+        print("refusing to start without auth: pass --token, set "
+              f"{TOKEN_ENV}, or (local testing only) pass --no-auth",
+              file=sys.stderr)
+        return 1
+    try:
+        import uvicorn
+        server = build_server(WorkspaceStore(ws),
+                              allow_direct_edits=args.allow_direct_edits)
+    except ModuleNotFoundError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 1
+    app = server.streamable_http_app()
+    if token:
+        app = _BearerAuth(app, token)
+    print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp"
+          + ("" if token else "  (NO AUTH — local testing only)"))
+    uvicorn.run(app, host=args.host, port=args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 6: Run to verify they pass — in BOTH interpreters**
+
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass (fix any SDK-drift breakage per Step 2's probe).
+Run: `python3 -m unittest tests.test_serve_mcp -v` → auth + main-guard tests pass, `TestBuildServer` reports **skipped**, not errored.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py .gitignore
+git commit -m "feat: serve-mcp MCP layer — read tools, doctrine resources, bearer auth"
+```
+
+---
+
+### Task 5: wiring — CLI, packaging, README (closes phase 1)
+
+**Files:**
+- Modify: `src/bunnyforge/cli.py:30-65` (imports, `_COMMANDS`, `_SUMMARIES`)
+- Modify: `pyproject.toml` (optional-dependencies)
+- Modify: `README.md` (subcommand table)
+- Modify: `tests/test_cli.py:41` (pins the exact `_COMMANDS` dict — must gain the new entry)
+
+**Interfaces:**
+- Consumes: `serve_mcp.main` (Task 4).
+- Produces: `bunnyforge serve-mcp` as a first-class subcommand; `pip install 'bunnyforge[mcp]'` extra.
+
+- [ ] **Step 1: Update the pinned CLI test first** — in `tests/test_cli.py`'s `test_every_subcommand_maps_to_its_modules_main`, add to the expected dict (and add `serve_mcp` to that test file's imports from `bunnyforge`):
+
+```python
+            "serve-mcp": serve_mcp.main,
+```
+
+Run: `python3 -m unittest tests.test_cli -v`
+Expected: `test_every_subcommand_maps_to_its_modules_main` FAILS (dict mismatch) — the right failure.
+
+- [ ] **Step 2: Register the subcommand** — in `src/bunnyforge/cli.py`, add `serve_mcp` to the `from bunnyforge import (...)` block, then:
+
+```python
+    "serve-mcp": serve_mcp.main,      # in _COMMANDS
+    "serve-mcp": "serve the workspace to a remote AI agent over MCP",  # in _SUMMARIES
+```
+
+(each into its dict, keeping both in the same order.)
+
+- [ ] **Step 3: Declare the extra** — in `pyproject.toml`, after `[project.urls]`:
+
+```toml
+[project.optional-dependencies]
+# serve-mcp only. Everything else stays zero-dependency; serve_mcp.py
+# imports these inside main(), so a bare install still gets --help and a
+# friendly install hint.
+mcp = ["mcp>=1.9"]
+```
+
+- [ ] **Step 4: README** — add to the subcommand table, after `names`:
+
+```markdown
+| `serve-mcp` | serve the workspace to a remote AI agent over MCP (needs `bunnyforge[mcp]`) |
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `python3 -m unittest discover -s tests -v` → all pass on bare python (MCP-layer tests skip).
+Run: `python3 -m bunnyforge serve-mcp --help` → help text, exit 0, on bare python.
+Run: `./.venv-mcp/bin/pip install -e . >/dev/null && ./.venv-mcp/bin/python -m unittest discover -s tests -v` → all pass, nothing skipped.
+
+- [ ] **Step 6: Commit — end of phase 1**
+
+```bash
+git add src/bunnyforge/cli.py pyproject.toml README.md tests/test_cli.py
+git commit -m "feat: register serve-mcp subcommand and bunnyforge[mcp] extra"
+```
+
+**PR checkpoint:** phase 1 is complete and shippable. Open the first PR (base `main`) here per the user's PR rules (Files changed / Work breakdown / Provenance sections; flag that phase 2 follows). Tasks 6–8 continue on a branch off this one — highlight the stacked base when opening the second PR.
+
+---
+
+### Task 6: `WorkspaceStore` write side
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py`
+- Test: `tests/test_store.py`
+
+**Interfaces:**
+- Consumes: `Config.staging_dir` (Task 1), `_canonical` guard (Task 2).
+- Produces (Task 7's tools call these exact signatures; each returns the workspace-relative path written, as posix str):
+  - `stage_draft(section: str, name: str, content: str) -> str`
+  - `stage_revision(path: str, content: str) -> str`
+  - `write_entity(path: str, content: str) -> str`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_store.py`:
+
+```python
+import subprocess
+
+
+class TestStageDraft(StoreCase):
+    def test_writes_into_staging_and_creates_dirs(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.stage_draft("NPCs", "Old Man Cho", "---\ntitle: Cho\n---\n")
+        self.assertEqual(rel, "_ExtractInbound/NPCs/Old Man Cho.md")
+        self.assertTrue((ws.root / rel).is_file())
+
+    def test_refuses_overwrite(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.stage_draft("NPCs", "Cho", "x")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.stage_draft("NPCs", "Cho", "y")
+        self.assertIn("another name", str(ctx.exception))
+
+    def test_refuses_unknown_section_and_bad_names(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.stage_draft("Nope", "Cho", "x")
+        for bad in ("../escape", "a/b", ".hidden", "_underscore"):
+            with self.assertRaises(_store.StoreError):
+                store.stage_draft("NPCs", bad, "x")
+
+    def test_honors_configured_staging_dir(self):
+        ws = self.make_ws('\n[workspace]\nstaging_dir = "_Inbox"\n')
+        rel = _store.WorkspaceStore(ws).stage_draft("NPCs", "Cho", "x")
+        self.assertEqual(rel, "_Inbox/NPCs/Cho.md")
+
+
+class TestStageRevision(StoreCase):
+    def test_shadow_mirrors_the_canonical_path(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.stage_revision("NPCs/kim-ha-eun.md", "new text")
+        self.assertEqual(rel, "_ExtractInbound/NPCs/kim-ha-eun.md")
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
+                         "new text")
+
+    def test_latest_proposal_wins(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.stage_revision("NPCs/kim-ha-eun.md", "first")
+        rel = store.stage_revision("NPCs/kim-ha-eun.md", "second")
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
+                         "second")
+
+    def test_requires_an_existing_target(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.stage_revision("NPCs/nobody.md", "x")
+        self.assertIn("stage_draft", str(ctx.exception))  # points at the fix
+
+    def test_refuses_escapes(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.stage_revision("../outside.md", "x")
+
+
+class TestWriteEntity(StoreCase):
+    def make_git_ws(self):
+        ws = self.make_ws()
+        for cmd in (["init", "-q"], ["config", "user.email", "t@t"],
+                    ["config", "user.name", "t"], ["add", "-A"],
+                    ["commit", "-qm", "seed"]):
+            subprocess.run(["git", "-C", str(ws.root)] + cmd, check=True)
+        return ws
+
+    def test_edits_and_commits(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        store.write_entity("NPCs/kim-ha-eun.md", "---\ntitle: X\n---\nnew\n")
+        self.assertIn("new", (ws.root / "NPCs/kim-ha-eun.md").read_text(
+            encoding="utf-8"))
+        log = subprocess.run(
+            ["git", "-C", str(ws.root), "log", "-1", "--format=%s"],
+            capture_output=True, text=True, check=True).stdout
+        self.assertIn("serve-mcp: edit NPCs/kim-ha-eun.md", log)
+        status = subprocess.run(
+            ["git", "-C", str(ws.root), "status", "--porcelain"],
+            capture_output=True, text=True, check=True).stdout
+        self.assertEqual(status.strip(), "")  # nothing left uncommitted
+
+    def test_identical_content_is_a_quiet_no_op(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        original = (ws.root / "NPCs/kim-ha-eun.md").read_text(encoding="utf-8")
+        store.write_entity("NPCs/kim-ha-eun.md", original)  # must not raise
+
+    def test_refuses_outside_a_git_repo(self):
+        store = _store.WorkspaceStore(self.make_ws())  # no git init
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.write_entity("NPCs/kim-ha-eun.md", "x")
+        self.assertIn("git", str(ctx.exception))
+
+    def test_refuses_missing_target_and_escapes(self):
+        store = _store.WorkspaceStore(self.make_git_ws())
+        with self.assertRaises(_store.StoreError):
+            store.write_entity("NPCs/nobody.md", "x")
+        with self.assertRaises(_store.StoreError):
+            store.write_entity("../outside.md", "x")
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python3 -m unittest tests.test_store -v`
+Expected: errors — no attribute `stage_draft` / `stage_revision` / `write_entity`.
+
+- [ ] **Step 3: Implement** — in `_store.py`, add `import re` and `import subprocess` to the imports, a module-level pattern next to the other constants:
+
+```python
+# Draft names become filenames. No path separators, no leading dot or
+# underscore (dot-files hide; the _-prefix is the workspace's own marker
+# for machinery directories).
+_DRAFT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9 _'-]*")
+```
+
+and the write side on `WorkspaceStore`:
+
+```python
+    # -- write side ---------------------------------------------------------
+    # Staging paths are built directly rather than through _canonical: the
+    # staging directory is excluded from reads BY DESIGN, and these two
+    # methods are the only writers. Traversal is impossible by construction
+    # — section is validated against config, and _DRAFT_NAME_RE admits no
+    # separator.
+
+    def _staging(self) -> Path:
+        return self.ws.root / self.ws.config.staging_dir
+
+    def stage_draft(self, section: str, name: str, content: str) -> str:
+        self._check_section(section)
+        if not _DRAFT_NAME_RE.fullmatch(name):
+            raise StoreError(
+                f"bad draft name {name!r} — letters, digits, spaces, "
+                "- _ ' only, starting with a letter or digit")
+        dest = self._staging() / section / f"{name}.md"
+        if dest.exists():
+            rel = dest.relative_to(self.ws.root).as_posix()
+            raise StoreError(f"{rel} already exists — pick another name")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+        return dest.relative_to(self.ws.root).as_posix()
+
+    def stage_revision(self, path: str, content: str) -> str:
+        target = self._canonical(path)
+        if not target.is_file() or target.suffix != ".md":
+            raise StoreError(
+                f"no such content file: {path} — stage_revision proposes "
+                "changes to an existing file; use stage_draft for new "
+                "content")
+        dest = self._staging() / target.relative_to(self.ws.root)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")  # latest proposal wins
+        return dest.relative_to(self.ws.root).as_posix()
+
+    def write_entity(self, path: str, content: str) -> str:
+        target = self._canonical(path)
+        if not target.is_file() or target.suffix != ".md":
+            raise StoreError(f"no such content file: {path}")
+        rel = target.relative_to(self.ws.root).as_posix()
+        if target.read_text(encoding="utf-8") == content:
+            return rel  # nothing to change, nothing to commit
+        probe = subprocess.run(
+            ["git", "-C", str(self.ws.root), "rev-parse",
+             "--is-inside-work-tree"], capture_output=True, text=True)
+        if probe.returncode != 0:
+            raise StoreError(
+                "direct edits require the workspace to be a git repository "
+                "— refusing to edit canon without history")
+        target.write_text(content, encoding="utf-8")
+        for sub in (["add", "--", rel],
+                    ["commit", "-m", f"serve-mcp: edit {rel}"]):
+            done = subprocess.run(["git", "-C", str(self.ws.root)] + sub,
+                                  capture_output=True, text=True)
+            if done.returncode != 0:
+                raise StoreError(f"git {sub[0]} failed: "
+                                 f"{done.stderr.strip() or done.stdout.strip()}")
+        return rel
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python3 -m unittest tests.test_store -v` → all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py tests/test_store.py
+git commit -m "feat: WorkspaceStore write side — staged drafts, shadow revisions, gated direct edits"
+```
+
+---
+
+### Task 7: MCP write tools
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (inside `build_server`)
+- Test: `tests/test_serve_mcp.py`
+
+**Interfaces:**
+- Consumes: Task 6's three store methods.
+- Produces: MCP tools `save_draft`, `propose_revision` (always), `write_entity` (only when `allow_direct_edits=True`).
+
+- [ ] **Step 1: Write the failing tests** — in `tests/test_serve_mcp.py`, **replace** `test_write_tools_absent_in_phase_1` with:
+
+```python
+    async def test_staging_tools_always_registered(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual({"save_draft", "propose_revision"}, names)
+
+    async def test_write_entity_only_with_the_flag(self):
+        store = scaffold(self)
+        off = {t.name for t in await serve_mcp.build_server(store).list_tools()}
+        on = {t.name for t in await serve_mcp.build_server(
+            store, allow_direct_edits=True).list_tools()}
+        self.assertNotIn("write_entity", off)
+        self.assertIn("write_entity", on)
+
+    async def test_save_draft_lands_in_staging(self):
+        store = scaffold(self)
+        await serve_mcp.build_server(store).call_tool(
+            "save_draft", {"section": "NPCs", "name": "Cho",
+                           "content": "---\ntitle: Cho\n---\n"})
+        self.assertTrue(
+            (store.ws.root / "_ExtractInbound/NPCs/Cho.md").is_file())
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
+Expected: the three new tests fail (tools not registered).
+
+- [ ] **Step 3: Implement** — in `build_server`, after the `generate_names` tool and before the resource loop:
+
+```python
+    @server.tool()
+    def save_draft(section: str, name: str, content: str) -> str:
+        """Stage NEW content (a full markdown file, front matter included)
+        into the workspace's staging area for the GM to review and promote.
+        Never overwrites; returns the staged path."""
+        return store.stage_draft(section, name, content)
+
+    @server.tool()
+    def propose_revision(path: str, content: str) -> str:
+        """Stage a full-file revision of an EXISTING workspace file as a
+        shadow copy in the staging area. The GM reviews it as a diff.
+        Re-proposing replaces the earlier proposal; returns the staged
+        path."""
+        return store.stage_revision(path, content)
+
+    if allow_direct_edits:
+        @server.tool()
+        def write_entity(path: str, content: str) -> str:
+            """Edit a canonical workspace file in place. Each edit is
+            auto-committed to git. Available only because this server was
+            started with --allow-direct-edits."""
+            return store.write_entity(path, content)
+```
+
+- [ ] **Step 4: Run to verify they pass — both interpreters**
+
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass.
+Run: `python3 -m unittest discover -s tests -v` → all pass, MCP-layer tests skip.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: serve-mcp write tools — save_draft, propose_revision, gated write_entity"
+```
+
+---
+
+### Task 8: operator docs
+
+**Files:**
+- Create: `docs/serve-mcp.md`
+- Modify: `README.md` (link the doc from the serve-mcp row)
+
+**Interfaces:**
+- Consumes: everything above, as documented behaviour.
+- Produces: the operator guide the spec's "documented not implemented" tunnel promise refers to.
+
+- [ ] **Step 1: Write `docs/serve-mcp.md`:**
+
+```markdown
+# serve-mcp: your workspace as a claude.ai custom connector
+
+`bunnyforge serve-mcp` serves one campaign workspace over MCP so a
+web-based AI agent can read GM materials, generate names, and stage
+drafts back for your review. Design:
+`docs/superpowers/specs/2026-08-16-serve-mcp-design.md`.
+
+Everything it serves is GM-eyes-only. It never touches `Export/` or the
+wiki — publishing to players stays a local, human act.
+
+## Install and run
+
+    pip install 'bunnyforge[mcp]'
+    cd <your-campaign>
+    bunnyforge serve-mcp --token "$(openssl rand -hex 24)"
+
+The server refuses to start without a token unless you pass `--no-auth`
+(local testing only). Put the token in `BUNNYFORGE_MCP_TOKEN` to avoid
+retyping it. Default bind: `127.0.0.1:8765`, MCP endpoint path `/mcp`.
+
+## Exposing it to claude.ai
+
+claude.ai must reach the server over HTTPS. Two tunnel recipes; both
+keep the server itself bound to localhost.
+
+**Tailscale Funnel**
+
+    tailscale funnel 8765
+
+gives `https://<machine>.<tailnet>.ts.net/`. **cloudflared**
+
+    cloudflared tunnel --url http://localhost:8765
+
+prints a `https://….trycloudflare.com` URL (rotates each run; a named
+tunnel gives a stable one).
+
+Then in claude.ai: Settings → Connectors → Add custom connector → URL
+`https://<tunnel-host>/mcp`. Supply the bearer token where the connector
+form accepts one. If your claude.ai plan's connector flow will not pass
+a static bearer token, that is the known phase-1 limitation recorded in
+the design doc — file the finding and we wire up the SDK's OAuth
+support.
+
+The server is only reachable while your machine is awake and the tunnel
+is up; that is the accepted phase-1 trade-off.
+
+## What the agent can do
+
+Read tools: `campaign_overview`, `list_entities`, `read_entity`,
+`search`, `generate_names`. Doctrine (`style-guide.md`,
+`situation-design.md`, `AGENTS.md`) is served as resources — tell the
+agent to load them before writing content.
+
+Write tools stage into `staging_dir` (default `_ExtractInbound/`, see
+campaign.toml): `save_draft` for new files, `propose_revision` for
+full-file shadow copies of existing ones. Review and promote them with
+your usual extraction workflow; staged files are invisible to the read
+tools and to every other bunnyforge command.
+
+`--allow-direct-edits` additionally registers `write_entity`, which
+edits canonical files in place, one git commit per edit. Run with it
+only when you want that session editing canon directly; the workspace
+must be a git repository.
+```
+
+- [ ] **Step 2: Link it from the README row** (added in Task 5):
+
+```markdown
+| `serve-mcp` | serve the workspace to a remote AI agent over MCP (needs `bunnyforge[mcp]`; see [docs/serve-mcp.md](docs/serve-mcp.md)) |
+```
+
+- [ ] **Step 3: Verify the promises match the code** — reread the doc against `serve_mcp.py --help` output and the tool docstrings; every flag, default, path, and tool name in the doc must exist verbatim in the code.
+
+Run: `python3 -m bunnyforge serve-mcp --help`
+
+- [ ] **Step 4: Full suite, then commit**
+
+Run: `python3 -m unittest discover -s tests -v` → all pass.
+
+```bash
+git add docs/serve-mcp.md README.md
+git commit -m "docs: serve-mcp operator guide — setup, tunnels, claude.ai connector"
+```
+
+---
+
+## After Task 8
+
+Phase 2 PR (per the user's PR rules; its base is the phase-1 branch **only if that PR is still open — flag the stacked base explicitly**; otherwise rebase onto `main`). Then the end-to-end validation the spec assigns to a human-in-the-loop: real tunnel, real claude.ai custom connector, first staged draft flowing through the extraction workflow — findings go back onto the ticket, especially the connector-auth unknown.

--- a/docs/superpowers/plans/2026-08-16-serve-mcp.md
+++ b/docs/superpowers/plans/2026-08-16-serve-mcp.md
@@ -14,13 +14,62 @@
 
 - Core bunnyforge stays **stdlib-only**: `_store.py` must import cleanly on a bare Python 3.11; `serve_mcp.py` may import `mcp`/`uvicorn` **only inside function bodies**, never at module level (cli.py imports every module unconditionally).
 - Tests are **unittest**, live in `tests/test_<module>.py`, and must pass on a bare Python: MCP-layer tests skip themselves when the `mcp` package is absent (`@unittest.skipUnless`).
-- Run tests with `PYTHONPATH=src python3 -m unittest tests.<module> -v` from the repo root; full suite with `PYTHONPATH=src python3 -m unittest discover -s tests -v`.
-- **`PYTHONPATH=src` is mandatory on every interpreter invocation, and never optional.** This machine has a NON-editable `pip install .` of bunnyforge 0.3.1 in system site-packages, so a bare `python3` imports that installed *copy* and cannot see any checkout's source at all — measured, not assumed (a sentinel added to `src/bunnyforge/_common.py` was invisible to `python3` and visible to `PYTHONPATH=src python3`). Without the prefix, new modules (`_store.py`, `serve_mcp.py`) fail to import no matter how correct the code, and edits to existing modules silently test stale installed code — TDD's red→green cycle never goes green and the failure looks like your bug. **Do not "fix" this by reinstalling or `pip install -e .` into system site-packages:** that installed copy is what the user's real campaign work (`bunnyforge review`, `deploy-export` against `~/Dropbox/Games/TTRPGs/Anjeong`) runs on. It is shared machine-global state — leave it exactly as found.
+- Run tests with `./.venv/bin/python -m unittest tests.<module> -v` from the repo root; full suite with `./.venv/bin/python -m unittest discover -s tests -v`.
+- **Never write a bare `python3` in a command; always name the interpreter by path.** On this machine `python3` is ambiguous — it resolves `bunnyforge` at least three different ways, and *which one you get depends on the shell, not the command*:
+  | interpreter | `bunnyforge` resolves to |
+  |---|---|
+  | bare `python3` (framework 3.13) | a NON-editable **copy** in system site-packages — tracks no checkout |
+  | `~/Github/bunnyforge/.venv/bin/python` | **editable** → the shared clone's `src/`, i.e. whatever branch it has checked out |
+  | `~/Github/bunnyforge-33/.venv/bin/python` | **editable** → another agent's worktree |
+  Get this wrong and TDD breaks in the worst way: new modules (`_store.py`, `serve_mcp.py`) fail to import no matter how correct the code, and edits to existing modules silently test someone else's tree, so red→green never goes green and the failure looks like your bug. Task 0 builds this worktree's own `.venv`; every command in this plan names it explicitly.
+- **Assert the resolution before trusting any run** — a precaution proves nothing, evidence does. Task 0's preflight is repeatable; re-run it any time results look strange:
+  ```bash
+  ./.venv/bin/python -c "import bunnyforge,pathlib; p=pathlib.Path(bunnyforge.__file__).resolve(); assert p.is_relative_to(pathlib.Path.cwd().resolve()), f'WRONG TREE: {p}'; print('OK:',p)"
+  ```
+- **Never `pip install` into system site-packages.** That copy is what the user's live campaign work runs on (`bunnyforge review`, `deploy-export` against `~/Dropbox/Games/TTRPGs/Anjeong`); it was deliberately refreshed from `main` on 2026-08-16 and must stay there. All installs in this plan go into worktree-local venvs, which are disposable and private to this checkout.
 - Every `[workspace]` config key is optional with a default in `_config._DEFAULTS`.
 - Work on branch `feat/serve-mcp` in an **isolated git worktree** — one already exists at `~/Github/bunnyforge-mcp`; work there. Other agents are concurrently active on this machine (`~/Github/bunnyforge` is shared neutral ground on `main`; `~/Github/bunnyforge-33` holds another agent's branch). Never run `git checkout` in the shared clone. **Never commit to `main`.** Run `git branch --show-current` as its own command, and read its output, before every commit.
 - Every commit message ends with a `Co-Authored-By: <current model> <noreply@anthropic.com>` trailer.
 - **PR boundary:** Tasks 1–5 are phase 1 (read-only server) → first PR. Tasks 6–8 are phase 2 (write-back) → second PR branched from the first. Keep the boundary; the user's rules prefer small PRs.
 - The one external unknown (spec §Deployment): the exact `mcp` SDK surface. Task 4 opens with a probe step; if a name has drifted, adapt from the installed SDK's README rather than pinning an older SDK.
+
+---
+
+### Task 0: environment setup (do this first — every later task depends on it)
+
+**Files:** none committed. Creates `.venv/` (already gitignored) in the worktree.
+
+**Interfaces:**
+- Produces: `./.venv/bin/python` — the interpreter every command in this plan names. Editable install, so it always reflects the working tree with no `PYTHONPATH` juggling and no cwd sensitivity.
+
+- [ ] **Step 1: Confirm you are in the right worktree**
+
+```bash
+pwd && git branch --show-current
+```
+
+Expected: `/Users/dcltdw/Github/bunnyforge-mcp` and `feat/serve-mcp`. If you are in `~/Github/bunnyforge` (the shared clone) or `~/Github/bunnyforge-33` (another agent's), stop — do not `git checkout` there; move to the right worktree.
+
+- [ ] **Step 2: Build the venv** (may already exist from setup; harmless to re-run)
+
+```bash
+python3 -m venv .venv && ./.venv/bin/pip install -q -e .
+```
+
+- [ ] **Step 3: Preflight — assert it resolves to THIS worktree**
+
+```bash
+./.venv/bin/python -c "import bunnyforge,pathlib,sys; p=pathlib.Path(bunnyforge.__file__).resolve(); assert p.is_relative_to(pathlib.Path.cwd().resolve()), f'WRONG TREE: {p}'; print('OK:',p); print('python', sys.version.split()[0])"
+```
+
+Expected: `OK: /Users/dcltdw/Github/bunnyforge-mcp/src/bunnyforge/__init__.py`, python 3.13.2. **If it names any other path, stop and fix the environment before writing code** — every downstream test result would be meaningless.
+
+- [ ] **Step 4: Baseline — the suite is green before you change anything**
+
+Run: `./.venv/bin/python -m unittest discover -s tests`
+Expected: 605 tests, OK. (If the count differs, `main` has moved; that is fine, but note the new baseline so a later regression is recognisable.)
+
+Nothing to commit.
 
 ---
 
@@ -55,7 +104,7 @@
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_config -v`
+Run: `./.venv/bin/python -m unittest tests.test_config -v`
 Expected: 3 failures/errors — `AttributeError: 'Config' object has no attribute 'staging_dir'` (and a KeyError from `_DEFAULTS` on the third).
 
 - [ ] **Step 3: Implement** in `src/bunnyforge/_config.py`:
@@ -85,11 +134,11 @@ In `load()`'s `return Config(...)`, add after `type_dirs=_type_dirs(ws),`:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_config -v` → all pass.
+Run: `./.venv/bin/python -m unittest tests.test_config -v` → all pass.
 
 - [ ] **Step 5: Full suite, then commit**
 
-Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → no regressions (other modules construct Config only through `load()`, so the new field is invisible to them).
+Run: `./.venv/bin/python -m unittest discover -s tests -v` → no regressions (other modules construct Config only through `load()`, so the new field is invisible to them).
 
 ```bash
 git add src/bunnyforge/_config.py tests/test_config.py
@@ -233,7 +282,7 @@ if __name__ == "__main__":
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Run: `./.venv/bin/python -m unittest tests.test_store -v`
 Expected: import error — `bunnyforge._store` does not exist.
 
 - [ ] **Step 3: Implement** — create `src/bunnyforge/_store.py`:
@@ -360,7 +409,7 @@ class WorkspaceStore:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v` → all pass.
+Run: `./.venv/bin/python -m unittest tests.test_store -v` → all pass.
 
 - [ ] **Step 5: Commit**
 
@@ -424,7 +473,7 @@ class TestGenerateNames(StoreCase):
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Run: `./.venv/bin/python -m unittest tests.test_store -v`
 Expected: 4 errors — `AttributeError: 'WorkspaceStore' object has no attribute 'generate_names'`.
 
 - [ ] **Step 3: Implement** — in `_store.py`, add to the imports:
@@ -461,7 +510,7 @@ and add to `WorkspaceStore`:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v` → all pass.
+Run: `./.venv/bin/python -m unittest tests.test_store -v` → all pass.
 
 - [ ] **Step 5: Commit**
 
@@ -491,9 +540,17 @@ git commit -m "feat: name generation on WorkspaceStore"
 
 ```bash
 python3 -m venv .venv-mcp
-./.venv-mcp/bin/pip install mcp
+./.venv-mcp/bin/pip install -e . mcp
 echo '.venv-mcp/' >> .gitignore
 ```
+
+`-e .` is **not optional**: a venv is isolated from system site-packages, so without the editable install `from bunnyforge import ...` raises ModuleNotFoundError in every test here. Preflight it the same way as Task 0 before trusting any result:
+
+```bash
+./.venv-mcp/bin/python -c "import bunnyforge,mcp,pathlib; p=pathlib.Path(bunnyforge.__file__).resolve(); assert p.is_relative_to(pathlib.Path.cwd().resolve()), f'WRONG TREE: {p}'; print('OK:',p)"
+```
+
+The two venvs differ in exactly one respect, and that difference is load-bearing: `.venv` has no `mcp` (so it proves the skip-without-the-extra behaviour) and `.venv-mcp` has it (so it exercises the MCP layer). Never install `mcp` into `.venv`.
 
 - [ ] **Step 2: Probe the installed SDK** — the spec's one external unknown. Run:
 
@@ -635,7 +692,7 @@ if __name__ == "__main__":
 
 - [ ] **Step 4: Run to verify they fail**
 
-Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
 Expected: import error — `bunnyforge.serve_mcp` does not exist.
 
 - [ ] **Step 5: Implement** — create `src/bunnyforge/serve_mcp.py`:
@@ -801,8 +858,8 @@ if __name__ == "__main__":
 
 - [ ] **Step 6: Run to verify they pass — in BOTH interpreters**
 
-Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass (fix any SDK-drift breakage per Step 2's probe).
-Run: `PYTHONPATH=src python3 -m unittest tests.test_serve_mcp -v` → auth + main-guard tests pass, `TestBuildServer` reports **skipped**, not errored.
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass (fix any SDK-drift breakage per Step 2's probe).
+Run: `./.venv/bin/python -m unittest tests.test_serve_mcp -v` → auth + main-guard tests pass, `TestBuildServer` reports **skipped**, not errored.
 
 - [ ] **Step 7: Commit**
 
@@ -838,7 +895,7 @@ git commit -m "feat: serve-mcp MCP layer — read tools, doctrine resources, bea
             "serve-mcp": serve_mcp.main,
 ```
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_cli -v`
+Run: `./.venv/bin/python -m unittest tests.test_cli -v`
 Expected: `test_every_subcommand_maps_to_its_modules_main` FAILS (dict mismatch) — the right failure.
 
 - [ ] **Step 2: Register the subcommand** — in `src/bunnyforge/cli.py`, add `serve_mcp` to the `from bunnyforge import (...)` block, then:
@@ -868,9 +925,9 @@ mcp = ["mcp>=1.9"]
 
 - [ ] **Step 5: Verify**
 
-Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → all pass on bare python (MCP-layer tests skip).
-Run: `PYTHONPATH=src python3 -m bunnyforge serve-mcp --help` → help text, exit 0, on bare python.
-Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest discover -s tests -v` → all pass, nothing skipped.
+Run: `./.venv/bin/python -m unittest discover -s tests -v` → all pass on bare python (MCP-layer tests skip).
+Run: `./.venv/bin/python -m bunnyforge serve-mcp --help` → help text, exit 0, on bare python.
+Run: `./.venv-mcp/bin/python -m unittest discover -s tests -v` → all pass, nothing skipped.
 
 Confirm the packaging metadata parses and declares the extra (a read-only check — do NOT install into system site-packages):
 
@@ -1014,7 +1071,7 @@ class TestWriteEntity(StoreCase):
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Run: `./.venv/bin/python -m unittest tests.test_store -v`
 Expected: errors — no attribute `stage_draft` / `stage_revision` / `write_entity`.
 
 - [ ] **Step 3: Implement** — in `_store.py`, add `import re` and `import subprocess` to the imports, a module-level pattern next to the other constants:
@@ -1092,7 +1149,7 @@ and the write side on `WorkspaceStore`:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v` → all pass.
+Run: `./.venv/bin/python -m unittest tests.test_store -v` → all pass.
 
 - [ ] **Step 5: Commit**
 
@@ -1140,7 +1197,7 @@ git commit -m "feat: WorkspaceStore write side — staged drafts, shadow revisio
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
 Expected: the three new tests fail (tools not registered).
 
 - [ ] **Step 3: Implement** — in `build_server`, after the `generate_names` tool and before the resource loop:
@@ -1172,8 +1229,8 @@ Expected: the three new tests fail (tools not registered).
 
 - [ ] **Step 4: Run to verify they pass — both interpreters**
 
-Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass.
-Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → all pass, MCP-layer tests skip.
+Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass.
+Run: `./.venv/bin/python -m unittest discover -s tests -v` → all pass, MCP-layer tests skip.
 
 - [ ] **Step 5: Commit**
 
@@ -1270,11 +1327,11 @@ must be a git repository.
 
 - [ ] **Step 3: Verify the promises match the code** — reread the doc against `serve_mcp.py --help` output and the tool docstrings; every flag, default, path, and tool name in the doc must exist verbatim in the code.
 
-Run: `PYTHONPATH=src python3 -m bunnyforge serve-mcp --help`
+Run: `./.venv/bin/python -m bunnyforge serve-mcp --help`
 
 - [ ] **Step 4: Full suite, then commit**
 
-Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → all pass.
+Run: `./.venv/bin/python -m unittest discover -s tests -v` → all pass.
 
 ```bash
 git add docs/serve-mcp.md README.md

--- a/docs/superpowers/plans/2026-08-16-serve-mcp.md
+++ b/docs/superpowers/plans/2026-08-16-serve-mcp.md
@@ -825,6 +825,13 @@ git commit -m "feat: serve-mcp MCP layer — read tools, doctrine resources, bea
 - Consumes: `serve_mcp.main` (Task 4).
 - Produces: `bunnyforge serve-mcp` as a first-class subcommand; `pip install 'bunnyforge[mcp]'` extra.
 
+> **⚠ Guard — this task collides with PR #38 (`feat/33-vscode-command`), open as of 2026-08-16.**
+> That PR adds a `vscode` subcommand at the *same insertion point* this task uses: `"vscode": vscode.main,` goes between `names` and `test` in `cli.py`'s `_COMMANDS` and `_SUMMARIES`, in its `from bunnyforge import (...)` block, and in `test_cli.py`'s pinned dict — plus a `README.md` table row after `names`. Tasks 1–4 are unaffected; only this task overlaps.
+>
+> **Before starting, rebase onto current `main`** and then **re-read all three files** (`src/bunnyforge/cli.py`, `tests/test_cli.py`, `README.md`) — the line numbers above are pre-#38 and the surrounding content will have moved. Expect textual conflicts if you rebase mid-task instead.
+>
+> **The trap git cannot catch:** `cli.py`'s module docstring counts the subcommands. It says "eight subcommands"; #38 changes it to "nine"; this task also makes it nine on its own. **If both have landed, it must read "ten."** A clean auto-merge leaves that number silently wrong — check it explicitly, and check `test_cli.py`'s pinned dict contains BOTH `"vscode"` and `"serve-mcp"` entries.
+
 - [ ] **Step 1: Update the pinned CLI test first** — in `tests/test_cli.py`'s `test_every_subcommand_maps_to_its_modules_main`, add to the expected dict (and add `serve_mcp` to that test file's imports from `bunnyforge`):
 
 ```python

--- a/docs/superpowers/plans/2026-08-16-serve-mcp.md
+++ b/docs/superpowers/plans/2026-08-16-serve-mcp.md
@@ -14,9 +14,10 @@
 
 - Core bunnyforge stays **stdlib-only**: `_store.py` must import cleanly on a bare Python 3.11; `serve_mcp.py` may import `mcp`/`uvicorn` **only inside function bodies**, never at module level (cli.py imports every module unconditionally).
 - Tests are **unittest**, live in `tests/test_<module>.py`, and must pass on a bare Python: MCP-layer tests skip themselves when the `mcp` package is absent (`@unittest.skipUnless`).
-- Run tests with `python3 -m unittest tests.<module> -v` from the repo root; full suite with `python3 -m unittest discover -s tests -v`.
+- Run tests with `PYTHONPATH=src python3 -m unittest tests.<module> -v` from the repo root; full suite with `PYTHONPATH=src python3 -m unittest discover -s tests -v`.
+- **`PYTHONPATH=src` is mandatory on every interpreter invocation, and never optional.** This machine has a NON-editable `pip install .` of bunnyforge 0.3.1 in system site-packages, so a bare `python3` imports that installed *copy* and cannot see any checkout's source at all — measured, not assumed (a sentinel added to `src/bunnyforge/_common.py` was invisible to `python3` and visible to `PYTHONPATH=src python3`). Without the prefix, new modules (`_store.py`, `serve_mcp.py`) fail to import no matter how correct the code, and edits to existing modules silently test stale installed code — TDD's red→green cycle never goes green and the failure looks like your bug. **Do not "fix" this by reinstalling or `pip install -e .` into system site-packages:** that installed copy is what the user's real campaign work (`bunnyforge review`, `deploy-export` against `~/Dropbox/Games/TTRPGs/Anjeong`) runs on. It is shared machine-global state — leave it exactly as found.
 - Every `[workspace]` config key is optional with a default in `_config._DEFAULTS`.
-- Work on branch `feat/serve-mcp` (exists; spec + this plan are its first commits). **Never commit to `main`.** Run `git branch --show-current` before every commit.
+- Work on branch `feat/serve-mcp` in an **isolated git worktree** — one already exists at `~/Github/bunnyforge-mcp`; work there. Other agents are concurrently active on this machine (`~/Github/bunnyforge` is shared neutral ground on `main`; `~/Github/bunnyforge-33` holds another agent's branch). Never run `git checkout` in the shared clone. **Never commit to `main`.** Run `git branch --show-current` as its own command, and read its output, before every commit.
 - Every commit message ends with a `Co-Authored-By: <current model> <noreply@anthropic.com>` trailer.
 - **PR boundary:** Tasks 1–5 are phase 1 (read-only server) → first PR. Tasks 6–8 are phase 2 (write-back) → second PR branched from the first. Keep the boundary; the user's rules prefer small PRs.
 - The one external unknown (spec §Deployment): the exact `mcp` SDK surface. Task 4 opens with a probe step; if a name has drifted, adapt from the installed SDK's README rather than pinning an older SDK.
@@ -54,7 +55,7 @@
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `python3 -m unittest tests.test_config -v`
+Run: `PYTHONPATH=src python3 -m unittest tests.test_config -v`
 Expected: 3 failures/errors — `AttributeError: 'Config' object has no attribute 'staging_dir'` (and a KeyError from `_DEFAULTS` on the third).
 
 - [ ] **Step 3: Implement** in `src/bunnyforge/_config.py`:
@@ -84,11 +85,11 @@ In `load()`'s `return Config(...)`, add after `type_dirs=_type_dirs(ws),`:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `python3 -m unittest tests.test_config -v` → all pass.
+Run: `PYTHONPATH=src python3 -m unittest tests.test_config -v` → all pass.
 
 - [ ] **Step 5: Full suite, then commit**
 
-Run: `python3 -m unittest discover -s tests -v` → no regressions (other modules construct Config only through `load()`, so the new field is invisible to them).
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → no regressions (other modules construct Config only through `load()`, so the new field is invisible to them).
 
 ```bash
 git add src/bunnyforge/_config.py tests/test_config.py
@@ -232,7 +233,7 @@ if __name__ == "__main__":
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `python3 -m unittest tests.test_store -v`
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
 Expected: import error — `bunnyforge._store` does not exist.
 
 - [ ] **Step 3: Implement** — create `src/bunnyforge/_store.py`:
@@ -359,7 +360,7 @@ class WorkspaceStore:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `python3 -m unittest tests.test_store -v` → all pass.
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v` → all pass.
 
 - [ ] **Step 5: Commit**
 
@@ -423,7 +424,7 @@ class TestGenerateNames(StoreCase):
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `python3 -m unittest tests.test_store -v`
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
 Expected: 4 errors — `AttributeError: 'WorkspaceStore' object has no attribute 'generate_names'`.
 
 - [ ] **Step 3: Implement** — in `_store.py`, add to the imports:
@@ -460,7 +461,7 @@ and add to `WorkspaceStore`:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `python3 -m unittest tests.test_store -v` → all pass.
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v` → all pass.
 
 - [ ] **Step 5: Commit**
 
@@ -634,7 +635,7 @@ if __name__ == "__main__":
 
 - [ ] **Step 4: Run to verify they fail**
 
-Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
+Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
 Expected: import error — `bunnyforge.serve_mcp` does not exist.
 
 - [ ] **Step 5: Implement** — create `src/bunnyforge/serve_mcp.py`:
@@ -800,8 +801,8 @@ if __name__ == "__main__":
 
 - [ ] **Step 6: Run to verify they pass — in BOTH interpreters**
 
-Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass (fix any SDK-drift breakage per Step 2's probe).
-Run: `python3 -m unittest tests.test_serve_mcp -v` → auth + main-guard tests pass, `TestBuildServer` reports **skipped**, not errored.
+Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass (fix any SDK-drift breakage per Step 2's probe).
+Run: `PYTHONPATH=src python3 -m unittest tests.test_serve_mcp -v` → auth + main-guard tests pass, `TestBuildServer` reports **skipped**, not errored.
 
 - [ ] **Step 7: Commit**
 
@@ -830,7 +831,7 @@ git commit -m "feat: serve-mcp MCP layer — read tools, doctrine resources, bea
             "serve-mcp": serve_mcp.main,
 ```
 
-Run: `python3 -m unittest tests.test_cli -v`
+Run: `PYTHONPATH=src python3 -m unittest tests.test_cli -v`
 Expected: `test_every_subcommand_maps_to_its_modules_main` FAILS (dict mismatch) — the right failure.
 
 - [ ] **Step 2: Register the subcommand** — in `src/bunnyforge/cli.py`, add `serve_mcp` to the `from bunnyforge import (...)` block, then:
@@ -860,9 +861,17 @@ mcp = ["mcp>=1.9"]
 
 - [ ] **Step 5: Verify**
 
-Run: `python3 -m unittest discover -s tests -v` → all pass on bare python (MCP-layer tests skip).
-Run: `python3 -m bunnyforge serve-mcp --help` → help text, exit 0, on bare python.
-Run: `./.venv-mcp/bin/pip install -e . >/dev/null && ./.venv-mcp/bin/python -m unittest discover -s tests -v` → all pass, nothing skipped.
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → all pass on bare python (MCP-layer tests skip).
+Run: `PYTHONPATH=src python3 -m bunnyforge serve-mcp --help` → help text, exit 0, on bare python.
+Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest discover -s tests -v` → all pass, nothing skipped.
+
+Confirm the packaging metadata parses and declares the extra (a read-only check — do NOT install into system site-packages):
+
+```bash
+python3 -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['optional-dependencies'])"
+```
+
+Expected: `{'mcp': ['mcp>=1.9']}`
 
 - [ ] **Step 6: Commit — end of phase 1**
 
@@ -998,7 +1007,7 @@ class TestWriteEntity(StoreCase):
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `python3 -m unittest tests.test_store -v`
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
 Expected: errors — no attribute `stage_draft` / `stage_revision` / `write_entity`.
 
 - [ ] **Step 3: Implement** — in `_store.py`, add `import re` and `import subprocess` to the imports, a module-level pattern next to the other constants:
@@ -1076,7 +1085,7 @@ and the write side on `WorkspaceStore`:
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `python3 -m unittest tests.test_store -v` → all pass.
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v` → all pass.
 
 - [ ] **Step 5: Commit**
 
@@ -1124,7 +1133,7 @@ git commit -m "feat: WorkspaceStore write side — staged drafts, shadow revisio
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
+Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v`
 Expected: the three new tests fail (tools not registered).
 
 - [ ] **Step 3: Implement** — in `build_server`, after the `generate_names` tool and before the resource loop:
@@ -1156,8 +1165,8 @@ Expected: the three new tests fail (tools not registered).
 
 - [ ] **Step 4: Run to verify they pass — both interpreters**
 
-Run: `./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass.
-Run: `python3 -m unittest discover -s tests -v` → all pass, MCP-layer tests skip.
+Run: `PYTHONPATH=src ./.venv-mcp/bin/python -m unittest tests.test_serve_mcp -v` → all pass.
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → all pass, MCP-layer tests skip.
 
 - [ ] **Step 5: Commit**
 
@@ -1254,11 +1263,11 @@ must be a git repository.
 
 - [ ] **Step 3: Verify the promises match the code** — reread the doc against `serve_mcp.py --help` output and the tool docstrings; every flag, default, path, and tool name in the doc must exist verbatim in the code.
 
-Run: `python3 -m bunnyforge serve-mcp --help`
+Run: `PYTHONPATH=src python3 -m bunnyforge serve-mcp --help`
 
 - [ ] **Step 4: Full suite, then commit**
 
-Run: `python3 -m unittest discover -s tests -v` → all pass.
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests -v` → all pass.
 
 ```bash
 git add docs/serve-mcp.md README.md

--- a/docs/superpowers/plans/2026-08-16-serve-mcp.md
+++ b/docs/superpowers/plans/2026-08-16-serve-mcp.md
@@ -882,12 +882,14 @@ git commit -m "feat: serve-mcp MCP layer — read tools, doctrine resources, bea
 - Consumes: `serve_mcp.main` (Task 4).
 - Produces: `bunnyforge serve-mcp` as a first-class subcommand; `pip install 'bunnyforge[mcp]'` extra.
 
-> **⚠ Guard — this task collides with PR #38 (`feat/33-vscode-command`), open as of 2026-08-16.**
-> That PR adds a `vscode` subcommand at the *same insertion point* this task uses: `"vscode": vscode.main,` goes between `names` and `test` in `cli.py`'s `_COMMANDS` and `_SUMMARIES`, in its `from bunnyforge import (...)` block, and in `test_cli.py`'s pinned dict — plus a `README.md` table row after `names`. Tasks 1–4 are unaffected; only this task overlaps.
+> **⚠ Guard — PR #38 has MERGED (`65a2cc7`, 2026-08-16). This branch is rebased onto it; the collision is resolved in advance, but its consequences are live.** Verified on `main` as it now stands:
+> - `cli.py`'s `_COMMANDS` and `_SUMMARIES` already contain `"vscode": vscode.main,` **between `names` and `test`**, and `vscode` is in the `from bunnyforge import (...)` block.
+> - `tests/test_cli.py`'s pinned dict likewise. It must end up containing **both** `"vscode"` and `"serve-mcp"`.
+> - `README.md`'s table has a `vscode` row between `names` and `test`.
 >
-> **Before starting, rebase onto current `main`** and then **re-read all three files** (`src/bunnyforge/cli.py`, `tests/test_cli.py`, `README.md`) — the line numbers above are pre-#38 and the surrounding content will have moved. Expect textual conflicts if you rebase mid-task instead.
+> **Insert `serve-mcp` after `vscode`, keeping `test` last** — that is the existing ordering convention in all three places. **Re-read all three files before editing**; the line numbers in this task's Files list predate #38 and are stale.
 >
-> **The trap git cannot catch:** `cli.py`'s module docstring counts the subcommands. It says "eight subcommands"; #38 changes it to "nine"; this task also makes it nine on its own. **If both have landed, it must read "ten."** A clean auto-merge leaves that number silently wrong — check it explicitly, and check `test_cli.py`'s pinned dict contains BOTH `"vscode"` and `"serve-mcp"` entries.
+> **The trap git cannot catch:** `cli.py`'s module docstring counts the subcommands, and no diff makes the number visible. It read "eight"; #38 took it to **"nine"** (confirmed on `main`). This task must take it to **"ten."**
 
 - [ ] **Step 1: Update the pinned CLI test first** — in `tests/test_cli.py`'s `test_every_subcommand_maps_to_its_modules_main`, add to the expected dict (and add `serve_mcp` to that test file's imports from `bunnyforge`):
 

--- a/docs/superpowers/specs/2026-08-16-serve-mcp-design.md
+++ b/docs/superpowers/specs/2026-08-16-serve-mcp-design.md
@@ -1,0 +1,163 @@
+# serve-mcp: remote MCP access to a campaign workspace — design
+
+**Date:** 2026-08-16
+**Status:** draft, awaiting review
+
+## Problem
+
+A GM wants to do campaign content creation with a web-based Claude agent
+(claude.ai), whose conversational "ask questions, offer options" style suits
+brainstorming better than the local coding agent. But the GM materials — the
+source of truth — live in a local bunnyforge workspace the web agent cannot
+see. claude.ai reaches external data through custom connectors, which are
+remote MCP servers.
+
+`bunnyforge serve-mcp` runs an MCP server over a campaign workspace so a
+web-based agent can read GM materials, use bunnyforge's generators, and write
+drafts back — without ever becoming a second source of truth.
+
+## Goals
+
+- Give a claude.ai custom connector read access to the whole workspace,
+  plus the name generator, with enough orientation tooling that a fresh
+  conversation gets its bearings in one call.
+- Serve workspace doctrine (style guide, situation-design guide, AGENTS.md)
+  so the web agent collaborates under the same contract as a local agent.
+- Accept written output back — new drafts and proposed revisions — into the
+  workspace's staging area, feeding the existing extraction workflow.
+- Keep the server deployable from the GM's own machine behind a tunnel,
+  with a storage seam that permits a hosted deployment later.
+
+## Non-goals
+
+- **No publishing.** `export-player`, `deploy-export`, and anything touching
+  `Export/` or the wiki are absent from the tool surface. Publishing to
+  players remains a local, human-initiated act.
+- **No visibility filtering.** The connector authenticates as the GM and
+  serves everything, including `gm-only` material. A player-facing,
+  visibility-filtered server is a conceivable future feature, not this one.
+- **No hosted backend yet.** Phase 3 sketches it; this spec builds the
+  local-machine shape.
+
+## Decisions already made (with the user)
+
+1. **Optional extra, not stdlib.** The MCP protocol layer comes from the
+   official `mcp` Python SDK, installed via `pip install bunnyforge[mcp]`.
+   Core bunnyforge keeps its zero-runtime-dependency doctrine; `serve-mcp`
+   is inherently online, so an install-time dependency is acceptable there.
+   Importing the subcommand without the extra fails with a friendly
+   "install bunnyforge[mcp]" error; every other subcommand is unaffected.
+2. **Write-back is required for the feature to be worth using.** Phase 1
+   (read-only) is scaffolding; phase 2 (writes) is the usability milestone.
+3. **Staging by default, direct edits behind a flag.** Without the flag the
+   server never writes canonical directories. `--allow-direct-edits` enables
+   in-place edits, each auto-committed to git.
+4. **Start Mac-local, design for hosting.** All file access goes through one
+   storage interface so a later hosted (git-clone-backed) deployment swaps
+   the backend, not the tools.
+
+## Architecture
+
+```
+claude.ai custom connector
+        │  streamable HTTP (JSON-RPC / MCP)
+        ▼
+tunnel (Tailscale Funnel / cloudflared — user-run, documented not implemented)
+        ▼
+bunnyforge serve-mcp  ──►  MCP layer: tools + resources (mcp SDK)
+        │
+        ▼
+WorkspaceStore (interface): read / list / search / stage_write / write
+        │
+        ▼
+LocalStore → the workspace on disk (resolved via campaign.toml, like every
+             other subcommand)
+```
+
+The server resolves its workspace exactly as other commands do
+(`resolve_workspace`, `_config.load`). Tools are thin handlers over
+`WorkspaceStore`; the store owns path resolution, traversal guards, and the
+staging/canonical boundary. Phase 3's `GitStore` (clone, pull, commit, push)
+implements the same interface.
+
+## Deployment and auth
+
+- The server binds localhost; reaching it from claude.ai is the tunnel's
+  job. Bunnyforge documents the Tailscale Funnel / cloudflared recipe but
+  does not manage tunnels.
+- Auth is required by default: a static bearer token (`--token` /
+  `BUNNYFORGE_MCP_TOKEN`), checked on every request. `--no-auth` exists for
+  local testing only.
+- claude.ai's connector auth requirements (OAuth support, token handling)
+  must be validated end-to-end as part of phase 1; if a static bearer token
+  is not accepted, the SDK's OAuth support is the fallback. This is the one
+  external unknown in the design.
+
+## Tool surface
+
+| tool | phase | behaviour |
+|---|---|---|
+| `campaign_overview()` | 1 | Campaign name; each configured entity dir with entity counts; full text of `front-burner.md` and `open-questions.md` when present. One call to orient a fresh conversation. |
+| `list_entities(section)` | 1 | Files in one entity dir: workspace-relative path, title, and a one-line summary drawn from front matter. |
+| `read_entity(path)` | 1 | Full file content, front matter included. Any workspace-relative path, not just entity dirs (excluded dirs stay excluded). |
+| `search(query, section?)` | 1 | Case-insensitive substring search across workspace content files; returns path + surrounding snippet per hit, capped per response. |
+| `generate_names(culture, count)` | 1 | Wraps the existing name generator against the workspace's culture inventories. |
+| `save_draft(section, name, content)` | 2 | Writes new content to `<staging>/<section>/<name>.md`. Refuses to overwrite an existing draft — the error tells the agent to pick another name. |
+| `propose_revision(path, content)` | 2 | Full-file shadow copy of an existing canonical file, written to `<staging>/<path>` mirroring its workspace-relative path. Requires the target to exist. Local review is a diff away. |
+| `write_entity(path, content)` | 2 | Registered only when the server runs with `--allow-direct-edits`. Edits the canonical file in place and auto-commits (`serve-mcp: edit <path>`), so review and undo are git operations. |
+
+Write tools confine themselves mechanically: `save_draft` and
+`propose_revision` may only create files under the staging directory;
+`write_entity` may only touch existing content files inside the workspace.
+Path traversal outside the workspace is rejected in `WorkspaceStore`, not in
+each handler.
+
+### Staging directory
+
+New `[workspace]` config key `staging_dir`, default `_ExtractInbound`
+(matching the existing convention where inbound material awaits extraction
+and spent sources move to `_Done/`). The server creates it on first write if
+absent. Drafts landing there feed the extraction workflow the workspace's
+AGENTS.md already defines — the server's responsibility ends at staging.
+
+### Resources
+
+Workspace doctrine exposed as MCP resources, so the connector can load them
+at conversation start: `style-guide.md`, `situation-design.md`, `AGENTS.md`.
+Missing files are simply not listed.
+
+## Phasing
+
+1. **Phase 1 — read + orient.** The five read/generate tools, resources,
+   token auth, tunnel recipe docs. Exit criterion: a claude.ai conversation
+   can orient itself and answer questions about the campaign unaided.
+2. **Phase 2 — write-back.** `save_draft`, `propose_revision`,
+   `write_entity` + flag, `staging_dir` config. Exit criterion: a draft
+   written from claude.ai lands in staging and flows through the local
+   extraction workflow. *The feature is not usable in practice until this
+   lands.*
+3. **Phase 3 — hosted (not yet committed).** `GitStore` over the campaign's
+   git remote; drafts arrive as commits. Only if Mac-only availability
+   proves annoying in practice.
+
+## Testing
+
+- `WorkspaceStore` and each tool handler unit-tested against temporary
+  workspaces built the way existing tests do (`load()` / `open_workspace()`
+  against a scaffolded tree) — including traversal rejection, staging
+  confinement, overwrite refusal, and flag-gating of `write_entity`.
+- MCP layer exercised with the SDK's in-memory client against the running
+  server object: list tools, call each, list/read resources.
+- Auth: request without token → rejected; with token → served.
+- The claude.ai connector handshake itself is validated manually in phase 1
+  (external service; not automatable from the test suite).
+
+## Security considerations
+
+- Everything served is GM-eyes-only; the bearer token (and the tunnel's own
+  auth, where used) is the only gate. Default-deny: no token configured and
+  no `--no-auth` → the server refuses to start.
+- Write surface is confined as described above; the deploy/publish path is
+  structurally absent rather than merely forbidden.
+- `--allow-direct-edits` trades a mechanical boundary for git history; the
+  flag exists so that trade is always explicit and per-run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,18 @@ classifiers = [
 Repository = "https://github.com/dcltdw/bunnyforge"
 Issues = "https://github.com/dcltdw/bunnyforge/issues"
 
+[project.optional-dependencies]
+# serve-mcp only. Every other subcommand stays zero-dependency, and
+# serve_mcp.py imports these inside function bodies, so a bare install can
+# still import the module, answer --help, and print an install hint.
+#
+# The floor is 2.0, not 1.x: serve_mcp.py uses `from mcp.server import
+# MCPServer`, which 1.x does not have -- it spelled the same object
+# `mcp.server.fastmcp.FastMCP` and took stateless_http on the constructor
+# rather than on streamable_http_app(). An older SDK would install cleanly
+# and then fail at import.
+mcp = ["mcp>=2.0"]
+
 [project.scripts]
 bunnyforge = "bunnyforge.cli:main"
 

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -35,7 +35,7 @@ Config = namedtuple(
     "Config",
     "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
     "exclude_dirs names_cultures names_official_culture names_spelling "
-    "briefs_dir sheets_dir perceptions_dir type_dirs wiki_url "
+    "briefs_dir sheets_dir perceptions_dir type_dirs staging_dir wiki_url "
     "wiki_install_root accepted snapshot_max_age_days fetch_command",
     # wiki_url and wiki_install_root: [wiki] is entirely optional, so a
     # workspace using neither RPC nor the `wiki` review suite leaves both
@@ -118,6 +118,10 @@ _DEFAULTS = {
                   "style-guide.md", "tickets.md"],
     "exclude_dirs": ["_Ignore", "_Archive", "_ExtractInbound", "_Templates",
                      "Sheets", "Reviews", "docs", "scripts", "tests"],
+    # Where material authored outside the workspace lands to await
+    # extraction. Deliberately one of exclude_dirs above: a staged draft is
+    # not content until a human promotes it, so nothing walks it.
+    "staging_dir": "_ExtractInbound",
     "briefs_dir": "Briefs",
     "sheets_dir": "Sheets",
     "perceptions_dir": "Perceptions",
@@ -327,6 +331,7 @@ def load(workspace: Path) -> Config:
         sheets_dir=_str(ws, "sheets_dir"),
         perceptions_dir=_str(ws, "perceptions_dir"),
         type_dirs=_type_dirs(ws),
+        staging_dir=_str(ws, "staging_dir"),
         wiki_url=wiki_url,
         wiki_install_root=wiki_install_root,
         accepted=accepted,

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -19,13 +19,16 @@ belongs on the class, never in free functions serve_mcp.py calls directly.
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
 
 from bunnyforge import _common
+from bunnyforge import generate_names as _names
 from bunnyforge._config import Workspace
 
 SEARCH_CAP = 50       # hits per search reply; the reply says when it truncated
 SNIPPET_RADIUS = 80   # characters of context on each side of a match
+NAME_COUNT_CAP = 50   # names per request; a brainstorm needs a handful, not a page
 
 
 class StoreError(Exception):
@@ -154,3 +157,37 @@ class WorkspaceStore:
                              "narrow the query)"})
                 break
         return hits
+
+    # -- generators ---------------------------------------------------------
+
+    def generate_names(self, culture: str, count: int) -> dict:
+        """Culture-appropriate person and place names for this setting.
+
+        A thin wrapper over the existing generator, which already owns every
+        rule about how a culture's names are built. Its exceptions are
+        translated to StoreError here: an InventoryError reaching the tool
+        layer would surface to the remote agent as a crash rather than as
+        something it could act on.
+        """
+        count = max(1, min(int(count), NAME_COUNT_CAP))
+        try:
+            inv = _names.load_inventory(self.ws)
+        except _names.InventoryError as exc:
+            raise StoreError(str(exc)) from exc
+
+        # resolve() answers a key, a list of candidates when an alias is
+        # ambiguous, or None. Only the first is usable — guessing between
+        # two cultures would be worse than refusing.
+        key = _names.resolve(inv.cultures, culture)
+        if not isinstance(key, str):
+            available = ", ".join(sorted(inv.cultures))
+            hint = ("ambiguous" if isinstance(key, list) else "unknown")
+            raise StoreError(
+                f"{hint} culture {culture!r} — available: {available}")
+
+        rng = random.Random()
+        return {"culture": key,
+                "people": [_names.person_name(rng, inv, key, None)
+                           for _ in range(count)],
+                "places": [_names.place_name(rng, inv, key)
+                           for _ in range(count)]}

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+_store.py — the workspace-access layer behind `bunnyforge serve-mcp`.
+
+Every MCP tool call touches the workspace through WorkspaceStore, so the
+path guards and the staging/canonical boundary have exactly one home. A
+remote agent's request is untrusted input: it names a path, and refusing
+the ones that escape the workspace or reach into excluded directories is
+this module's job, not the tool layer's.
+
+Stdlib only, deliberately: the MCP SDK belongs to serve_mcp.py, and even
+there only inside function bodies — this module must import cleanly on a
+bare Python.
+
+The class is also the phase-3 seam. A hosted deployment swaps in a
+git-clone-backed implementation with the same method surface, so behaviour
+belongs on the class, never in free functions serve_mcp.py calls directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bunnyforge import _common
+from bunnyforge._config import Workspace
+
+SEARCH_CAP = 50       # hits per search reply; the reply says when it truncated
+SNIPPET_RADIUS = 80   # characters of context on each side of a match
+
+
+class StoreError(Exception):
+    """A refusal the remote agent will see verbatim: unknown section, bad
+    path, missing file. The message text is the API — write it to be acted
+    on, naming the valid alternatives rather than merely saying no."""
+
+
+class WorkspaceStore:
+
+    def __init__(self, ws: Workspace):
+        self.ws = ws
+
+    # -- guards -------------------------------------------------------------
+
+    def _sections(self) -> tuple[str, ...]:
+        cfg = self.ws.config
+        return cfg.entity_dirs + cfg.inherit_dirs
+
+    def _check_section(self, section: str) -> None:
+        if section not in self._sections():
+            raise StoreError(f"unknown section {section!r} — one of: "
+                             + ", ".join(self._sections()))
+
+    def _canonical(self, path: str) -> Path:
+        """Resolve a workspace-relative path, refusing escapes and excluded
+        directories.
+
+        The staging directory is one of the excluded ones, so a draft written
+        there is not readable back through this method: the read tools serve
+        canon, and staged material is not canon until a human promotes it.
+        """
+        root = self.ws.root
+        p = (root / path).resolve()
+        if not p.is_relative_to(root):
+            raise StoreError(f"path escapes the workspace: {path}")
+        excluded = self.ws.config.exclude_dirs & set(p.relative_to(root).parts)
+        if excluded:
+            raise StoreError(
+                f"path is in an excluded directory ({', '.join(sorted(excluded))}): "
+                f"{path}")
+        return p
+
+    # -- read side ----------------------------------------------------------
+
+    def overview(self) -> dict:
+        """One call to orient a fresh conversation: what this campaign is,
+        what it holds, and what is currently live."""
+        cfg = self.ws.config
+        # Counted from the same walk list_entities uses, so a count here and
+        # the list it promises cannot disagree. A bare rglob would include
+        # files inside excluded subdirectories that list_entities omits.
+        counts: dict[str, int] = {}
+        for rec in _common.iter_content_files(self.ws):
+            parts = rec.path.relative_to(self.ws.root).parts
+            if len(parts) > 1:
+                counts[parts[0]] = counts.get(parts[0], 0) + 1
+        # Only directories that exist: a section the campaign has not created
+        # yet is absent, not empty. Reporting it as 0 would present an unused
+        # part of the layout as an emptied one.
+        sections = {d: counts.get(d, 0) for d in self._sections()
+                    if (self.ws.root / d).is_dir()}
+
+        out: dict = {"name": cfg.name, "sections": sections}
+        for key, fname in (("front_burner", "front-burner.md"),
+                           ("open_questions", "open-questions.md")):
+            p = self.ws.root / fname
+            out[key] = p.read_text(encoding="utf-8") if p.is_file() else None
+        return out
+
+    def list_entities(self, section: str) -> list[dict]:
+        """One section's files: workspace path, title, one-line summary.
+
+        Summaries come from front matter, where this workspace's convention
+        puts a retrievable one-sentence description — which is what makes a
+        listing useful to an agent that has not read the files.
+        """
+        self._check_section(section)
+        out = []
+        for rec in _common.iter_content_files(self.ws):
+            rel = rec.path.relative_to(self.ws.root)
+            if rel.parts[0] != section:
+                continue
+            out.append({"path": rel.as_posix(),
+                        "title": rec.fm.get("title") or rec.path.stem,
+                        "summary": rec.fm.get("summary", "")})
+        return out
+
+    def read_entity(self, path: str) -> str:
+        """Full text of one workspace file, front matter included."""
+        p = self._canonical(path)
+        if not p.is_file():
+            raise StoreError(f"no such file: {path}")
+        return p.read_text(encoding="utf-8")
+
+    def search(self, query: str, section: str | None = None) -> list[dict]:
+        """Case-insensitive substring search across content files.
+
+        Deliberately literal rather than clever: an agent that can see the
+        matched text decides relevance better than a ranking heuristic
+        would, and a substring match is explainable when it surprises.
+        """
+        q = query.strip().lower()
+        if not q:
+            raise StoreError("empty search query")
+        if section is not None:
+            self._check_section(section)
+
+        hits: list[dict] = []
+        for rec in _common.iter_content_files(self.ws):
+            rel = rec.path.relative_to(self.ws.root).as_posix()
+            if section is not None and not rel.startswith(section + "/"):
+                continue
+            text = rec.path.read_text(encoding="utf-8")
+            i = text.lower().find(q)
+            if i == -1:
+                continue
+            lo = max(0, i - SNIPPET_RADIUS)
+            hi = min(len(text), i + len(q) + SNIPPET_RADIUS)
+            hits.append({"path": rel, "snippet": text[lo:hi]})
+            if len(hits) >= SEARCH_CAP:
+                # Say so rather than truncating silently: a capped reply that
+                # looks complete is worse than a short one that admits it.
+                hits.append({"path": "", "snippet":
+                             f"(truncated at {SEARCH_CAP} hits — "
+                             "narrow the query)"})
+                break
+        return hits

--- a/src/bunnyforge/cli.py
+++ b/src/bunnyforge/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cli.py — the `bunnyforge` front door: one command, nine subcommands.
+cli.py — the `bunnyforge` front door: one command, ten subcommands.
 
 Only the first token is parsed here; everything after it passes to the
 target module's main(argv) verbatim. This parser never mirrors a tool's
@@ -36,6 +36,7 @@ from bunnyforge import (
     init,
     review,
     run_tests,
+    serve_mcp,
     vscode,
 )
 
@@ -50,6 +51,7 @@ _COMMANDS = {
     "build-sheets": build_sheets.main,
     "names": generate_names.main,
     "vscode": vscode.main,
+    "serve-mcp": serve_mcp.main,
     "test": run_tests.main,
 }
 
@@ -64,6 +66,7 @@ _SUMMARIES = {
     "build-sheets": "build one-page HTML reference sheets for a session",
     "names": "generate culture-appropriate names",
     "vscode": "install the preview extension and toggle editor colouring",
+    "serve-mcp": "serve the workspace to a remote AI agent over MCP",
     "test": "run the workspace test suite",
 }
 

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+serve_mcp.py — `bunnyforge serve-mcp`: serve one campaign workspace to a
+remote AI agent over MCP, as a claude.ai custom connector.
+
+Design doc: docs/superpowers/specs/2026-08-16-serve-mcp-design.md.
+
+The `mcp` SDK is this package's only third-party dependency and it is
+optional (`pip install 'bunnyforge[mcp]'`), so it is imported only INSIDE
+function bodies. cli.py imports every subcommand module unconditionally: a
+bare Python must be able to import this one, print its --help, and get a
+friendly install hint, with no other subcommand affected.
+
+Everything served here is GM-eyes-only, so auth is default-deny: no token
+and no explicit --no-auth means the server refuses to start. _BearerAuth is
+deliberately pure ASGI rather than starlette middleware — it must work
+whatever the SDK builds its app from, and it is short enough to read in one
+sitting, which is what you want of the only thing between a tunnel and the
+campaign's secrets.
+
+Publishing is structurally absent, not merely forbidden: no tool here
+touches Export/ or the wiki, so a remote agent cannot leak GM material to
+players even by accident.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from bunnyforge import _config
+from bunnyforge._config import ConfigError, WorkspaceError
+from bunnyforge._store import StoreError, WorkspaceStore
+
+TOKEN_ENV = "BUNNYFORGE_MCP_TOKEN"
+
+# Workspace doctrine, offered as MCP resources so a fresh conversation can
+# load the house rules before it writes anything. Absent files are simply
+# not listed.
+DOCTRINE_FILES = ("style-guide.md", "situation-design.md", "AGENTS.md")
+
+_INSTALL_HINT = ("serve-mcp needs its optional dependencies:\n"
+                 "  pip install 'bunnyforge[mcp]'")
+
+
+class _BearerAuth:
+    """Require `Authorization: Bearer <token>` on every HTTP request.
+
+    Non-HTTP scopes (lifespan) pass through untouched: they carry no headers,
+    and answering them with 401 would stop the app from starting.
+    """
+
+    def __init__(self, app, token: str):
+        self._app = app
+        self._expected = f"Bearer {token}".encode()
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            headers = {k.lower(): v for k, v in scope.get("headers") or []}
+            if headers.get(b"authorization") != self._expected:
+                await send({"type": "http.response.start", "status": 401,
+                            "headers": [(b"content-type", b"text/plain"),
+                                        (b"www-authenticate", b"Bearer")]})
+                await send({"type": "http.response.body",
+                            "body": b"unauthorized"})
+                return
+        await self._app(scope, receive, send)
+
+
+def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False):
+    """Assemble the MCP server over one workspace store.
+
+    Imports the SDK, so a caller without the extra gets ModuleNotFoundError;
+    main() translates that into the install hint.
+
+    Tool docstrings are not decoration — they are what the remote agent reads
+    to decide whether to call a tool, so they say when to use it, not merely
+    what it does.
+    """
+    from mcp.server import MCPServer
+
+    server = MCPServer("bunnyforge")
+
+    @server.tool()
+    def campaign_overview() -> dict:
+        """Get your bearings in one call: the campaign's name, each section
+        with how many entities it holds, and the current front-burner and
+        open-questions documents. Call this before anything else."""
+        return store.overview()
+
+    @server.tool()
+    def list_entities(section: str) -> list[dict]:
+        """List one section's files with their titles and one-line
+        summaries. Use it to see what already exists before inventing
+        something new."""
+        return store.list_entities(section)
+
+    @server.tool()
+    def read_entity(path: str) -> str:
+        """Read one workspace file in full, front matter included. Paths
+        come from list_entities or search."""
+        return store.read_entity(path)
+
+    @server.tool()
+    def search(query: str, section: str | None = None) -> list[dict]:
+        """Search the workspace for a phrase, returning each file that
+        matches and the text around the match. Use it to check what has
+        already been established about a name, place, or idea."""
+        return store.search(query, section)
+
+    @server.tool()
+    def generate_names(culture: str, count: int = 10) -> dict:
+        """Generate person and place names appropriate to one of this
+        setting's cultures. Call campaign_overview or read a Setting file
+        first if you are unsure which cultures exist."""
+        return store.generate_names(culture, count)
+
+    def _reader(path):
+        def read() -> str:
+            return path.read_text(encoding="utf-8")
+        return read
+
+    for filename in DOCTRINE_FILES:
+        path = store.ws.root / filename
+        if path.is_file():
+            server.resource(
+                f"bunnyforge://doctrine/{filename}",
+                name=filename,
+                description=f"Workspace doctrine: {filename}. Read this "
+                            "before writing content for this campaign.",
+            )(_reader(path))
+
+    return server
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bunnyforge serve-mcp",
+        description="Serve this workspace to a remote AI agent over MCP.")
+    parser.add_argument("--workspace",
+                        help="path to the campaign workspace")
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="bind address (default: %(default)s; expose it "
+                             "through a tunnel, not by binding wider)")
+    parser.add_argument("--port", type=int, default=8765,
+                        help="bind port (default: %(default)s)")
+    parser.add_argument("--token",
+                        help=f"bearer token, or set {TOKEN_ENV}; required "
+                             "unless --no-auth")
+    parser.add_argument("--no-auth", action="store_true",
+                        help="serve with no authentication — local testing "
+                             "only; everything served is GM-only material")
+    parser.add_argument("--allow-direct-edits", action="store_true",
+                        help="also expose write_entity, which edits "
+                             "canonical files in place and commits each edit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        ws = _config.resolve_workspace(args.workspace)
+    except (ConfigError, WorkspaceError) as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    token = (args.token or os.environ.get(TOKEN_ENV, "")).strip()
+    if not token and not args.no_auth:
+        print("refusing to start without auth: pass --token, set "
+              f"{TOKEN_ENV}, or (local testing only) pass --no-auth",
+              file=sys.stderr)
+        return 1
+
+    try:
+        import uvicorn
+        server = build_server(WorkspaceStore(ws),
+                              allow_direct_edits=args.allow_direct_edits)
+    except ModuleNotFoundError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 1
+
+    app = server.streamable_http_app(stateless_http=True)
+    if token:
+        app = _BearerAuth(app, token)
+    else:
+        print("WARNING: serving with no authentication", file=sys.stderr)
+
+    print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp")
+    uvicorn.run(app, host=args.host, port=args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from bunnyforge import (
     init,
     review,
     run_tests,
+    serve_mcp,
     vscode,
 )
 
@@ -48,6 +49,7 @@ class TestDispatchTable(unittest.TestCase):
             "build-sheets": build_sheets.main,
             "names": generate_names.main,
             "vscode": vscode.main,
+            "serve-mcp": serve_mcp.main,
             "test": run_tests.main,
         })
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -246,6 +246,26 @@ class TestConfigLoad(unittest.TestCase):
             _config.load(cfg)
         self.assertIn("must be a table of strings", str(ctx.exception))
 
+    def test_staging_dir_defaults_to_extract_inbound(self):
+        # Where material written from outside the workspace lands to await
+        # extraction. The default matches the existing convention, and is
+        # already in the default exclude_dirs -- staged drafts are meant to
+        # be invisible to every walk until a human promotes them.
+        cfg = _config.load(self._ws(MINIMAL))
+        self.assertEqual(cfg.staging_dir, "_ExtractInbound")
+        self.assertIn(cfg.staging_dir, cfg.exclude_dirs)
+
+    def test_staging_dir_honours_explicit_override(self):
+        cfg = _config.load(self._ws(
+            MINIMAL + '\n[workspace]\nstaging_dir = "_Inbox"\n'))
+        self.assertEqual(cfg.staging_dir, "_Inbox")
+
+    def test_staging_dir_wrong_type_raises(self):
+        with self.assertRaises(_config.ConfigError) as ctx:
+            _config.load(self._ws(
+                MINIMAL + '\n[workspace]\nstaging_dir = ["x"]\n'))
+        self.assertIn("staging_dir", str(ctx.exception))
+
 
 class TestWorkspace(unittest.TestCase):
     """Workspace bundles a root with the config loaded from it, so callers

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -1,0 +1,203 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bunnyforge import _config, _store, serve_mcp
+
+# The MCP SDK is an optional extra. Everything that does not need it runs on
+# a bare Python; the rest skips rather than failing, so the suite stays green
+# for anyone who installed bunnyforge without `[mcp]`.
+HAVE_MCP = importlib.util.find_spec("mcp") is not None
+
+MINIMAL = '[campaign]\nnamespace = "testwiki"\nname = "Testmere"\n'
+
+NPC = """---
+title: Kim Ha-eun
+summary: Kim Ha-eun is a ferry captain in Testmere harbor.
+---
+She knows the tides.
+"""
+
+
+def scaffold(case: unittest.TestCase) -> _store.WorkspaceStore:
+    root = Path(case.enterContext(tempfile.TemporaryDirectory()))
+    (root / "campaign.toml").write_text(MINIMAL, encoding="utf-8")
+    (root / "NPCs").mkdir()
+    (root / "NPCs" / "kim-ha-eun.md").write_text(NPC, encoding="utf-8")
+    (root / "style-guide.md").write_text("# Style\nSpare prose.\n",
+                                         encoding="utf-8")
+    return _store.WorkspaceStore(_config.open_workspace(root))
+
+
+class TestBearerAuth(unittest.IsolatedAsyncioTestCase):
+    """Pure ASGI, so this runs without the mcp extra installed."""
+
+    async def _call(self, auth, headers):
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+
+        await auth({"type": "http", "headers": headers}, None, send)
+        return sent
+
+    async def test_missing_token_is_401_and_never_reaches_the_app(self):
+        async def inner(scope, receive, send):
+            raise AssertionError("unauthenticated request reached the app")
+
+        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"), [])
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_wrong_token_is_401(self):
+        async def inner(scope, receive, send):
+            raise AssertionError("unauthenticated request reached the app")
+
+        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
+                                [(b"authorization", b"Bearer wrong")])
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_near_miss_token_is_401(self):
+        # A prefix of the real token must not pass: the comparison is of the
+        # whole header value, not a startswith.
+        async def inner(scope, receive, send):
+            raise AssertionError("unauthenticated request reached the app")
+
+        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
+                                [(b"authorization", b"Bearer sek")])
+        self.assertEqual(sent[0]["status"], 401)
+
+    async def test_right_token_passes_through(self):
+        seen = []
+
+        async def inner(scope, receive, send):
+            seen.append(scope)
+
+        await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
+                         [(b"authorization", b"Bearer sekrit")])
+        self.assertEqual(len(seen), 1)
+
+    async def test_non_http_scope_passes_through_untouched(self):
+        # Lifespan events carry no headers and must not be answered with 401,
+        # or the app never starts.
+        seen = []
+
+        async def inner(scope, receive, send):
+            seen.append(scope)
+
+        await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
+                         [])  # headers ignored for a lifespan scope
+        self.assertEqual(len(seen), 0)  # the http scope above was rejected
+
+        auth = serve_mcp._BearerAuth(inner, "sekrit")
+        await auth({"type": "lifespan"}, None, None)
+        self.assertEqual(len(seen), 1)
+
+
+class TestMainGuards(unittest.TestCase):
+    """argparse and the refusals — no mcp extra needed for any of these."""
+
+    def _ws(self) -> Path:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "campaign.toml").write_text(MINIMAL, encoding="utf-8")
+        return root
+
+    def test_help_works_without_the_extra(self):
+        with self.assertRaises(SystemExit) as ctx:
+            serve_mcp.main(["--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_refuses_to_start_without_token_or_no_auth(self):
+        # A token in the invoking environment must not leak into the test.
+        with mock.patch.dict("os.environ", {serve_mcp.TOKEN_ENV: ""}):
+            self.assertEqual(
+                serve_mcp.main(["--workspace", str(self._ws())]), 1)
+
+    def test_bad_workspace_is_one_error_line_not_a_traceback(self):
+        empty = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.assertEqual(serve_mcp.main(["--workspace", str(empty)]), 1)
+
+
+@unittest.skipUnless(HAVE_MCP, "mcp extra not installed")
+class TestBuildServer(unittest.IsolatedAsyncioTestCase):
+
+    async def _text(self, result) -> str:
+        return "".join(part.text for part in result.content)
+
+    async def test_read_tools_are_registered(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual(
+            {"campaign_overview", "list_entities", "read_entity", "search",
+             "generate_names"}, names)
+
+    async def test_write_tools_absent_in_phase_1(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertFalse({"save_draft", "propose_revision", "write_entity"}
+                         & names)
+
+    async def test_every_tool_carries_a_description(self):
+        # The description is how the remote agent decides to call a tool at
+        # all; an undocumented tool is an unused one.
+        server = serve_mcp.build_server(scaffold(self))
+        for tool in await server.list_tools():
+            self.assertTrue((tool.description or "").strip(), tool.name)
+
+    async def test_campaign_overview_answers(self):
+        server = serve_mcp.build_server(scaffold(self))
+        payload = await self._text(
+            await server.call_tool("campaign_overview", {}))
+        self.assertIn("Testmere", payload)
+        self.assertIn("NPCs", payload)
+
+    async def test_read_entity_round_trips(self):
+        server = serve_mcp.build_server(scaffold(self))
+        payload = await self._text(await server.call_tool(
+            "read_entity", {"path": "NPCs/kim-ha-eun.md"}))
+        self.assertIn("ferry captain", payload)
+
+    async def test_search_accepts_an_omitted_section(self):
+        server = serve_mcp.build_server(scaffold(self))
+        payload = await self._text(
+            await server.call_tool("search", {"query": "tides"}))
+        self.assertIn("kim-ha-eun", payload)
+
+    async def test_a_refusal_carries_its_reason_to_the_caller(self):
+        # A StoreError must reach the agent as an actionable message rather
+        # than a silent empty answer. Two layers are involved and only the
+        # first is exercised here: call_tool() -- the convenience API --
+        # raises, while the SDK's protocol handler (_handle_call_tool)
+        # catches that and returns CallToolResult(is_error=True) with
+        # str(exc) as the content, which is what a real client receives.
+        # What both layers depend on, and what this pins, is that the
+        # reason survives into the exception's message.
+        server = serve_mcp.build_server(scaffold(self))
+        with self.assertRaises(Exception) as ctx:
+            await server.call_tool("read_entity", {"path": "../escape.md"})
+        self.assertIn("escapes the workspace", str(ctx.exception))
+        self.assertIn("read_entity", str(ctx.exception))
+
+    async def test_doctrine_resource_lists_and_reads(self):
+        server = serve_mcp.build_server(scaffold(self))
+        uris = {str(r.uri) for r in await server.list_resources()}
+        self.assertIn("bunnyforge://doctrine/style-guide.md", uris)
+        parts = list(await server.read_resource(
+            "bunnyforge://doctrine/style-guide.md"))
+        self.assertIn("Spare prose", "".join(p.content for p in parts))
+
+    async def test_absent_doctrine_file_is_not_listed(self):
+        server = serve_mcp.build_server(scaffold(self))
+        uris = {str(r.uri) for r in await server.list_resources()}
+        self.assertNotIn("bunnyforge://doctrine/situation-design.md", uris)
+
+    async def test_streamable_app_is_asgi_and_wrappable(self):
+        server = serve_mcp.build_server(scaffold(self))
+        app = server.streamable_http_app(stateless_http=True)
+        self.assertTrue(callable(app))
+        self.assertTrue(callable(serve_mcp._BearerAuth(app, "t")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -162,5 +162,69 @@ class TestSearch(StoreCase):
         self.assertEqual(store.search("nothing here says this"), [])
 
 
+
+# A self-contained culture, built here rather than copied from the shipped
+# inventories: a portable test builds its own fixtures, and this one then
+# cannot break when the packaged cultures change. Minimal but valid --
+# `name` plus the four required keys, plus given_<category> for the one
+# declared category.
+CULTURE = """
+name            = "Testland"
+categories      = ["personal"]
+family          = ["Alba", "Bern", "Cass", "Dorn"]
+given_personal  = ["ka", "lo", "mi", "ru", "ta"]
+place           = ["Ash", "Bel", "Cor", "Dun"]
+place_tail      = ["ford", "mere", "wick", "holm"]
+"""
+
+
+class TestGenerateNames(StoreCase):
+
+    def make_names_ws(self) -> _config.Workspace:
+        ws = self.make_ws('\n[names]\ncultures = "cultures"\n')
+        cultures = ws.root / "cultures"
+        cultures.mkdir()
+        (cultures / "testland.toml").write_text(CULTURE, encoding="utf-8")
+        return ws
+
+    def test_generates_people_and_places(self):
+        store = _store.WorkspaceStore(self.make_names_ws())
+        out = store.generate_names("Testland", 5)
+        self.assertEqual(out["culture"], "testland")
+        self.assertEqual(len(out["people"]), 5)
+        self.assertEqual(len(out["places"]), 5)
+        self.assertTrue(all(isinstance(n, str) and n.strip()
+                            for n in out["people"] + out["places"]))
+
+    def test_names_are_drawn_from_this_culture_only(self):
+        # The generator's whole promise is that a name belongs to its
+        # culture; a family name from nowhere in the inventory would mean
+        # the wrong culture was resolved.
+        store = _store.WorkspaceStore(self.make_names_ws())
+        out = store.generate_names("Testland", 10)
+        for person in out["people"]:
+            self.assertIn(person.split()[0],
+                          ["Alba", "Bern", "Cass", "Dorn"], person)
+
+    def test_unknown_culture_raises_listing_the_available_ones(self):
+        store = _store.WorkspaceStore(self.make_names_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.generate_names("martian", 3)
+        self.assertIn("testland", str(ctx.exception))
+
+    def test_unconfigured_names_is_a_store_error_not_a_crash(self):
+        # No [names] at all: the remote agent must get an explainable
+        # refusal, not an InventoryError leaking through the tool layer.
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.generate_names("testland", 3)
+
+    def test_count_is_clamped_at_both_ends(self):
+        store = _store.WorkspaceStore(self.make_names_ws())
+        self.assertEqual(len(store.generate_names("Testland", 999)["people"]),
+                         _store.NAME_COUNT_CAP)
+        self.assertEqual(len(store.generate_names("Testland", 0)["people"]), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,166 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from bunnyforge import _config, _store
+
+MINIMAL = '[campaign]\nnamespace = "testwiki"\nname = "Testmere"\n'
+
+NPC = """---
+title: Kim Ha-eun
+summary: Kim Ha-eun is a ferry captain in Testmere harbor.
+visibility: gm-only
+---
+She knows the tides and owes the Harbormasters a debt.
+"""
+
+
+class StoreCase(unittest.TestCase):
+    """A scaffolded temp workspace shared by the store tests."""
+
+    def make_ws(self, toml_extra: str = "") -> _config.Workspace:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "campaign.toml").write_text(
+            MINIMAL + toml_extra, encoding="utf-8")
+        (root / "NPCs").mkdir()
+        (root / "NPCs" / "kim-ha-eun.md").write_text(NPC, encoding="utf-8")
+        (root / "front-burner.md").write_text(
+            "- resolve the ferry plot\n", encoding="utf-8")
+        return _config.open_workspace(root)
+
+
+class TestOverview(StoreCase):
+
+    def test_reports_name_sections_and_burner(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        ov = store.overview()
+        self.assertEqual(ov["name"], "Testmere")
+        self.assertEqual(ov["sections"]["NPCs"], 1)
+        self.assertIn("ferry plot", ov["front_burner"])
+        self.assertIsNone(ov["open_questions"])
+
+    def test_counts_agree_with_list_entities(self):
+        # An overview count and the list it promises must never disagree.
+        # A bare rglob would count a file inside an excluded subdirectory
+        # that list_entities then omits, so the two are derived from one
+        # walk rather than from two that can drift.
+        ws = self.make_ws()
+        archived = ws.root / "NPCs" / "_Archive"
+        archived.mkdir()
+        (archived / "old.md").write_text(NPC, encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(store.overview()["sections"]["NPCs"], 1)
+        self.assertEqual(len(store.list_entities("NPCs")), 1)
+
+    def test_existing_but_empty_section_reports_zero(self):
+        ws = self.make_ws()
+        (ws.root / "Factions").mkdir()
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(store.overview()["sections"]["Factions"], 0)
+
+    def test_absent_section_is_omitted_not_zero(self):
+        # A directory the campaign has not created yet is not a section with
+        # nothing in it; saying "Factions: 0" would invite the agent to treat
+        # an unused part of the layout as an empty one.
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertNotIn("Factions", store.overview()["sections"])
+
+
+class TestListEntities(StoreCase):
+
+    def test_lists_title_and_summary(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.list_entities("NPCs"), [{
+            "path": "NPCs/kim-ha-eun.md",
+            "title": "Kim Ha-eun",
+            "summary": "Kim Ha-eun is a ferry captain in Testmere harbor.",
+        }])
+
+    def test_title_falls_back_to_the_stem(self):
+        ws = self.make_ws()
+        (ws.root / "NPCs" / "no-front-matter.md").write_text(
+            "just a body\n", encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        found = {e["path"]: e for e in store.list_entities("NPCs")}
+        self.assertEqual(found["NPCs/no-front-matter.md"]["title"],
+                         "no-front-matter")
+        self.assertEqual(found["NPCs/no-front-matter.md"]["summary"], "")
+
+    def test_unknown_section_raises_listing_the_valid_ones(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.list_entities("Nope")
+        self.assertIn("NPCs", str(ctx.exception))
+
+
+class TestReadEntity(StoreCase):
+
+    def test_reads_full_file_including_front_matter(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        text = store.read_entity("NPCs/kim-ha-eun.md")
+        self.assertIn("title: Kim Ha-eun", text)
+        self.assertIn("owes the Harbormasters", text)
+
+    def test_escape_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("../outside.md")
+
+    def test_absolute_path_outside_the_workspace_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("/etc/hosts")
+
+    def test_excluded_dir_is_refused(self):
+        # The staging directory is excluded by default, so drafts written
+        # there are not readable back: the read tools serve canon.
+        ws = self.make_ws()
+        staged = ws.root / "_ExtractInbound"
+        staged.mkdir()
+        (staged / "secret.md").write_text("staged", encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("_ExtractInbound/secret.md")
+
+    def test_missing_file_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_entity("NPCs/nobody.md")
+
+
+class TestSearch(StoreCase):
+
+    def test_hit_returns_path_and_snippet(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        hits = store.search("harbormasters")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["path"], "NPCs/kim-ha-eun.md")
+        self.assertIn("owes the Harbormasters", hits[0]["snippet"])
+
+    def test_search_is_case_insensitive_and_spans_root_docs(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        paths = {h["path"] for h in store.search("FERRY")}
+        self.assertEqual(paths, {"NPCs/kim-ha-eun.md", "front-burner.md"})
+
+    def test_section_filter_narrows_to_that_directory(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        hits = store.search("ferry", section="NPCs")
+        self.assertEqual([h["path"] for h in hits], ["NPCs/kim-ha-eun.md"])
+
+    def test_bad_section_raises(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.search("ferry", section="Nope")
+
+    def test_empty_query_raises(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.search("   ")
+
+    def test_no_match_is_an_empty_list_not_an_error(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.search("nothing here says this"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #40. Phase 2 is #41; the live risk is #42.

**Base is `main`** (not stacked).

## What this is

`bunnyforge serve-mcp` — an MCP server over one campaign workspace, so a web-based AI agent (a claude.ai custom connector) can read GM materials that otherwise live only on the GM's disk.

This is **phase 1: read-only**. It is deliberately not the usable milestone — write-back (#41) is what makes the feature worth running. Phase 1 is the scaffolding under it.

Design: `docs/superpowers/specs/2026-08-16-serve-mcp-design.md`. Plan: `docs/superpowers/plans/2026-08-16-serve-mcp.md` (tasks 0–5 here; 6–8 are #41).

## Files changed

| file | |
|---|---|
| `src/bunnyforge/_store.py` | **(new)** `WorkspaceStore`: the single point every tool call goes through — path guards, section validation, the staging boundary |
| `src/bunnyforge/serve_mcp.py` | **(new)** the MCP layer, `_BearerAuth`, and `main()` |
| `tests/test_store.py` | **(new)** 23 tests |
| `tests/test_serve_mcp.py` | **(new)** 18 tests, the MCP-layer ones self-skipping without the extra |
| `docs/superpowers/specs/2026-08-16-serve-mcp-design.md` | **(new)** design |
| `docs/superpowers/plans/2026-08-16-serve-mcp.md` | **(new)** implementation plan |
| `src/bunnyforge/_config.py` | (modified) new optional `[workspace] staging_dir`, default `_ExtractInbound` |
| `src/bunnyforge/cli.py` | (modified) registers `serve-mcp`; docstring count nine → ten |
| `pyproject.toml` | (modified) `[project.optional-dependencies] mcp = ["mcp>=2.0"]` |
| `README.md` | (modified) subcommand table row |
| `.gitignore` | (modified) `.venv-mcp/` |
| `tests/test_config.py` | (modified) 3 tests for `staging_dir` |
| `tests/test_cli.py` | (modified) pinned dispatch table gains `serve-mcp` |

## Work breakdown

**Tools:** `campaign_overview`, `list_entities`, `read_entity`, `search`, `generate_names`. **Resources:** workspace doctrine (`style-guide.md`, `situation-design.md`, `AGENTS.md`), so a fresh conversation can load the house rules before writing anything.

**Why a store class rather than functions.** Every tool call resolves a path supplied by a remote agent, so traversal and exclusion checks belong in one place, not repeated per handler. It is also the phase-3 seam (#43): a git-backed implementation with the same method surface swaps the backend without touching a handler.

**`overview()` counts from the same walk `list_entities()` uses.** A bare `rglob` would count files inside excluded subdirectories that the listing then omits — a count and the list it promises must not disagree.

**Auth is default-deny.** No token and no `--no-auth` refuses to start, because everything served is GM-only. `_BearerAuth` is pure ASGI rather than starlette middleware, so it holds whatever the SDK builds its app from; non-HTTP scopes pass through untouched or the app never starts.

**Publishing is structurally absent**, not merely forbidden: no tool reaches `Export/` or the wiki, so a remote agent cannot leak GM material to players even by accident.

**Optional extra.** `serve_mcp.py` imports the SDK only inside function bodies, so `cli.py` can import it unconditionally, a bare install answers `--help`, and starting the server without the extra prints an install hint and exits 1. Every other subcommand stays zero-dependency.

## Deviations from the plan

1. **SDK drift.** Installed `mcp` is **2.0.0**, above the `>=1.9` the plan assumed. `mcp.server.fastmcp` is gone; `MCPServer` replaces `FastMCP`, and `stateless_http` moved from the constructor to `streamable_http_app()`. Naming, not design — the tool/resource decorators and the Starlette app were unchanged in shape, so the plan's architecture survived intact.
2. **The extra floors at `mcp>=2.0`, not 1.9.** The code uses `from mcp.server import MCPServer`, absent in 1.x, so the plan's floor would have installed a version that imports cleanly and then fails.
3. **The name-generation test builds its own culture inventory** rather than copying a packaged one, per `test_portability`'s doctrine that a portable test builds its own fixtures. It also cannot now break when the shipped cultures change.

## Test expectations

None — 743 tests pass in both configurations. Recorded because the two runs differ deliberately: **with** the extra, nothing skips; **without** it, `OK (skipped=10)`, which is the evidence that a bare install is unaffected.

## Operational impact

- `pip install bunnyforge` is unchanged and gains no dependencies. `serve-mcp` needs `pip install 'bunnyforge[mcp]'`.
- No migration. `staging_dir` is optional and defaults to the existing `_ExtractInbound` convention; it is inert until #41.
- **Not yet validated end to end against claude.ai.** That needs a tunnel and the connector form, and #42 records why it may not accept a static bearer token.

## Verification

- 743 tests, both interpreters, as above.
- Exercised against a real campaign workspace, not only fixtures — including that the path guard honours campaign-specific `exclude_dirs`, not just built-in defaults.
- Live HTTP: 401 without a token, 401 with a wrong one, valid MCP `initialize` with the right one.
- Independently verified with `@modelcontextprotocol/inspector` — a third-party client, so this tests protocol conformance rather than agreement with our own SDK assumptions: tools and schemas, a tool call, resource list and read.

## Reviewer's attention

`cli.py`'s docstring counts subcommands and no diff makes that number visible; #38 took it to nine and this takes it to ten. Worth confirming by eye.

---
Provenance — Agent: Claude Code (VSCode). Model / version: Opus 5 (per session transcript).
