### PR TITLE
docs(ci): canary header reflects that main is now protected

### DIFF
--- a/.github/workflows/live-wiki-canary.yml
+++ b/.github/workflows/live-wiki-canary.yml
@@ -17,12 +17,20 @@ name: live-wiki-canary
 # secrets-requiring check on `pull_request` would be permanently red on every
 # outside contribution with no way for the contributor to fix it.
 #
-# NON-BLOCKING, ON PURPOSE. This repo has no branch protection today, so
-# nothing here blocks a merge either way. The job is written to genuinely
-# fail (not continue-on-error) when the live check fails, so a real failure
-# shows red and is visible -- silencing it would defeat the point of a
-# canary. The only thing allowed to make this NOT fail is missing
-# configuration (see below), never a check that actually ran and failed.
+# NON-BLOCKING, ON PURPOSE. `main` is protected by the "Main" ruleset, whose
+# required status checks are the `suite` matrix jobs from tests.yml and
+# deliberately NOT this canary -- which could not serve as a merge gate
+# anyway, since it runs only on a schedule and never on `pull_request` (see
+# above: secrets are withheld from forked pull requests, so a
+# secrets-requiring check there would be permanently red with no way for a
+# contributor to fix it). Requiring it would block every merge forever.
+#
+# So nothing here blocks a merge, and that is the intent. The job is still
+# written to genuinely fail (not continue-on-error) when the live check
+# fails, so a real failure shows red and is visible -- silencing it would
+# defeat the point of a canary. The only thing allowed to make this NOT fail
+# is missing configuration (see below), never a check that actually ran and
+# failed.
 on:
   schedule:
     # Sundays 06:00 UTC -- a quiet time, chosen only to avoid contention with


### PR DESCRIPTION
**Base is `main`** (not stacked).

## What this is

A comments-only fix to `live-wiki-canary.yml`'s header, which asserted:

> This repo has no branch protection today, so nothing here blocks a merge either way.

That stopped being true when the `Main` ruleset was added (required status checks: the `suite` matrix from `tests.yml`; no bypass actors).

## Files changed

| file | |
|---|---|
| `.github/workflows/live-wiki-canary.yml` | (modified) header comment only |

## Work breakdown

The canary is *still* non-blocking, so the conclusion was right and only the reason was wrong. The replacement states the sharper reason, which is worth recording where the next person will look:

- it is deliberately **not** among the ruleset's required status checks, and
- it could not be one anyway — it runs on a `schedule` and never on `pull_request`, because secrets are withheld from forked pull requests. Requiring it would block every merge forever.

That second point is a trap for whoever next edits the ruleset, which is why it now lives next to the workflow it describes rather than only in the ruleset's configuration.

## Test expectations

None. Every changed line is a comment; the workflow body is untouched. Verified the file still parses as YAML and that the diff contains no non-comment lines.

## Operational impact

None.

---
Provenance — Agent: Claude Code (VSCode). Model / version: Opus 5 (per session transcript).