### PR TITLE
serve-mcp: self-hosted OAuth so the claude.ai connector can authenticate (#42)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,20 @@ jobs:
         run: |
           git status --porcelain
           test -z "$(git status --porcelain)"
+
+  # The `suite` matrix installs bunnyforge without the `mcp` extra, so every
+  # OAuth and MCP-server test is HAVE_MCP-skipped there. One job, one Python
+  # version: the matrix above already covers version portability, and this
+  # job exists only to prove the auth layer -- the thing standing between a
+  # tunnel and a campaign's secrets -- actually executes somewhere.
+  mcp-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Install bunnyforge with the mcp extra
+        run: pip install -e '.[mcp]'
+      - name: Suite, discovery door
+        run: python3 -m unittest discover -s tests -t . -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,3 +60,10 @@ jobs:
         run: pip install -e '.[mcp]'
       - name: Suite, discovery door
         run: python3 -m unittest discover -s tests -t . -v
+      # The script door's mutation guard, right-sized to this repo: nothing
+      # here is git-ignored except build artifacts, so git sees any write a
+      # test makes into the tree -- which is what that guard is for.
+      - name: No test wrote into the repo
+        run: |
+          git status --porcelain
+          test -z "$(git status --porcelain)"

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -41,7 +41,13 @@ Settings → Connectors → Add custom connector:
   built-in single-user authorization server.
 
 On connect, your browser lands on the server's consent page; type the GM
-key. Tokens refresh silently for up to 30 days before the page reappears.
+key. Only do that on a consent page you reached by clicking Connect in
+claude.ai yourself — never one that arrived by link from someone else, since
+anyone who learns your public hostname can register their own client and
+generate a working-looking consent link. Refresh tokens rotate and each new
+one gets a fresh 30-day TTL, so silent refresh continues indefinitely as
+long as the connector is used at least once a month; the consent page
+reappears only after 30 days of disuse.
 
 ## Resetting access
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -1,0 +1,65 @@
+# serve-mcp: connecting claude.ai to a campaign workspace
+
+`bunnyforge serve-mcp` serves one campaign workspace to a remote AI agent
+over MCP. Everything it serves is GM-eyes-only; the server refuses to
+start without an auth mechanism.
+
+## Install
+
+    pip install 'bunnyforge[mcp]'
+
+## Generate a GM key (once)
+
+    python3 -c "import secrets; print(secrets.token_urlsafe(24))"
+
+Keep it out of git. You will type it exactly once per grant, on the
+consent page in your own browser — it is never stored by claude.ai.
+
+## Run behind a tunnel
+
+    export BUNNYFORGE_MCP_KEY=<your key>
+    cloudflared tunnel run <name>           # named tunnel, stable hostname
+    bunnyforge serve-mcp --public-host <name>.example.com
+
+A **named tunnel** (free with a Cloudflare-managed domain) is the
+recommended recipe: the hostname — and therefore the connector URL in
+claude.ai and the OAuth trust it anchors — survives restarts. A quick
+tunnel (`cloudflared tunnel --url http://127.0.0.1:8765`) also works, but
+its hostname changes every run: pass the new hostname to `--public-host`
+and update the connector URL in claude.ai each time.
+
+Local testing needs no tunnel: `--no-auth` (unauthenticated, loud
+warning) or `--auth-key` with the default localhost issuer.
+
+## Add the connector in claude.ai
+
+Settings → Connectors → Add custom connector:
+
+- **URL:** `https://<public-host>/mcp`
+- **OAuth Client ID / Client Secret:** leave **both blank**. claude.ai
+  registers itself (Dynamic Client Registration) against the server's
+  built-in single-user authorization server.
+
+On connect, your browser lands on the server's consent page; type the GM
+key. Tokens refresh silently for up to 30 days before the page reappears.
+
+## Resetting access
+
+Delete the token state file and restart the server:
+
+    rm ~/.local/state/bunnyforge/mcp-oauth-state.json
+
+(`$XDG_STATE_HOME/bunnyforge/mcp-oauth-state.json` if you set
+`XDG_STATE_HOME`.) Every issued token dies with it; claude.ai will run
+the consent flow again. Changing the GM key invalidates future grants
+but not already-issued tokens — delete the state file for that.
+
+## Troubleshooting
+
+- **401 from `/mcp`:** no or expired token — reconnect from claude.ai.
+- **421 Invalid Host header through a tunnel:** DNS-rebinding protection
+  does not know your public hostname — issue #46 tracks the
+  `--public-host` transport fix.
+- **"Couldn't register with sign-in service":** the server is not
+  reachable at the connector URL, or it was started `--no-auth` (no OAuth
+  routes exist in that mode).

--- a/docs/superpowers/plans/2026-08-16-serve-mcp-oauth.md
+++ b/docs/superpowers/plans/2026-08-16-serve-mcp-oauth.md
@@ -1,0 +1,1414 @@
+# serve-mcp OAuth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `_BearerAuth` with a self-hosted single-user OAuth
+authorization server (SDK DCR machinery + a GM-key consent page) so the
+claude.ai custom connector can authenticate against `bunnyforge serve-mcp`.
+
+**Architecture:** A new module `src/bunnyforge/_mcp_auth.py` implements the
+SDK's `OAuthAuthorizationServerProvider` over four in-process dicts, with
+clients and tokens persisted to a `0600` JSON state file under
+`$XDG_STATE_HOME`. `serve_mcp.py` passes the provider plus `AuthSettings`
+to `MCPServer`, which mounts the OAuth bootstrap routes publicly and guards
+`/mcp` — the SDK auto-wraps the provider in `ProviderTokenVerifier`. The
+one identity decision bunnyforge owns is a consent page (`/consent`,
+mounted via `custom_route`) where the GM types a pre-shared key.
+
+**Tech Stack:** Python ≥3.11, `mcp` SDK 2.0 (the existing `[mcp]` extra —
+**no new dependencies**), `unittest`, Starlette `TestClient` for HTTP tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-serve-mcp-oauth-design.md` —
+read it first; every SDK behavior it cites was measured against mcp 2.0.0.
+Evidence trail: GitHub issue #42.
+
+## Global Constraints
+
+- **Never commit to main** (protected: PRs required, CI `suite (3.11/3.12/3.13)`
+  must pass). Work in a git worktree on branch `feat/serve-mcp-oauth`, based
+  off current `main` — merge the spec/plan PR first if it is still open;
+  if you must base off `docs/serve-mcp-oauth-design` instead, flag the
+  stacked PR loudly per AGENTS.md.
+- **Worktree venv before any test run:** `python3 -m venv .venv && ./.venv/bin/pip install -e '.[mcp]'`,
+  then assert resolution:
+  `./.venv/bin/python -c "import bunnyforge,pathlib; p=pathlib.Path(bunnyforge.__file__).resolve(); assert p.is_relative_to(pathlib.Path.cwd().resolve()), p; print(p)"`.
+  Never pip install into system site-packages.
+- **Zero-dependency core:** `serve_mcp.py` imports the SDK only inside
+  function bodies (`cli.py` imports every subcommand unconditionally and
+  must keep working on bare Python). The new `_mcp_auth.py` MAY import
+  `mcp` at module top — it is itself imported only inside `serve_mcp.py`
+  function bodies.
+- **Tests are `unittest`, not pytest.** Follow the existing `HAVE_MCP`
+  skip discipline (`tests/test_serve_mcp.py:12`). Run with
+  `./.venv/bin/python -m unittest <module> -v`.
+- **`MCPServer` must NOT receive both `auth_server_provider` and
+  `token_verifier`** — that combination raises `ValueError`. Pass the
+  provider alone; the SDK wraps it in `ProviderTokenVerifier` itself.
+- Plain `httpx` is **not** installed (mcp 2.0 depends on `httpx2`). Use
+  `starlette.testclient.TestClient` (measured importable in the extra-only
+  venv). `python-multipart` and `anyio` are already in the tree.
+- **Credentials never reach git.** The state file lives at
+  `$XDG_STATE_HOME/bunnyforge/mcp-oauth-state.json` (default
+  `~/.local/state/...`); tests use temp dirs.
+- Flag spellings are fixed by the spec: `--auth-key` / `BUNNYFORGE_MCP_KEY`
+  (replacing `--token` / `BUNNYFORGE_MCP_TOKEN`, no aliases), `--no-auth`
+  kept, `--public-host` added (issuer derivation ONLY — its
+  `transport_security` plumbing is issue #46, out of scope here).
+- Lifetimes (spec): consent transaction 600 s, authorization code 300 s,
+  access token 3600 s, refresh token 30 days (rotating). Client cap 32.
+- Commit after every task; end each commit message with the model's
+  `Co-Authored-By:` trailer.
+
+---
+
+### Task 1: Provider skeleton — client registration, state persistence
+
+**Files:**
+- Create: `src/bunnyforge/_mcp_auth.py`
+- Test: `tests/test_mcp_auth.py` (create)
+
+**Interfaces:**
+- Consumes: `mcp.server.auth.provider.OAuthAuthorizationServerProvider`,
+  `mcp.shared.auth.OAuthClientInformationFull`,
+  `mcp.server.auth.provider.AccessToken` / `RefreshToken` (pydantic models).
+- Produces (later tasks rely on these exact names):
+  - `default_state_path() -> pathlib.Path`
+  - `SingleUserOAuthProvider(gm_key: str, issuer_url: str, state_path: Path)`
+    with attribute `issuer_url: str` (rstripped, no trailing slash),
+    internal dicts `_clients`, `_txns`, `_codes`, `_access`, `_refresh`,
+    methods `_save()`, `_load()`, and async `register_client` / `get_client`.
+  - Module constants `MAX_CLIENTS = 32`, `TXN_TTL = 600`, `CODE_TTL = 300`,
+    `ACCESS_TTL = 3600`, `REFRESH_TTL = 30 * 24 * 3600`, `_KEY_DELAY = 1.0`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_mcp_auth.py`:
+
+```python
+import importlib.util
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# The MCP SDK is an optional extra; _mcp_auth imports it at module top, so
+# every test here skips on a bare Python, matching test_serve_mcp.py.
+HAVE_MCP = importlib.util.find_spec("mcp") is not None
+if HAVE_MCP:
+    from bunnyforge import _mcp_auth
+    from bunnyforge._mcp_auth import SingleUserOAuthProvider
+
+
+def client_record(client_id: str):
+    from mcp.shared.auth import OAuthClientInformationFull
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret="s3cret",
+        client_name="Claude",
+        redirect_uris=["http://localhost:9999/cb"],
+    )
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestClientRegistry(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.state = root / "state" / "mcp-oauth-state.json"
+        self.provider = SingleUserOAuthProvider(
+            gm_key="k", issuer_url="http://127.0.0.1:8000/",
+            state_path=self.state)
+
+    def test_issuer_url_is_rstripped(self):
+        self.assertEqual(self.provider.issuer_url, "http://127.0.0.1:8000")
+
+    async def test_register_then_get_roundtrips(self):
+        await self.provider.register_client(client_record("c1"))
+        got = await self.provider.get_client("c1")
+        self.assertEqual(got.client_name, "Claude")
+        self.assertIsNone(await self.provider.get_client("nope"))
+
+    async def test_registration_capped_evicts_oldest(self):
+        for i in range(_mcp_auth.MAX_CLIENTS + 1):
+            await self.provider.register_client(client_record(f"c{i}"))
+        self.assertIsNone(await self.provider.get_client("c0"))
+        self.assertIsNotNone(await self.provider.get_client("c1"))
+        self.assertEqual(len(self.provider._clients), _mcp_auth.MAX_CLIENTS)
+
+    async def test_state_file_is_0600_and_survives_restart(self):
+        await self.provider.register_client(client_record("c1"))
+        mode = stat.S_IMODE(os.stat(self.state).st_mode)
+        self.assertEqual(mode, 0o600)
+        reborn = SingleUserOAuthProvider(
+            gm_key="k", issuer_url="http://127.0.0.1:8000",
+            state_path=self.state)
+        got = await reborn.get_client("c1")
+        self.assertEqual(got.client_secret, "s3cret")
+
+    async def test_corrupt_state_file_starts_empty_not_crashed(self):
+        self.state.parent.mkdir(parents=True)
+        self.state.write_text("{not json", encoding="utf-8")
+        with mock.patch("sys.stderr"):
+            provider = SingleUserOAuthProvider(
+                gm_key="k", issuer_url="http://127.0.0.1:8000",
+                state_path=self.state)
+        self.assertIsNone(await provider.get_client("c1"))
+        # first successful save replaces the corrupt file
+        await provider.register_client(client_record("c1"))
+        json.loads(self.state.read_text(encoding="utf-8"))
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestDefaultStatePath(unittest.TestCase):
+
+    def test_honours_xdg_state_home(self):
+        with mock.patch.dict(os.environ, {"XDG_STATE_HOME": "/x/state"}):
+            self.assertEqual(_mcp_auth.default_state_path(),
+                             Path("/x/state/bunnyforge/mcp-oauth-state.json"))
+
+    def test_defaults_under_home(self):
+        with mock.patch.dict(os.environ, clear=False) as env:
+            os.environ.pop("XDG_STATE_HOME", None)
+            self.assertEqual(
+                _mcp_auth.default_state_path(),
+                Path.home() / ".local/state/bunnyforge/mcp-oauth-state.json")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth -v`
+Expected: FAIL/ERROR with `ModuleNotFoundError: No module named 'bunnyforge._mcp_auth'`
+
+- [ ] **Step 3: Write the module**
+
+Create `src/bunnyforge/_mcp_auth.py`:
+
+```python
+#!/usr/bin/env python3
+"""_mcp_auth.py — single-user OAuth authorization server for serve-mcp.
+
+claude.ai's connector speaks OAuth with Dynamic Client Registration and
+nothing else (issue #42), so serve-mcp runs the smallest authorization
+server that satisfies it: the SDK's handlers do every protocol step, and
+the one identity decision bunnyforge owns — "is this the GM?" — is a
+pre-shared key checked on a consent page.
+
+This module imports the mcp SDK at top level. That is safe only because
+serve_mcp.py imports THIS module inside function bodies; a bare Python
+(no bunnyforge[mcp] extra) never loads it.
+
+Tokens are opaque random strings looked up server-side — no JWTs, no
+signing keys. Clients and tokens persist to a 0600 JSON file outside any
+git repo, so a laptop restart does not force a full re-auth in claude.ai;
+consent transactions and authorization codes live minutes and stay
+memory-only.
+"""
+
+from __future__ import annotations
+
+import hmac
+import html
+import json
+import os
+import secrets
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+    TokenError,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+MAX_CLIENTS = 32          # /register is public by RFC 7591; bound its memory
+TXN_TTL = 600             # seconds a consent page may wait for the GM
+CODE_TTL = 300
+ACCESS_TTL = 3600
+REFRESH_TTL = 30 * 24 * 3600
+_KEY_DELAY = 1.0          # pause after a wrong key; patched to 0 in tests
+
+
+def default_state_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+    return Path(base) / "bunnyforge" / "mcp-oauth-state.json"
+
+
+@dataclass
+class _Txn:
+    """One consent-in-flight: the authorize params parked while the GM
+    decides, keyed by an unguessable transaction id."""
+    params: AuthorizationParams
+    client_id: str
+    expires_at: float
+
+
+class SingleUserOAuthProvider(
+        OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken,
+                                         AccessToken]):
+    """The nine provider methods over four dicts and one state file."""
+
+    def __init__(self, gm_key: str, issuer_url: str, state_path: Path):
+        self._gm_key = gm_key
+        self.issuer_url = issuer_url.rstrip("/")
+        self._state_path = state_path
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+        self._txns: dict[str, _Txn] = {}
+        self._codes: dict[str, AuthorizationCode] = {}
+        self._access: dict[str, AccessToken] = {}
+        self._refresh: dict[str, RefreshToken] = {}
+        self._load()
+
+    # -- persistence -------------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            raw = json.loads(self._state_path.read_text(encoding="utf-8"))
+            clients = {c: OAuthClientInformationFull.model_validate(v)
+                       for c, v in raw.get("clients", {}).items()}
+            access = {t: AccessToken.model_validate(v)
+                      for t, v in raw.get("access_tokens", {}).items()}
+            refresh = {t: RefreshToken.model_validate(v)
+                       for t, v in raw.get("refresh_tokens", {}).items()}
+        except FileNotFoundError:
+            return
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            # Losing token state is an inconvenience, not an outage: the
+            # connector just re-runs the flow. Keep the corrupt file until
+            # the first good save renames over it.
+            print(f"warning: ignoring unreadable auth state "
+                  f"{self._state_path}: {exc}", file=sys.stderr)
+            return
+        now = time.time()
+        self._clients = clients
+        self._access = {t: a for t, a in access.items()
+                        if not a.expires_at or a.expires_at > now}
+        self._refresh = {t: r for t, r in refresh.items()
+                         if not r.expires_at or r.expires_at > now}
+
+    def _save(self) -> None:
+        data = {
+            "clients": {c: v.model_dump(mode="json")
+                        for c, v in self._clients.items()},
+            "access_tokens": {t: v.model_dump(mode="json")
+                              for t, v in self._access.items()},
+            "refresh_tokens": {t: v.model_dump(mode="json")
+                               for t, v in self._refresh.items()},
+        }
+        self._state_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        tmp = self._state_path.with_suffix(".tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+        os.replace(tmp, self._state_path)
+
+    # -- client registry (RFC 7591; the SDK handler mints the credentials) -
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    async def register_client(
+            self, client_info: OAuthClientInformationFull) -> None:
+        self._clients[client_info.client_id] = client_info
+        while len(self._clients) > MAX_CLIENTS:
+            evicted = next(iter(self._clients))
+            del self._clients[evicted]
+            self._access = {t: a for t, a in self._access.items()
+                            if a.client_id != evicted}
+            self._refresh = {t: r for t, r in self._refresh.items()
+                             if r.client_id != evicted}
+        self._save()
+```
+
+(The remaining provider methods arrive in Task 2; the class is complete
+enough for this task's tests.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth -v`
+Expected: PASS (all tests in the module)
+
+- [ ] **Step 5: Confirm bare-Python safety is untouched**
+
+Run: `./.venv/bin/python -c "import bunnyforge.serve_mcp; print('ok')"` and
+`python3 -c "import bunnyforge.cli; print('bare ok')"`
+Expected: both print. (`_mcp_auth` is not yet imported anywhere, and the
+system python must never gain an `mcp` dependency through this work.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/_mcp_auth.py tests/test_mcp_auth.py
+git commit -m "feat(serve-mcp): OAuth provider skeleton — client registry + persisted state"
+```
+
+---
+
+### Task 2: Consent transactions, codes, tokens — the rest of the provider
+
+**Files:**
+- Modify: `src/bunnyforge/_mcp_auth.py` (append methods to
+  `SingleUserOAuthProvider`)
+- Test: `tests/test_mcp_auth.py` (append)
+
+**Interfaces:**
+- Consumes: Task 1's class and constants.
+- Produces (Task 3 and the SDK rely on these exact signatures):
+  - async `authorize(client, params) -> str` — parks a `_Txn`, returns
+    `f"{self.issuer_url}/consent?txn=<id>"`.
+  - `check_key(submitted: str) -> bool` — constant-time.
+  - `consent_context(txn: str) -> dict | None` — `{"client_name": str}` or
+    `None` when unknown/expired.
+  - `grant(txn: str) -> str | None` — consumes the txn, mints a code,
+    returns the client redirect URL with `code` and `state` appended;
+    `None` when the txn is unknown/expired.
+  - async `load_authorization_code`, `exchange_authorization_code`,
+    `load_refresh_token`, `exchange_refresh_token`, `load_access_token`,
+    `revoke_token` — the provider contract the SDK handlers call.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mcp_auth.py`:
+
+```python
+def auth_params():
+    from mcp.server.auth.provider import AuthorizationParams
+    return AuthorizationParams(
+        state="st8", scopes=[], code_challenge="chal",
+        redirect_uri="http://localhost:9999/cb",
+        redirect_uri_provided_explicitly=True)
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestConsentAndTokens(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url="http://127.0.0.1:8000",
+            state_path=root / "state.json")
+
+    async def _register(self, cid="c1"):
+        record = client_record(cid)
+        await self.provider.register_client(record)
+        return record
+
+    async def test_authorize_parks_txn_and_points_at_consent(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        self.assertTrue(
+            url.startswith("http://127.0.0.1:8000/consent?txn="), url)
+        txn = url.split("txn=")[1]
+        self.assertEqual(self.provider.consent_context(txn),
+                         {"client_name": "Claude"})
+
+    async def test_consent_context_unknown_or_expired_is_none(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        txn = url.split("txn=")[1]
+        self.assertIsNone(self.provider.consent_context("bogus"))
+        future = time.time() + _mcp_auth.TXN_TTL + 1
+        with mock.patch("bunnyforge._mcp_auth.time.time",
+                        return_value=future):
+            self.assertIsNone(self.provider.consent_context(txn))
+
+    def test_check_key_right_wrong_and_near_miss(self):
+        self.assertTrue(self.provider.check_key("sekrit"))
+        self.assertFalse(self.provider.check_key("wrong"))
+        self.assertFalse(self.provider.check_key("sek"))
+        self.assertFalse(self.provider.check_key(""))
+
+    async def test_grant_consumes_txn_and_mints_single_use_code(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        txn = url.split("txn=")[1]
+        redirect = self.provider.grant(txn)
+        self.assertIn("code=", redirect)
+        self.assertIn("state=st8", redirect)
+        self.assertTrue(redirect.startswith("http://localhost:9999/cb?"))
+        self.assertIsNone(self.provider.grant(txn))  # consumed
+
+    async def _grant_code(self, client):
+        url = await self.provider.authorize(client, auth_params())
+        redirect = self.provider.grant(url.split("txn=")[1])
+        code = redirect.split("code=")[1].split("&")[0]
+        return await self.provider.load_authorization_code(client, code)
+
+    async def test_code_exchange_and_replay(self):
+        from mcp.server.auth.provider import TokenError
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        self.assertEqual(auth_code.code_challenge, "chal")
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        self.assertEqual(tokens.token_type, "Bearer")
+        self.assertEqual(tokens.expires_in, _mcp_auth.ACCESS_TTL)
+        with self.assertRaises(TokenError):
+            await self.provider.exchange_authorization_code(client, auth_code)
+
+    async def test_code_expires(self):
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        future = time.time() + _mcp_auth.CODE_TTL + 1
+        with mock.patch("bunnyforge._mcp_auth.time.time",
+                        return_value=future):
+            self.assertIsNone(await self.provider.load_authorization_code(
+                client, auth_code.code))
+
+    async def test_wrong_client_cannot_load_anothers_code(self):
+        client = await self._register()
+        other = await self._register("c2")
+        auth_code = await self._grant_code(client)
+        self.assertIsNone(await self.provider.load_authorization_code(
+            other, auth_code.code))
+
+    async def test_access_token_verifies_then_expires(self):
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        at = await self.provider.load_access_token(tokens.access_token)
+        self.assertEqual(at.client_id, "c1")
+        future = time.time() + _mcp_auth.ACCESS_TTL + 1
+        with mock.patch("bunnyforge._mcp_auth.time.time",
+                        return_value=future):
+            self.assertIsNone(await self.provider.load_access_token(
+                tokens.access_token))
+
+    async def test_refresh_rotates(self):
+        from mcp.server.auth.provider import TokenError
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        first = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        rt = await self.provider.load_refresh_token(
+            client, first.refresh_token)
+        second = await self.provider.exchange_refresh_token(client, rt, [])
+        self.assertNotEqual(first.refresh_token, second.refresh_token)
+        # the old refresh token died with the rotation
+        self.assertIsNone(await self.provider.load_refresh_token(
+            client, first.refresh_token))
+        with self.assertRaises(TokenError):
+            await self.provider.exchange_refresh_token(client, rt, [])
+
+    async def test_tokens_survive_restart_but_txns_do_not(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        txn = url.split("txn=")[1]
+        auth_code = await self._grant_code(client)
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        reborn = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url="http://127.0.0.1:8000",
+            state_path=self.provider._state_path)
+        self.assertIsNotNone(
+            await reborn.load_access_token(tokens.access_token))
+        self.assertIsNone(reborn.consent_context(txn))
+
+    async def test_revoke_deletes(self):
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        at = await self.provider.load_access_token(tokens.access_token)
+        await self.provider.revoke_token(at)
+        self.assertIsNone(
+            await self.provider.load_access_token(tokens.access_token))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth -v`
+Expected: Task 1 tests PASS; every `TestConsentAndTokens` test ERRORS with
+`AttributeError` (missing `authorize` / `grant` / …).
+
+- [ ] **Step 3: Implement the remaining provider methods**
+
+Append inside `SingleUserOAuthProvider` (after `register_client`):
+
+```python
+    # -- consent -----------------------------------------------------------
+    # authorize() is called by the SDK's /authorize handler, which 302s the
+    # GM's browser to whatever URL we return. We park the request under an
+    # unguessable transaction id and send the browser to our consent page;
+    # grant() is the consent POST handler redeeming it.
+
+    async def authorize(self, client: OAuthClientInformationFull,
+                        params: AuthorizationParams) -> str:
+        self._prune()
+        txn = secrets.token_urlsafe(32)
+        self._txns[txn] = _Txn(params=params, client_id=client.client_id,
+                               expires_at=time.time() + TXN_TTL)
+        return f"{self.issuer_url}/consent?txn={txn}"
+
+    def check_key(self, submitted: str) -> bool:
+        return hmac.compare_digest(submitted.encode(), self._gm_key.encode())
+
+    def consent_context(self, txn: str) -> dict | None:
+        t = self._txns.get(txn)
+        if t is None or t.expires_at < time.time():
+            self._txns.pop(txn, None)
+            return None
+        client = self._clients.get(t.client_id)
+        name = (client.client_name if client else None) or t.client_id
+        return {"client_name": name}
+
+    def grant(self, txn: str) -> str | None:
+        t = self._txns.pop(txn, None)
+        if t is None or t.expires_at < time.time():
+            return None
+        code = secrets.token_urlsafe(32)
+        p = t.params
+        self._codes[code] = AuthorizationCode(
+            code=code, scopes=p.scopes or [],
+            expires_at=time.time() + CODE_TTL,
+            client_id=t.client_id, code_challenge=p.code_challenge,
+            redirect_uri=p.redirect_uri,
+            redirect_uri_provided_explicitly=p.redirect_uri_provided_explicitly,
+            resource=p.resource)
+        return construct_redirect_uri(str(p.redirect_uri),
+                                      code=code, state=p.state)
+
+    def _prune(self) -> None:
+        now = time.time()
+        self._txns = {k: v for k, v in self._txns.items()
+                      if v.expires_at > now}
+        self._codes = {k: v for k, v in self._codes.items()
+                       if v.expires_at > now}
+
+    # -- codes and tokens (called by the SDK's /token handler; PKCE is
+    # verified there, not here) ------------------------------------------
+
+    async def load_authorization_code(
+            self, client: OAuthClientInformationFull,
+            authorization_code: str) -> AuthorizationCode | None:
+        ac = self._codes.get(authorization_code)
+        if ac is None or ac.client_id != client.client_id:
+            return None
+        if ac.expires_at < time.time():
+            del self._codes[authorization_code]
+            return None
+        return ac
+
+    async def exchange_authorization_code(
+            self, client: OAuthClientInformationFull,
+            authorization_code: AuthorizationCode) -> OAuthToken:
+        if self._codes.pop(authorization_code.code, None) is None:
+            raise TokenError("invalid_grant",
+                             "authorization code already used")
+        return self._issue(client.client_id, authorization_code.scopes)
+
+    async def load_refresh_token(
+            self, client: OAuthClientInformationFull,
+            refresh_token: str) -> RefreshToken | None:
+        rt = self._refresh.get(refresh_token)
+        if rt is None or rt.client_id != client.client_id:
+            return None
+        if rt.expires_at and rt.expires_at < time.time():
+            del self._refresh[refresh_token]
+            self._save()
+            return None
+        return rt
+
+    async def exchange_refresh_token(
+            self, client: OAuthClientInformationFull,
+            refresh_token: RefreshToken, scopes: list[str]) -> OAuthToken:
+        if self._refresh.pop(refresh_token.token, None) is None:
+            raise TokenError("invalid_grant", "refresh token already used")
+        return self._issue(client.client_id,
+                           scopes or refresh_token.scopes)
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        at = self._access.get(token)
+        if at is None:
+            return None
+        if at.expires_at and at.expires_at < time.time():
+            del self._access[token]
+            return None
+        return at
+
+    async def revoke_token(
+            self, token: AccessToken | RefreshToken) -> None:
+        self._access.pop(token.token, None)
+        self._refresh.pop(token.token, None)
+        self._save()
+
+    def _issue(self, client_id: str, scopes: list[str]) -> OAuthToken:
+        now = time.time()
+        access = secrets.token_urlsafe(32)
+        refresh = secrets.token_urlsafe(32)
+        self._access[access] = AccessToken(
+            token=access, client_id=client_id, scopes=scopes,
+            expires_at=int(now + ACCESS_TTL))
+        self._refresh[refresh] = RefreshToken(
+            token=refresh, client_id=client_id, scopes=scopes,
+            expires_at=int(now + REFRESH_TTL))
+        self._save()
+        return OAuthToken(access_token=access, token_type="Bearer",
+                          expires_in=ACCESS_TTL,
+                          scope=" ".join(scopes) or None,
+                          refresh_token=refresh)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth -v`
+Expected: PASS (all tests in the module)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_mcp_auth.py tests/test_mcp_auth.py
+git commit -m "feat(serve-mcp): consent transactions, codes, and rotating tokens"
+```
+
+---
+
+### Task 3: The consent page
+
+**Files:**
+- Modify: `src/bunnyforge/_mcp_auth.py` (append at module level)
+- Test: `tests/test_mcp_auth.py` (append)
+
+**Interfaces:**
+- Consumes: `SingleUserOAuthProvider.consent_context` / `check_key` /
+  `grant` (Task 2), `_KEY_DELAY` (Task 1).
+- Produces: `consent_endpoint(provider: SingleUserOAuthProvider,
+  campaign: str)` returning an async Starlette endpoint
+  `async (request) -> Response` handling `GET` and `POST /consent`.
+  Task 4 mounts it via `server.custom_route("/consent", methods=["GET", "POST"])`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mcp_auth.py`. These exercise the endpoint through a
+minimal Starlette app so form parsing and redirects are real:
+
+```python
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestConsentEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url="http://127.0.0.1:8000",
+            state_path=root / "state.json")
+        endpoint = _mcp_auth.consent_endpoint(self.provider, "Testmere")
+        app = Starlette(routes=[
+            Route("/consent", endpoint, methods=["GET", "POST"])])
+        self.client = TestClient(app, follow_redirects=False)
+        self.enterContext(
+            mock.patch("bunnyforge._mcp_auth._KEY_DELAY", 0))
+
+    def _txn(self):
+        import asyncio
+        record = client_record("c1")
+        asyncio.run(self.provider.register_client(record))
+        url = asyncio.run(self.provider.authorize(record, auth_params()))
+        return url.split("txn=")[1]
+
+    def test_get_unknown_txn_is_400_with_recovery_text(self):
+        resp = self.client.get("/consent", params={"txn": "bogus"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("claude.ai", resp.text)
+        self.assertEqual(resp.headers["cache-control"], "no-store")
+
+    def test_get_renders_form_naming_client_and_campaign(self):
+        resp = self.client.get("/consent", params={"txn": self._txn()})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Claude", resp.text)
+        self.assertIn("Testmere", resp.text)
+        self.assertIn('name="key"', resp.text)
+        self.assertEqual(resp.headers["cache-control"], "no-store")
+
+    def test_post_wrong_key_rerenders_and_mints_nothing(self):
+        txn = self._txn()
+        resp = self.client.post("/consent",
+                                data={"txn": txn, "key": "wrong"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("try again", resp.text.lower())
+        self.assertEqual(self.provider._codes, {})
+        # the txn survives a wrong key: the GM can retry
+        self.assertIsNotNone(self.provider.consent_context(txn))
+
+    def test_post_right_key_redirects_with_code_and_state(self):
+        resp = self.client.post(
+            "/consent", data={"txn": self._txn(), "key": "sekrit"})
+        self.assertEqual(resp.status_code, 302)
+        location = resp.headers["location"]
+        self.assertTrue(location.startswith("http://localhost:9999/cb?"))
+        self.assertIn("code=", location)
+        self.assertIn("state=st8", location)
+
+    def test_post_dead_txn_is_400(self):
+        resp = self.client.post("/consent",
+                                data={"txn": "bogus", "key": "sekrit"})
+        self.assertEqual(resp.status_code, 400)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth.TestConsentEndpoint -v`
+Expected: ERROR — `AttributeError: module 'bunnyforge._mcp_auth' has no attribute 'consent_endpoint'`
+
+- [ ] **Step 3: Implement the endpoint**
+
+Append to `_mcp_auth.py` at module level:
+
+```python
+# One page, used once per token lifetime by one person: inline HTML, no
+# styling, served no-store. The only secret it ever sees is the GM key.
+_CONSENT_PAGE = """<!doctype html>
+<title>bunnyforge — authorize access</title>
+<h1>Authorize {client} to access campaign “{campaign}”?</h1>
+{error}<form method="post" action="/consent">
+  <input type="hidden" name="txn" value="{txn}">
+  <label>GM key: <input type="password" name="key" autofocus></label>
+  <button type="submit">Authorize</button>
+</form>
+"""
+
+
+def consent_endpoint(provider: SingleUserOAuthProvider, campaign: str):
+    """Build the GET/POST /consent endpoint for one provider + campaign."""
+    import anyio
+    from starlette.responses import (HTMLResponse, PlainTextResponse,
+                                     RedirectResponse)
+
+    no_store = {"Cache-Control": "no-store"}
+
+    def dead_txn() -> PlainTextResponse:
+        return PlainTextResponse(
+            "This authorization link is no longer valid. "
+            "Retry the connection from claude.ai.",
+            status_code=400, headers=no_store)
+
+    def page(txn: str, client_name: str, error: str = "") -> HTMLResponse:
+        body = _CONSENT_PAGE.format(
+            client=html.escape(client_name),
+            campaign=html.escape(campaign),
+            txn=html.escape(txn),
+            error=f"<p><strong>{error}</strong></p>\n" if error else "")
+        return HTMLResponse(body, headers=no_store)
+
+    async def consent(request):
+        if request.method == "GET":
+            txn = request.query_params.get("txn", "")
+            ctx = provider.consent_context(txn)
+            if ctx is None:
+                return dead_txn()
+            return page(txn, ctx["client_name"])
+        form = await request.form()
+        txn = str(form.get("txn", ""))
+        ctx = provider.consent_context(txn)
+        if ctx is None:
+            return dead_txn()
+        if not provider.check_key(str(form.get("key", ""))):
+            await anyio.sleep(_KEY_DELAY)
+            return page(txn, ctx["client_name"], "Wrong key — try again.")
+        url = provider.grant(txn)
+        if url is None:
+            return dead_txn()
+        return RedirectResponse(url, status_code=302, headers=no_store)
+
+    return consent
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth -v`
+Expected: PASS (all tests in the module)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_mcp_auth.py tests/test_mcp_auth.py
+git commit -m "feat(serve-mcp): consent page — the one identity decision bunnyforge owns"
+```
+
+---
+
+### Task 4: Wire OAuth into build_server; route-surface and end-to-end tests
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (`build_server` only)
+- Test: `tests/test_mcp_auth.py` (append)
+
+**Interfaces:**
+- Consumes: `SingleUserOAuthProvider` (attribute `issuer_url`),
+  `consent_endpoint` (Task 3).
+- Produces: `build_server(store, *, allow_direct_edits=False, oauth=None)`
+  — `oauth` is a `SingleUserOAuthProvider` or `None` (unauthenticated,
+  today's `--no-auth` semantics). Task 5's `main()` calls this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mcp_auth.py`. Note three deliberate choices:
+`base_url="http://127.0.0.1:8000"` keeps the Host header inside the SDK's
+auto-enabled localhost DNS-rebinding allowlist (`testserver` would 421 —
+the #46 failure class); `with TestClient(...)` runs the lifespan so the
+session manager behind `/mcp` starts; the issuer given to the provider
+matches that base_url so consent URLs are directly fetchable.
+
+```python
+def scaffold_store(case: unittest.TestCase):
+    """Minimal workspace, same shape as test_serve_mcp.scaffold."""
+    from bunnyforge import _config, _store
+    root = Path(case.enterContext(tempfile.TemporaryDirectory()))
+    (root / "campaign.toml").write_text(
+        '[campaign]\nnamespace = "testwiki"\nname = "Testmere"\n',
+        encoding="utf-8")
+    (root / "NPCs").mkdir()
+    return _store.WorkspaceStore(_config.open_workspace(root))
+
+
+def pkce_pair():
+    import base64
+    import hashlib
+    verifier = "v" * 43
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestOAuthOverHTTP(unittest.TestCase):
+    """The discovery sequence from issue #42, now ending in tokens."""
+
+    ISSUER = "http://127.0.0.1:8000"
+
+    def setUp(self):
+        from starlette.testclient import TestClient
+        from bunnyforge import serve_mcp
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url=self.ISSUER,
+            state_path=root / "state.json")
+        server = serve_mcp.build_server(scaffold_store(self),
+                                        oauth=self.provider)
+        app = server.streamable_http_app(stateless_http=True)
+        self.client = self.enterContext(
+            TestClient(app, base_url=self.ISSUER, follow_redirects=False))
+        self.enterContext(
+            mock.patch("bunnyforge._mcp_auth._KEY_DELAY", 0))
+
+    def test_discovery_documents_are_public(self):
+        for path in ("/.well-known/oauth-authorization-server",
+                     "/.well-known/oauth-protected-resource/mcp"):
+            resp = self.client.get(path)
+            self.assertEqual(resp.status_code, 200, path)
+        meta = self.client.get(
+            "/.well-known/oauth-authorization-server").json()
+        self.assertEqual(meta["issuer"].rstrip("/"), self.ISSUER)
+        self.assertTrue(meta["registration_endpoint"].endswith("/register"))
+
+    def test_mcp_without_token_is_401_pointing_at_metadata(self):
+        resp = self.client.post("/mcp", json={})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("resource_metadata",
+                      resp.headers.get("www-authenticate", ""))
+
+    def test_full_flow_register_to_authenticated_mcp(self):
+        # 1. Dynamic Client Registration (blank form fields in claude.ai)
+        reg = self.client.post("/register", json={
+            "client_name": "Claude",
+            "redirect_uris": ["http://localhost:9999/cb"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        })
+        self.assertEqual(reg.status_code, 201, reg.text)
+        info = reg.json()
+
+        # 2. Authorize → 302 to the consent page
+        verifier, challenge = pkce_pair()
+        auth = self.client.get("/authorize", params={
+            "client_id": info["client_id"],
+            "response_type": "code",
+            "redirect_uri": "http://localhost:9999/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "st8",
+        })
+        self.assertEqual(auth.status_code, 302, auth.text)
+        consent_url = auth.headers["location"]
+        self.assertIn("/consent?txn=", consent_url)
+
+        # 3. GM types the key on the consent page
+        self.assertEqual(self.client.get(consent_url).status_code, 200)
+        txn = consent_url.split("txn=")[1]
+        granted = self.client.post(
+            "/consent", data={"txn": txn, "key": "sekrit"})
+        self.assertEqual(granted.status_code, 302)
+        code = granted.headers["location"].split("code=")[1].split("&")[0]
+
+        # 4. Code + PKCE verifier + minted client secret → tokens
+        tok = self.client.post("/token", data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "http://localhost:9999/cb",
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+            "code_verifier": verifier,
+        })
+        self.assertEqual(tok.status_code, 200, tok.text)
+        tokens = tok.json()
+
+        # 5. The bearer token opens /mcp (anything but 401 proves auth;
+        #    protocol-level responses are the SDK's business)
+        resp = self.client.post(
+            "/mcp", json={},
+            headers={"Authorization": f"Bearer {tokens['access_token']}"})
+        self.assertNotEqual(resp.status_code, 401)
+
+        # 6. Refresh rotates
+        ref = self.client.post("/token", data={
+            "grant_type": "refresh_token",
+            "refresh_token": tokens["refresh_token"],
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+        })
+        self.assertEqual(ref.status_code, 200, ref.text)
+        self.assertNotEqual(ref.json()["refresh_token"],
+                            tokens["refresh_token"])
+        replay = self.client.post("/token", data={
+            "grant_type": "refresh_token",
+            "refresh_token": tokens["refresh_token"],
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+        })
+        self.assertEqual(replay.status_code, 400)
+
+    def test_wrong_pkce_verifier_is_rejected(self):
+        reg = self.client.post("/register", json={
+            "client_name": "Claude",
+            "redirect_uris": ["http://localhost:9999/cb"],
+        }).json()
+        _, challenge = pkce_pair()
+        auth = self.client.get("/authorize", params={
+            "client_id": reg["client_id"], "response_type": "code",
+            "redirect_uri": "http://localhost:9999/cb",
+            "code_challenge": challenge, "code_challenge_method": "S256",
+        })
+        txn = auth.headers["location"].split("txn=")[1]
+        granted = self.client.post(
+            "/consent", data={"txn": txn, "key": "sekrit"})
+        code = granted.headers["location"].split("code=")[1].split("&")[0]
+        tok = self.client.post("/token", data={
+            "grant_type": "authorization_code", "code": code,
+            "redirect_uri": "http://localhost:9999/cb",
+            "client_id": reg["client_id"],
+            "client_secret": reg["client_secret"],
+            "code_verifier": "x" * 43,
+        })
+        self.assertEqual(tok.status_code, 400)
+
+    def test_no_oauth_means_no_auth_routes_and_open_mcp(self):
+        from starlette.testclient import TestClient
+        from bunnyforge import serve_mcp
+        server = serve_mcp.build_server(scaffold_store(self))
+        app = server.streamable_http_app(stateless_http=True)
+        with TestClient(app, base_url=self.ISSUER,
+                        follow_redirects=False) as client:
+            self.assertEqual(
+                client.get("/.well-known/oauth-authorization-server")
+                .status_code, 404)
+            self.assertNotEqual(client.post("/mcp", json={})
+                                .status_code, 401)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth.TestOAuthOverHTTP -v`
+Expected: ERROR — `build_server() got an unexpected keyword argument 'oauth'`
+
+- [ ] **Step 3: Extend build_server**
+
+In `src/bunnyforge/serve_mcp.py`, replace the current
+`def build_server(...)` signature and `MCPServer("bunnyforge")` call
+(everything down to `server = MCPServer("bunnyforge")`) with:
+
+```python
+def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
+                 oauth=None):
+    """Assemble the MCP server over one workspace store.
+
+    Imports the SDK, so a caller without the extra gets ModuleNotFoundError;
+    main() translates that into the install hint.
+
+    With `oauth` (a SingleUserOAuthProvider), the SDK mounts the OAuth
+    bootstrap routes publicly and guards /mcp — passing the provider alone
+    is deliberate: MCPServer refuses a provider AND a token_verifier, and
+    wraps the provider in its own ProviderTokenVerifier. With oauth=None
+    the app is unauthenticated (--no-auth semantics).
+
+    Tool docstrings are not decoration — they are what the remote agent reads
+    to decide whether to call a tool, so they say when to use it, not merely
+    what it does.
+    """
+    from mcp.server import MCPServer
+
+    if oauth is None:
+        server = MCPServer("bunnyforge")
+    else:
+        from mcp.server.auth.settings import (AuthSettings,
+                                              ClientRegistrationOptions)
+        from bunnyforge._mcp_auth import consent_endpoint
+
+        server = MCPServer(
+            "bunnyforge",
+            auth_server_provider=oauth,
+            auth=AuthSettings(
+                issuer_url=oauth.issuer_url,
+                resource_server_url=f"{oauth.issuer_url}/mcp",
+                client_registration_options=ClientRegistrationOptions(
+                    enabled=True),
+            ),
+        )
+        server.custom_route("/consent", methods=["GET", "POST"])(
+            consent_endpoint(oauth, store.ws.config.name))
+```
+
+The tool registrations that follow are unchanged.
+
+- [ ] **Step 4: Run the new tests, then the whole suite**
+
+Run: `./.venv/bin/python -m unittest tests.test_mcp_auth -v`
+Expected: PASS. (`tests.test_serve_mcp` still passes too — `build_server`'s
+new keyword defaults to `None`.)
+
+Run: `./.venv/bin/python -m unittest discover -s tests -v 2>&1 | tail -5`
+Expected: OK (some skips on unrelated suites are pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_mcp_auth.py
+git commit -m "feat(serve-mcp): delegate auth topology to the SDK — DCR to tokens end-to-end"
+```
+
+---
+
+### Task 5: CLI — new flags, startup contract, delete _BearerAuth
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (module docstring, constants,
+  delete `_BearerAuth`, `build_parser`, `main`)
+- Modify: `tests/test_serve_mcp.py` (delete `TestBearerAuth`, rewrite
+  startup-contract tests)
+
+**Interfaces:**
+- Consumes: `build_server(store, *, allow_direct_edits, oauth)` (Task 4),
+  `SingleUserOAuthProvider`, `default_state_path` (Task 1).
+- Produces: the shipped CLI. `KEY_ENV = "BUNNYFORGE_MCP_KEY"` replaces
+  `TOKEN_ENV`; flags `--auth-key`, `--public-host`, `--no-auth`;
+  `--token` is gone.
+
+- [ ] **Step 1: Rewrite the startup-contract tests**
+
+In `tests/test_serve_mcp.py`: delete the entire `TestBearerAuth` class and
+replace the existing startup test (`test_refuses_to_start_without_token_or_no_auth`
+and any sibling asserting `--token` behavior) with:
+
+```python
+class TestStartupContract(unittest.TestCase):
+    """Default-deny: the spec's startup matrix, refusal rows.
+
+    These run on bare Python: every refusal fires before the SDK import.
+    """
+
+    def setUp(self):
+        store = scaffold(self)
+        self.ws_args = ["--workspace", str(store.ws.root)]
+        self.enterContext(mock.patch.dict(
+            os.environ, {"BUNNYFORGE_MCP_KEY": ""}))
+
+    def _main(self, extra):
+        import contextlib
+        import io
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = serve_mcp.main(self.ws_args + extra)
+        return rc, stderr.getvalue()
+
+    def test_refuses_without_key_or_no_auth(self):
+        rc, err = self._main([])
+        self.assertEqual(rc, 1)
+        self.assertIn("--auth-key", err)
+        self.assertIn("BUNNYFORGE_MCP_KEY", err)
+        self.assertIn("--no-auth", err)
+
+    def test_refuses_key_and_no_auth_together(self):
+        rc, err = self._main(["--auth-key", "k", "--no-auth"])
+        self.assertEqual(rc, 1)
+        self.assertIn("contradict", err)
+
+    def test_env_key_counts_as_key_for_the_contradiction(self):
+        with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "k"}):
+            rc, err = self._main(["--no-auth"])
+        self.assertEqual(rc, 1)
+        self.assertIn("contradict", err)
+
+    def test_token_flag_is_gone(self):
+        with self.assertRaises(SystemExit):
+            with contextlib.redirect_stderr(io.StringIO()):
+                serve_mcp.build_parser().parse_args(["--token", "t"])
+```
+
+(Add `import contextlib` and `import io` at the top of the test module;
+`os` and `mock` are already imported.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./.venv/bin/python -m unittest tests.test_serve_mcp -v`
+Expected: FAIL — refusal message still names `--token`; `--token` still
+parses; `TestBearerAuth` deletion leaves no reference to `_BearerAuth`.
+
+- [ ] **Step 3: Rewrite the CLI layer**
+
+In `src/bunnyforge/serve_mcp.py`:
+
+1. **Module docstring**, replace the `_BearerAuth` paragraph (lines
+   14–19 of the current file) with:
+
+```python
+Everything served here is GM-eyes-only, so auth is default-deny: no GM key
+and no explicit --no-auth means the server refuses to start. Auth itself is
+delegated to the SDK (design: docs/superpowers/specs/
+2026-08-16-serve-mcp-oauth-design.md): bunnyforge runs the smallest OAuth
+authorization server that satisfies claude.ai's connector — SDK handlers
+for registration, authorize, and token; bunnyforge owns one decision, a
+consent page checking a pre-shared GM key (_mcp_auth.py).
+```
+
+2. Replace `TOKEN_ENV = "BUNNYFORGE_MCP_TOKEN"` with
+   `KEY_ENV = "BUNNYFORGE_MCP_KEY"`.
+
+3. **Delete the `_BearerAuth` class entirely.**
+
+4. In `build_parser()`, replace the `--token` argument with:
+
+```python
+    parser.add_argument("--auth-key",
+                        help="pre-shared GM key typed on the OAuth consent "
+                             f"page, or set {KEY_ENV}; required unless "
+                             "--no-auth")
+    parser.add_argument("--public-host",
+                        help="public hostname the tunnel serves this host "
+                             "as; the OAuth issuer becomes https://HOST "
+                             "(default: the local bind address)")
+```
+
+5. In `main()`, replace everything from the `token = ...` line through the
+   `uvicorn.run(...)` call with:
+
+```python
+    key = (args.auth_key or os.environ.get(KEY_ENV, "")).strip()
+    if key and args.no_auth:
+        print(f"--no-auth contradicts --auth-key/{KEY_ENV}; pick one",
+              file=sys.stderr)
+        return 1
+    if not key and not args.no_auth:
+        print("refusing to start without auth: pass --auth-key, set "
+              f"{KEY_ENV}, or (local testing only) pass --no-auth",
+              file=sys.stderr)
+        return 1
+
+    # Issue #46 will also plumb --public-host into transport_security;
+    # here it only names the OAuth issuer.
+    issuer = (f"https://{args.public_host}" if args.public_host
+              else f"http://127.0.0.1:{args.port}")
+
+    try:
+        import uvicorn
+
+        oauth = None
+        if key:
+            from bunnyforge._mcp_auth import (SingleUserOAuthProvider,
+                                              default_state_path)
+            oauth = SingleUserOAuthProvider(
+                gm_key=key, issuer_url=issuer,
+                state_path=default_state_path())
+        server = build_server(WorkspaceStore(ws),
+                              allow_direct_edits=args.allow_direct_edits,
+                              oauth=oauth)
+    except ModuleNotFoundError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 1
+
+    app = server.streamable_http_app(stateless_http=True)
+    if not key:
+        print("WARNING: serving with no authentication", file=sys.stderr)
+
+    print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp "
+          f"(OAuth issuer: {issuer})" if key else
+          f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp")
+    uvicorn.run(app, host=args.host, port=args.port)
+    return 0
+```
+
+- [ ] **Step 4: Run the full suite on the venv, and the bare-Python checks**
+
+Run: `./.venv/bin/python -m unittest discover -s tests -v 2>&1 | tail -5`
+Expected: OK.
+
+Run: `python3 -c "import bunnyforge.cli; print('bare ok')"` and
+`./.venv/bin/bunnyforge serve-mcp --help`
+Expected: `bare ok`; help shows `--auth-key`, `--public-host`, `--no-auth`,
+and no `--token`.
+
+- [ ] **Step 5: Grep for stragglers**
+
+Run: `grep -rn "BearerAuth\|BUNNYFORGE_MCP_TOKEN\|--token" src tests docs README.md --include='*.py' --include='*.md' | grep -v superpowers/specs | grep -v superpowers/plans`
+Expected: no hits (the spec/plan may mention them historically; shipped
+code and docs must not).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat(serve-mcp)!: --auth-key/--public-host replace --token; delete _BearerAuth"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Create: `docs/serve-mcp.md`
+- Modify: `docs/superpowers/specs/2026-08-16-serve-mcp-design.md`
+  (supersession pointer only)
+
+**Interfaces:**
+- Consumes: the shipped CLI surface from Task 5 (flag names, env var,
+  state-file path). No code.
+
+- [ ] **Step 1: Write the operator doc**
+
+Create `docs/serve-mcp.md`:
+
+```markdown
+# serve-mcp: connecting claude.ai to a campaign workspace
+
+`bunnyforge serve-mcp` serves one campaign workspace to a remote AI agent
+over MCP. Everything it serves is GM-eyes-only; the server refuses to
+start without an auth mechanism.
+
+## Install
+
+    pip install 'bunnyforge[mcp]'
+
+## Generate a GM key (once)
+
+    python3 -c "import secrets; print(secrets.token_urlsafe(24))"
+
+Keep it out of git. You will type it exactly once per grant, on the
+consent page in your own browser — it is never stored by claude.ai.
+
+## Run behind a tunnel
+
+    export BUNNYFORGE_MCP_KEY=<your key>
+    cloudflared tunnel run <name>           # named tunnel, stable hostname
+    bunnyforge serve-mcp --public-host <name>.example.com
+
+A **named tunnel** (free with a Cloudflare-managed domain) is the
+recommended recipe: the hostname — and therefore the connector URL in
+claude.ai and the OAuth trust it anchors — survives restarts. A quick
+tunnel (`cloudflared tunnel --url http://127.0.0.1:8765`) also works, but
+its hostname changes every run: pass the new hostname to `--public-host`
+and update the connector URL in claude.ai each time.
+
+Local testing needs no tunnel: `--no-auth` (unauthenticated, loud
+warning) or `--auth-key` with the default localhost issuer.
+
+## Add the connector in claude.ai
+
+Settings → Connectors → Add custom connector:
+
+- **URL:** `https://<public-host>/mcp`
+- **OAuth Client ID / Client Secret:** leave **both blank**. claude.ai
+  registers itself (Dynamic Client Registration) against the server's
+  built-in single-user authorization server.
+
+On connect, your browser lands on the server's consent page; type the GM
+key. Tokens refresh silently for up to 30 days before the page reappears.
+
+## Resetting access
+
+Delete the token state file and restart the server:
+
+    rm ~/.local/state/bunnyforge/mcp-oauth-state.json
+
+(`$XDG_STATE_HOME/bunnyforge/mcp-oauth-state.json` if you set
+`XDG_STATE_HOME`.) Every issued token dies with it; claude.ai will run
+the consent flow again. Changing the GM key invalidates future grants
+but not already-issued tokens — delete the state file for that.
+
+## Troubleshooting
+
+- **401 from `/mcp`:** no or expired token — reconnect from claude.ai.
+- **421 Invalid Host header through a tunnel:** DNS-rebinding protection
+  does not know your public hostname — issue #46 tracks the
+  `--public-host` transport fix.
+- **"Couldn't register with sign-in service":** the server is not
+  reachable at the connector URL, or it was started `--no-auth` (no OAuth
+  routes exist in that mode).
+```
+
+- [ ] **Step 2: Point the old spec at the new one**
+
+In `docs/superpowers/specs/2026-08-16-serve-mcp-design.md`, insert
+directly under the `## Deployment and auth` heading:
+
+```markdown
+> **Superseded (2026-08-16):** the static-bearer-token scheme below was
+> disproved against the real claude.ai connector (issue #42). Current
+> design: `2026-08-16-serve-mcp-oauth-design.md`.
+```
+
+- [ ] **Step 3: Verify doc claims against the shipped CLI**
+
+Run: `./.venv/bin/bunnyforge serve-mcp --help`
+Expected: every flag named in `docs/serve-mcp.md` exists with the
+documented spelling.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/serve-mcp.md docs/superpowers/specs/2026-08-16-serve-mcp-design.md
+git commit -m "docs(serve-mcp): operator guide for OAuth connector setup"
+```
+
+---
+
+## Final verification (before the PR)
+
+- [ ] Full suite in the worktree venv:
+  `./.venv/bin/python -m unittest discover -s tests 2>&1 | tail -3` → OK.
+- [ ] Clean-checkout check per AGENTS.md ("verify where the artifact will
+  live"): fresh worktree of the branch, fresh venv,
+  `pip install -e '.[mcp]'`, assert resolution, run the suite.
+- [ ] Bare-python: `python3 -c "import bunnyforge.cli"` still works and the
+  system copy was never touched.
+- [ ] Manual smoke (the one thing tests cannot cover, may be deferred to
+  the owner): live tunnel + claude.ai connector with blank Client ID/Secret
+  completes the consent flow and lists tools. Note in the PR whether this
+  was run or deferred — #46's 421 may block it until that fix lands.
+- [ ] Scan the diff for secrets before pushing.
+- [ ] PR per AGENTS.md: base `main` (flag loudly if not), body with Files
+  changed / Work breakdown / Test expectations / Operational impact
+  (breaking flag rename; state file introduced) / Provenance. Move the
+  board card.
+```

--- a/docs/superpowers/specs/2026-08-16-serve-mcp-design.md
+++ b/docs/superpowers/specs/2026-08-16-serve-mcp-design.md
@@ -82,6 +82,10 @@ implements the same interface.
 
 ## Deployment and auth
 
+> **Superseded (2026-08-16):** the static-bearer-token scheme below was
+> disproved against the real claude.ai connector (issue #42). Current
+> design: `2026-08-16-serve-mcp-oauth-design.md`.
+
 - The server binds localhost; reaching it from claude.ai is the tunnel's
   job. Bunnyforge documents the Tailscale Funnel / cloudflared recipe but
   does not manage tunnels.

--- a/docs/superpowers/specs/2026-08-16-serve-mcp-oauth-design.md
+++ b/docs/superpowers/specs/2026-08-16-serve-mcp-oauth-design.md
@@ -1,0 +1,376 @@
+# serve-mcp: OAuth for the claude.ai connector — design
+
+**Date:** 2026-08-16
+**Status:** draft, awaiting review
+**Supersedes:** the "Deployment and auth" section of
+`2026-08-16-serve-mcp-design.md`, whose static-bearer-token assumption was
+disproved empirically (issue #42).
+
+## Problem
+
+The original design assumed the claude.ai custom connector would carry a
+static bearer token, with OAuth as fallback. Testing against the real
+connector form over a live cloudflared tunnel (issue #42) disproved it:
+
+- The form offers **OAuth Client ID** and **OAuth Client Secret**, both
+  optional, and no custom-header field. A static token has nowhere to go.
+- With both blank, claude.ai walks the standard OAuth discovery sequence —
+  `/.well-known/oauth-protected-resource/mcp`, `/.well-known/oauth-authorization-server`,
+  then `POST /register` (RFC 7591 Dynamic Client Registration) — and gives
+  up when every probe returns 401: *"Couldn't register with bunnyforge-mcp's
+  sign-in service."*
+
+Two conclusions follow:
+
+1. **claude.ai registers itself.** DCR means no pre-provisioned client at an
+   external identity provider is needed. That is the tractable case.
+2. **`_BearerAuth` is structurally incompatible with OAuth**, not merely
+   missing a feature. It wraps the whole ASGI app and 401s everything
+   without a token, but OAuth bootstrap is by definition unauthenticated —
+   a client cannot present a token before discovering how to obtain one.
+   Carving exemptions into the wrapper would mean re-deriving, and then
+   tracking, the spec's list of public routes by hand.
+
+## Goals
+
+- A claude.ai custom connector connects with the Client ID / Secret fields
+  **left blank**: DCR, authorization-code grant with PKCE, token refresh.
+- Only the GM can authorize a client. Everything served remains
+  GM-eyes-only; the tunnel makes the endpoints public, the auth design must
+  keep the content private.
+- Preserve the existing posture: default-deny (refuse to start without an
+  auth mechanism) and `--no-auth` for local testing only.
+- Stay inside the `bunnyforge[mcp]` extra with **no new dependencies**, and
+  keep `serve_mcp.py` importable on a bare Python (SDK imports only inside
+  function bodies).
+- Nothing credential-shaped ever reaches git — neither this public repo nor
+  the campaign workspace, which is itself a git repo.
+
+## Non-goals
+
+- **#46** (DNS-rebinding 421 through a tunnel). Independent fix, already
+  confirmed. This design *coordinates on one shared flag* (`--public-host`,
+  below) but does not implement transport security.
+- **#41 / phase 2 write-back.** Planned elsewhere; unaffected — auth wraps
+  the transport, not the tool surface.
+- Multi-user auth, scopes, player-facing visibility filtering. One user,
+  full access; `required_scopes` stays unset.
+
+## Measured SDK surface (mcp 2.0.0)
+
+Decisions below rest on these measured facts, not on documentation:
+
+- `MCPServer(...)` accepts `auth_server_provider`, `token_verifier`, and
+  `auth: AuthSettings`. Supplying **both** provider and verifier is a
+  `ValueError`; supplying a provider alone auto-wraps it in the SDK's
+  `ProviderTokenVerifier`, which verifies bearer tokens by calling the
+  provider's own `load_access_token`. With provider + `AuthSettings`,
+  `streamable_http_app()` assembles exactly the topology we need — **the
+  SDK already knows which routes must be public**:
+  - Mounted **unauthenticated**: `/.well-known/oauth-authorization-server`,
+    `/.well-known/oauth-protected-resource/mcp`, `/authorize`, `/token`,
+    `/register` (when `client_registration_options.enabled`), `/revoke`
+    (when enabled).
+  - Mounted **behind `RequireAuthMiddleware`**: `/mcp` only. Its 401 carries
+    `WWW-Authenticate: Bearer ... resource_metadata="…"` pointing at the
+    protected-resource metadata — the breadcrumb claude.ai's discovery
+    follows.
+- `OAuthAuthorizationServerProvider` has ten methods; the identity-assertion
+  one is gated off by default (`identity_assertion_enabled=False`), leaving
+  nine to implement: `get_client`, `register_client`, `authorize`,
+  `load_authorization_code`, `exchange_authorization_code`,
+  `load_refresh_token`, `exchange_refresh_token`, `load_access_token`,
+  `revoke_token`.
+- The SDK's handlers do the protocol work: the token handler **enforces
+  PKCE** (S256 check of `code_verifier` against the stored
+  `code_challenge`), the registration handler generates client
+  credentials, and the authorization handler validates `redirect_uri`,
+  scope, and response type before calling `provider.authorize()` — whose
+  string return value it 302-redirects to. That return value is the hook
+  where a consent page slots in.
+- `validate_issuer_url` requires HTTPS **except** for
+  localhost/127.0.0.1/::1, and forbids query/fragment. A cloudflared
+  hostname (`https://…`) and a local dev issuer (`http://127.0.0.1:8765`)
+  both pass.
+- `MCPServer.custom_route(path, methods)` mounts extra Starlette routes on
+  the same app — sufficient for a consent page.
+
+## Approaches considered
+
+### A. Self-hosted minimal authorization server, GM authenticated by a pre-shared key — **recommended**
+
+bunnyforge implements the nine-method provider over in-process state plus a
+small state file. DCR is enabled, so claude.ai registers itself. The one
+place identity actually matters — the `/authorize` step — renders a minimal
+consent page where the GM types a pre-shared key; correct key ⇒
+authorization code ⇒ SDK-managed token exchange.
+
+- **For:** proportionate to one user on one laptop. No accounts, no hosted
+  services, no subscription, no new dependencies (the SDK ships all the
+  protocol machinery; tokens are opaque random strings, so no JWT library).
+  The security-critical surface bunnyforge owns is one constant-time string
+  comparison; everything protocol-shaped (PKCE, redirect validation,
+  client auth, metadata) is the SDK's tested code.
+- **Against:** bunnyforge is now running an internet-facing OAuth
+  authorization server, however small. The mitigation is that a stolen
+  *protocol* interaction yields nothing without the GM key, and a stolen
+  *token* is time-limited and revocable by restarting with a new key state.
+
+### B. Resource-server mode only; delegate issuing to an external IdP
+
+Implement only `TokenVerifier` (~10 lines) and point
+`AuthSettings.issuer_url` at an external authorization server (Auth0,
+Keycloak, Cloudflare Access…) that supports DCR.
+
+- **For:** bunnyforge's auth code shrinks to token validation; a security
+  team maintains the hard parts.
+- **Against:** disproportionate for one user — a hosted IdP account (or a
+  self-hosted Keycloak, a heavier operational burden than all of
+  bunnyforge), tenant configuration, and DCR enablement, to protect one
+  laptop. It also needs a stable public identity for callback URLs, so the
+  ephemeral-tunnel question gets *harder*, not easier. Stated plainly per
+  the design brief: this is the right call for a team or a hosted phase-3
+  deployment, and the `TokenVerifier` seam keeps it reachable later, but it
+  is not the least-bad option today.
+
+### C. Self-hosted AS as in A, but GM login federated through GitHub
+
+Same provider skeleton, but the consent step redirects to a GitHub OAuth
+app and accepts only the repo owner's GitHub identity.
+
+- **For:** no pre-shared key to manage; phishing-resistant login.
+- **Against:** a GitHub OAuth app requires a **fixed callback URL**, which
+  an ephemeral quick-tunnel hostname breaks every run; it adds a network
+  dependency and a second protocol leg to debug; and it protects a
+  single-user consent form whose threat model a high-entropy key already
+  covers. More moving parts, same effective assurance.
+
+### Rejected without a lettered entry
+
+Keeping `_BearerAuth` and exempting the bootstrap routes. The evidence in
+#42 already names the flaw: the wrapper would have to re-derive the SDK's
+public-route list and track it as the spec evolves — and behind the
+exemptions we would *still* need the authorization server of approach A.
+All cost, no savings.
+
+## Design (approach A)
+
+### Architecture
+
+`_BearerAuth` is deleted. Auth assembly moves into the SDK call:
+
+```
+MCPServer(
+    "bunnyforge",
+    auth_server_provider=SingleUserOAuthProvider(...),
+    auth=AuthSettings(
+        issuer_url=<derived, see below>,
+        resource_server_url=<issuer>/mcp,
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+    ),
+)
+```
+
+No `token_verifier` is passed — the SDK forbids supplying both and wraps
+the provider in `ProviderTokenVerifier` itself, so `/mcp` bearer checks
+route through the provider's `load_access_token` (measured, above).
+
+Resulting route surface:
+
+| route | auth | source |
+|---|---|---|
+| `/.well-known/oauth-authorization-server` | public | SDK |
+| `/.well-known/oauth-protected-resource/mcp` | public | SDK |
+| `POST /register` | public (open DCR, per RFC 7591) | SDK |
+| `GET/POST /authorize` | public entry; **GM key gates approval** | SDK → provider |
+| `POST /token` | client credentials + PKCE | SDK |
+| `GET/POST /consent` | public entry; GM key checked on POST | bunnyforge (`custom_route`) |
+| `/mcp` | Bearer token required | SDK `RequireAuthMiddleware` |
+
+### The provider: `SingleUserOAuthProvider`
+
+One class in a new module `src/bunnyforge/_mcp_auth.py`. The module may
+import `mcp` at top level — it is itself imported only inside
+`serve_mcp.py` function bodies, so bare-Python imports of `serve_mcp`
+remain safe (`cli.py` imports every subcommand unconditionally).
+
+State: four dicts — registered clients, pending consent transactions,
+authorization codes, access/refresh tokens — with clients and tokens
+persisted (below) and transactions/codes deliberately memory-only.
+
+| method | behaviour |
+|---|---|
+| `register_client` | Store the SDK-built client record. Cap stored clients (e.g. 32, evict oldest) so an internet-reachable open endpoint cannot grow memory unboundedly. |
+| `get_client` | Lookup. |
+| `authorize` | Park the `AuthorizationParams` under a random transaction id (10-minute expiry) and return `<issuer>/consent?txn=<id>` — the SDK 302s the GM's browser there. |
+| `load_authorization_code` / `exchange_authorization_code` | Standard single-use code flow: codes expire after 5 minutes, are bound to the client id, and are deleted on exchange. PKCE verification is the SDK's job. Exchange issues an access token (1 h) and refresh token. |
+| `load_refresh_token` / `exchange_refresh_token` | Rotate: old refresh token invalidated, new access + refresh pair issued. This is what makes server restarts and access-token expiry invisible to the GM. |
+| `load_access_token` | Lookup; `None` if unknown or expired (prune on read). Serves as token verification for `/mcp`. |
+| `revoke_token` | Delete access or refresh token. `RevocationOptions` stays disabled initially — claude.ai did not probe `/revoke` — but the method is trivial, so implement it and leave the route off. |
+
+All tokens, codes, and transaction ids are `secrets.token_urlsafe(32)` —
+opaque and looked up server-side. No JWTs, even though `pyjwt` happens to
+ship with the SDK: opaque tokens need no signing keys to generate, rotate,
+or leak, and revocation is a dict delete instead of a denylist.
+
+### GM authentication: the consent page
+
+The only place bunnyforge makes a security decision of its own.
+
+- `GET /consent?txn=…` — minimal inline-HTML form: campaign name, the
+  requesting client's `client_name` ("Claude"), one password input, submit.
+  Unknown or expired txn ⇒ 400 with a "restart the connection from
+  claude.ai" message.
+- `POST /consent` — compare the submitted key against the configured GM key
+  with `hmac.compare_digest`. On success: consume the transaction, mint the
+  authorization code, 302 to the client's `redirect_uri` with `code` and
+  `state`. On failure: re-render the form with an error after a ~1 s delay.
+- The form is styled with nothing (it is used once per token lifetime by
+  one person) and served with `Cache-Control: no-store`.
+
+Brute-force posture: the key is expected to be high-entropy (docs show
+`python3 -c "import secrets; print(secrets.token_urlsafe(24))"`), the
+comparison is constant-time, failures are delayed, and transactions expire.
+A lockout counter is deliberately omitted — it adds a self-DoS lever to
+protect a 128-bit secret.
+
+### Key naming: `--auth-key` replaces `--token`
+
+The GM key is not a bearer token — it is never sent by the MCP client, it
+is typed by the GM into the consent form once per grant. Keeping the name
+`--token` / `BUNNYFORGE_MCP_TOKEN` would misdescribe the mechanism the
+moment it ships. New spelling: **`--auth-key` / `BUNNYFORGE_MCP_KEY`**, and
+the old spellings are removed rather than aliased — the server is pre-1.0
+with exactly one operator, and a silent alias would preserve the wrong
+mental model. `--help` text and `docs/serve-mcp.md` explain the change.
+
+### Issuer URL and the tunnel
+
+`AuthSettings.issuer_url` is required, and tunnel hostnames are ephemeral;
+this is a real constraint with a two-part answer:
+
+1. **The issuer is derived at startup, not configured separately.**
+   serve-mcp gains `--public-host HOST` — *the same flag issue #46
+   specifies* for transport security; whichever lands first defines it,
+   the other consumes it. With the flag: `issuer_url =
+   https://<public-host>`, `resource_server_url =
+   https://<public-host>/mcp`. Without it: `http://127.0.0.1:<port>`,
+   which `validate_issuer_url` accepts for local testing.
+2. **Quick tunnels work; a named tunnel is the recommended recipe.** With a
+   cloudflared quick tunnel the hostname changes every run — the GM must
+   start the tunnel, read the hostname, and pass it to `--public-host`. The
+   connector URL in claude.ai changes at the same time, so quick tunnels
+   force reconfiguration *and* a fresh OAuth dance every run regardless of
+   what this design does. A named tunnel (free with a Cloudflare-managed
+   domain) gives a stable hostname, which makes the persisted refresh
+   tokens actually useful: laptop restarts become invisible to claude.ai.
+   The design therefore *supports* ephemeral hostnames but the documented
+   recipe uses a named tunnel. No requirement for a hosted identity of any
+   kind follows from this.
+
+Auth mode does not require `--public-host` (localhost issuer is valid for
+testing with the SDK's inspector), but the startup banner states the issuer
+so a mismatch is visible immediately.
+
+### Persistence
+
+Registered clients and tokens survive restarts in a state file:
+
+- **Location:** `$XDG_STATE_HOME/bunnyforge/mcp-oauth-state.json`
+  (default `~/.local/state/bunnyforge/…`). Outside every git repo by
+  construction — never in the bunnyforge repo, never in the campaign
+  workspace. Created `0600`, parent dirs `0700`, written atomically
+  (temp file + `os.replace`).
+- **Contents:** registered clients; refresh tokens; access tokens with
+  expiries. Pending transactions and authorization codes are *not*
+  persisted — they live minutes and losing them only re-prompts consent.
+- **Pruning:** expired entries dropped on load and on write.
+- **Reset:** deleting the file revokes everything; document this as the
+  "log everyone out" move. Refresh tokens expire after 30 days of disuse,
+  bounding how long the file stays sensitive.
+
+Persistence is what turns approach A from "re-authorize every server
+restart" (real friction on a laptop that serves per-session) into "connect
+once per month". It is scoped to this one JSON file so the trade — a
+credential cache on disk, `0600`, outside any repo — is explicit.
+
+### Startup contract (default-deny preserved)
+
+| invocation | result |
+|---|---|
+| `--auth-key` present (or `BUNNYFORGE_MCP_KEY` set) | OAuth mode: SDK auth routes + guarded `/mcp` |
+| `--no-auth` | unauthenticated app, loud warning — local testing only |
+| neither | **refuse to start**, message names `--auth-key`, the env var, and `--no-auth` |
+| both | refuse to start: contradictory intent |
+
+`--no-auth` builds the app with no `AuthSettings`, no provider, no
+verifier — the SDK then mounts `/mcp` unguarded and no OAuth routes exist,
+matching today's semantics exactly.
+
+### What is exposed unauthenticated, and why that is acceptable
+
+The OAuth bootstrap routes are public because the protocol requires it.
+What each yields an attacker: metadata (server names and endpoint URLs — no
+campaign content), open registration (a client record in a capped store),
+an authorize/consent page (a password form over a high-entropy key), a
+token endpoint (useless without a code minted by that form, bound by PKCE).
+Campaign content sits solely behind `/mcp`, which requires a token that
+only the consent flow issues. The GM-eyes-only property reduces to the
+secrecy of one key plus the SDK's protocol correctness — the same trust
+shape as the old design, minus the incompatibility.
+
+## Error handling
+
+- Protocol errors (bad redirect URI, unknown client, failed PKCE, expired
+  code) are the SDK handlers' responsibility; the provider signals them by
+  returning `None`/raising per the provider contract.
+- Consent errors are bunnyforge's: unknown/expired txn ⇒ 400 with recovery
+  instructions; wrong key ⇒ delayed re-render; both paths `no-store`.
+- State-file corruption (unparseable JSON) ⇒ log a warning, start with
+  empty state, do not overwrite the corrupt file until the first
+  successful write renames over it. Losing token state is an
+  inconvenience, not an outage: claude.ai re-runs the flow.
+- Startup validation failures (issuer rejected by `validate_issuer_url`,
+  contradictory flags) refuse to start with the reason on stderr, matching
+  the existing posture.
+
+## Testing
+
+`unittest`, in `tests/test_serve_mcp.py` and a new `tests/test_mcp_auth.py`,
+following the existing `HAVE_MCP` skip discipline (provider logic that
+imports `mcp` skips on bare Python; anything SDK-free runs everywhere).
+
+- **Provider unit tests:** registration cap and eviction; code single-use
+  and expiry; refresh rotation (old token dead after use); access-token
+  expiry pruning; state-file round-trip, atomic write, `0600` mode,
+  corrupt-file recovery.
+- **Consent flow over the assembled ASGI app** (Starlette's `TestClient`,
+  measured importable in an extra-only venv; note plain `httpx` is *not*
+  in the tree — mcp 2.0 depends on `httpx2` — so do not reach for it):
+  full happy path — `POST /register`, `GET /authorize` → 302 to consent,
+  `POST /consent` with the right key → 302 with `code` and `state`,
+  `POST /token` with PKCE verifier → tokens, `POST /mcp` with the access
+  token → 200. Wrong key re-renders and does not mint a code; a code
+  replay fails; wrong `code_verifier` fails.
+- **Route-surface assertions:** the well-known documents and `/register`
+  answer without credentials; `/mcp` without a token is 401 and its
+  `WWW-Authenticate` names the resource metadata URL (the exact sequence
+  #42 logged, now succeeding).
+- **Startup contract:** each row of the table above, as `main()` tests in
+  the style of the existing `test_refuses_to_start_without_token_or_no_auth`.
+- The claude.ai handshake end-to-end remains a manual validation step, as
+  phase 1's was: external service, not automatable from the suite.
+
+## Migration and cleanup
+
+- Delete `_BearerAuth` and its tests (`TestBearerAuth`); the module
+  docstring paragraph explaining it is rewritten to describe SDK
+  delegation.
+- Replace `--token` / `BUNNYFORGE_MCP_TOKEN` with `--auth-key` /
+  `BUNNYFORGE_MCP_KEY` everywhere, including docs.
+- Amend the superseded section of `2026-08-16-serve-mcp-design.md` with a
+  pointer to this document (one-line edit, not a rewrite).
+- Document the connector setup: Client ID / Secret **left blank**; the
+  named-tunnel recipe; key generation; the state-file reset move.
+- Coordinate with #46 on `--public-host` (single definition, two
+  consumers). Neither blocks the other.

--- a/src/bunnyforge/_mcp_auth.py
+++ b/src/bunnyforge/_mcp_auth.py
@@ -262,3 +262,61 @@ class SingleUserOAuthProvider(
                           expires_in=ACCESS_TTL,
                           scope=" ".join(scopes) or None,
                           refresh_token=refresh)
+
+
+# One page, used once per token lifetime by one person: inline HTML, no
+# styling, served no-store. The only secret it ever sees is the GM key.
+_CONSENT_PAGE = """<!doctype html>
+<title>bunnyforge — authorize access</title>
+<h1>Authorize {client} to access campaign “{campaign}”?</h1>
+{error}<form method="post" action="/consent">
+  <input type="hidden" name="txn" value="{txn}">
+  <label>GM key: <input type="password" name="key" autofocus></label>
+  <button type="submit">Authorize</button>
+</form>
+"""
+
+
+def consent_endpoint(provider: SingleUserOAuthProvider, campaign: str):
+    """Build the GET/POST /consent endpoint for one provider + campaign."""
+    import anyio
+    from starlette.responses import (HTMLResponse, PlainTextResponse,
+                                     RedirectResponse)
+
+    no_store = {"Cache-Control": "no-store"}
+
+    def dead_txn() -> PlainTextResponse:
+        return PlainTextResponse(
+            "This authorization link is no longer valid. "
+            "Retry the connection from claude.ai.",
+            status_code=400, headers=no_store)
+
+    def page(txn: str, client_name: str, error: str = "") -> HTMLResponse:
+        body = _CONSENT_PAGE.format(
+            client=html.escape(client_name),
+            campaign=html.escape(campaign),
+            txn=html.escape(txn),
+            error=f"<p><strong>{error}</strong></p>\n" if error else "")
+        return HTMLResponse(body, headers=no_store)
+
+    async def consent(request):
+        if request.method == "GET":
+            txn = request.query_params.get("txn", "")
+            ctx = provider.consent_context(txn)
+            if ctx is None:
+                return dead_txn()
+            return page(txn, ctx["client_name"])
+        form = await request.form()
+        txn = str(form.get("txn", ""))
+        ctx = provider.consent_context(txn)
+        if ctx is None:
+            return dead_txn()
+        if not provider.check_key(str(form.get("key", ""))):
+            await anyio.sleep(_KEY_DELAY)
+            return page(txn, ctx["client_name"], "Wrong key — try again.")
+        url = provider.grant(txn)
+        if url is None:
+            return dead_txn()
+        return RedirectResponse(url, status_code=302, headers=no_store)
+
+    return consent

--- a/src/bunnyforge/_mcp_auth.py
+++ b/src/bunnyforge/_mcp_auth.py
@@ -140,3 +140,125 @@ class SingleUserOAuthProvider(
             self._refresh = {t: r for t, r in self._refresh.items()
                              if r.client_id != evicted}
         self._save()
+
+    # -- consent -----------------------------------------------------------
+    # authorize() is called by the SDK's /authorize handler, which 302s the
+    # GM's browser to whatever URL we return. We park the request under an
+    # unguessable transaction id and send the browser to our consent page;
+    # grant() is the consent POST handler redeeming it.
+
+    async def authorize(self, client: OAuthClientInformationFull,
+                        params: AuthorizationParams) -> str:
+        self._prune()
+        txn = secrets.token_urlsafe(32)
+        self._txns[txn] = _Txn(params=params, client_id=client.client_id,
+                               expires_at=time.time() + TXN_TTL)
+        return f"{self.issuer_url}/consent?txn={txn}"
+
+    def check_key(self, submitted: str) -> bool:
+        return hmac.compare_digest(submitted.encode(), self._gm_key.encode())
+
+    def consent_context(self, txn: str) -> dict | None:
+        t = self._txns.get(txn)
+        if t is None or t.expires_at < time.time():
+            self._txns.pop(txn, None)
+            return None
+        client = self._clients.get(t.client_id)
+        name = (client.client_name if client else None) or t.client_id
+        return {"client_name": name}
+
+    def grant(self, txn: str) -> str | None:
+        t = self._txns.pop(txn, None)
+        if t is None or t.expires_at < time.time():
+            return None
+        code = secrets.token_urlsafe(32)
+        p = t.params
+        self._codes[code] = AuthorizationCode(
+            code=code, scopes=p.scopes or [],
+            expires_at=time.time() + CODE_TTL,
+            client_id=t.client_id, code_challenge=p.code_challenge,
+            redirect_uri=p.redirect_uri,
+            redirect_uri_provided_explicitly=p.redirect_uri_provided_explicitly,
+            resource=p.resource)
+        return construct_redirect_uri(str(p.redirect_uri),
+                                      code=code, state=p.state)
+
+    def _prune(self) -> None:
+        now = time.time()
+        self._txns = {k: v for k, v in self._txns.items()
+                      if v.expires_at > now}
+        self._codes = {k: v for k, v in self._codes.items()
+                       if v.expires_at > now}
+
+    # -- codes and tokens (called by the SDK's /token handler; PKCE is
+    # verified there, not here) ------------------------------------------
+
+    async def load_authorization_code(
+            self, client: OAuthClientInformationFull,
+            authorization_code: str) -> AuthorizationCode | None:
+        ac = self._codes.get(authorization_code)
+        if ac is None or ac.client_id != client.client_id:
+            return None
+        if ac.expires_at < time.time():
+            del self._codes[authorization_code]
+            return None
+        return ac
+
+    async def exchange_authorization_code(
+            self, client: OAuthClientInformationFull,
+            authorization_code: AuthorizationCode) -> OAuthToken:
+        if self._codes.pop(authorization_code.code, None) is None:
+            raise TokenError("invalid_grant",
+                             "authorization code already used")
+        return self._issue(client.client_id, authorization_code.scopes)
+
+    async def load_refresh_token(
+            self, client: OAuthClientInformationFull,
+            refresh_token: str) -> RefreshToken | None:
+        rt = self._refresh.get(refresh_token)
+        if rt is None or rt.client_id != client.client_id:
+            return None
+        if rt.expires_at and rt.expires_at < time.time():
+            del self._refresh[refresh_token]
+            self._save()
+            return None
+        return rt
+
+    async def exchange_refresh_token(
+            self, client: OAuthClientInformationFull,
+            refresh_token: RefreshToken, scopes: list[str]) -> OAuthToken:
+        if self._refresh.pop(refresh_token.token, None) is None:
+            raise TokenError("invalid_grant", "refresh token already used")
+        return self._issue(client.client_id,
+                           scopes or refresh_token.scopes)
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        at = self._access.get(token)
+        if at is None:
+            return None
+        if at.expires_at and at.expires_at < time.time():
+            del self._access[token]
+            return None
+        return at
+
+    async def revoke_token(
+            self, token: AccessToken | RefreshToken) -> None:
+        self._access.pop(token.token, None)
+        self._refresh.pop(token.token, None)
+        self._save()
+
+    def _issue(self, client_id: str, scopes: list[str]) -> OAuthToken:
+        now = time.time()
+        access = secrets.token_urlsafe(32)
+        refresh = secrets.token_urlsafe(32)
+        self._access[access] = AccessToken(
+            token=access, client_id=client_id, scopes=scopes,
+            expires_at=int(now + ACCESS_TTL))
+        self._refresh[refresh] = RefreshToken(
+            token=refresh, client_id=client_id, scopes=scopes,
+            expires_at=int(now + REFRESH_TTL))
+        self._save()
+        return OAuthToken(access_token=access, token_type="Bearer",
+                          expires_in=ACCESS_TTL,
+                          scope=" ".join(scopes) or None,
+                          refresh_token=refresh)

--- a/src/bunnyforge/_mcp_auth.py
+++ b/src/bunnyforge/_mcp_auth.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""_mcp_auth.py — single-user OAuth authorization server for serve-mcp.
+
+claude.ai's connector speaks OAuth with Dynamic Client Registration and
+nothing else (issue #42), so serve-mcp runs the smallest authorization
+server that satisfies it: the SDK's handlers do every protocol step, and
+the one identity decision bunnyforge owns — "is this the GM?" — is a
+pre-shared key checked on a consent page.
+
+This module imports the mcp SDK at top level. That is safe only because
+serve_mcp.py imports THIS module inside function bodies; a bare Python
+(no bunnyforge[mcp] extra) never loads it.
+
+Tokens are opaque random strings looked up server-side — no JWTs, no
+signing keys. Clients and tokens persist to a 0600 JSON file outside any
+git repo, so a laptop restart does not force a full re-auth in claude.ai;
+consent transactions and authorization codes live minutes and stay
+memory-only.
+"""
+
+from __future__ import annotations
+
+import hmac
+import html
+import json
+import os
+import secrets
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+    TokenError,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+MAX_CLIENTS = 32          # /register is public by RFC 7591; bound its memory
+TXN_TTL = 600             # seconds a consent page may wait for the GM
+CODE_TTL = 300
+ACCESS_TTL = 3600
+REFRESH_TTL = 30 * 24 * 3600
+_KEY_DELAY = 1.0          # pause after a wrong key; patched to 0 in tests
+
+
+def default_state_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+    return Path(base) / "bunnyforge" / "mcp-oauth-state.json"
+
+
+@dataclass
+class _Txn:
+    """One consent-in-flight: the authorize params parked while the GM
+    decides, keyed by an unguessable transaction id."""
+    params: AuthorizationParams
+    client_id: str
+    expires_at: float
+
+
+class SingleUserOAuthProvider(
+        OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken,
+                                         AccessToken]):
+    """The nine provider methods over four dicts and one state file."""
+
+    def __init__(self, gm_key: str, issuer_url: str, state_path: Path):
+        self._gm_key = gm_key
+        self.issuer_url = issuer_url.rstrip("/")
+        self._state_path = state_path
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+        self._txns: dict[str, _Txn] = {}
+        self._codes: dict[str, AuthorizationCode] = {}
+        self._access: dict[str, AccessToken] = {}
+        self._refresh: dict[str, RefreshToken] = {}
+        self._load()
+
+    # -- persistence -------------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            raw = json.loads(self._state_path.read_text(encoding="utf-8"))
+            clients = {c: OAuthClientInformationFull.model_validate(v)
+                       for c, v in raw.get("clients", {}).items()}
+            access = {t: AccessToken.model_validate(v)
+                      for t, v in raw.get("access_tokens", {}).items()}
+            refresh = {t: RefreshToken.model_validate(v)
+                       for t, v in raw.get("refresh_tokens", {}).items()}
+        except FileNotFoundError:
+            return
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            # Losing token state is an inconvenience, not an outage: the
+            # connector just re-runs the flow. Keep the corrupt file until
+            # the first good save renames over it.
+            print(f"warning: ignoring unreadable auth state "
+                  f"{self._state_path}: {exc}", file=sys.stderr)
+            return
+        now = time.time()
+        self._clients = clients
+        self._access = {t: a for t, a in access.items()
+                        if not a.expires_at or a.expires_at > now}
+        self._refresh = {t: r for t, r in refresh.items()
+                         if not r.expires_at or r.expires_at > now}
+
+    def _save(self) -> None:
+        data = {
+            "clients": {c: v.model_dump(mode="json")
+                        for c, v in self._clients.items()},
+            "access_tokens": {t: v.model_dump(mode="json")
+                              for t, v in self._access.items()},
+            "refresh_tokens": {t: v.model_dump(mode="json")
+                               for t, v in self._refresh.items()},
+        }
+        self._state_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        tmp = self._state_path.with_suffix(".tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+        os.replace(tmp, self._state_path)
+
+    # -- client registry (RFC 7591; the SDK handler mints the credentials) -
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    async def register_client(
+            self, client_info: OAuthClientInformationFull) -> None:
+        self._clients[client_info.client_id] = client_info
+        while len(self._clients) > MAX_CLIENTS:
+            evicted = next(iter(self._clients))
+            del self._clients[evicted]
+            self._access = {t: a for t, a in self._access.items()
+                            if a.client_id != evicted}
+            self._refresh = {t: r for t, r in self._refresh.items()
+                             if r.client_id != evicted}
+        self._save()

--- a/src/bunnyforge/_mcp_auth.py
+++ b/src/bunnyforge/_mcp_auth.py
@@ -27,6 +27,7 @@ import os
 import secrets
 import sys
 import time
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -132,6 +133,14 @@ class SingleUserOAuthProvider(
     async def register_client(
             self, client_info: OAuthClientInformationFull) -> None:
         self._clients[client_info.client_id] = client_info
+        # /register has no auth, so this cap is the only thing standing
+        # between an anonymous caller and unbounded memory growth. The
+        # trade it accepts: enough registration spam evicts the oldest
+        # client -- ordinarily claude.ai's -- along with its tokens,
+        # forcing the GM to click through consent again, and sustained
+        # spam can keep doing that indefinitely. Still the right trade;
+        # RFC 7591 mandates public registration, so there is no way to
+        # tell a legitimate re-registration from an attacker's here.
         while len(self._clients) > MAX_CLIENTS:
             evicted = next(iter(self._clients))
             del self._clients[evicted]
@@ -165,7 +174,12 @@ class SingleUserOAuthProvider(
             return None
         client = self._clients.get(t.client_id)
         name = (client.client_name if client else None) or t.client_id
-        return {"client_name": name}
+        # /register is public, so client_name alone can't be trusted -- an
+        # attacker can register a client called "Claude" with their own
+        # redirect_uri and mail the GM the resulting consent link. Showing
+        # the redirect target's host lets the GM notice it isn't localhost.
+        redirect_host = urllib.parse.urlsplit(str(t.params.redirect_uri)).netloc
+        return {"client_name": name, "redirect_host": redirect_host}
 
     def grant(self, txn: str) -> str | None:
         t = self._txns.pop(txn, None)
@@ -269,6 +283,11 @@ class SingleUserOAuthProvider(
 _CONSENT_PAGE = """<!doctype html>
 <title>bunnyforge — authorize access</title>
 <h1>Authorize {client} to access campaign “{campaign}”?</h1>
+<p>If you authorize, the access code will be sent to
+<strong>{redirect_host}</strong>. That should be <code>localhost</code> if
+you got here by clicking Connect in claude.ai; if it names some other
+site, do not enter your key — stop and start the connection over from
+claude.ai instead.</p>
 {error}<form method="post" action="/consent">
   <input type="hidden" name="txn" value="{txn}">
   <label>GM key: <input type="password" name="key" autofocus></label>
@@ -291,10 +310,12 @@ def consent_endpoint(provider: SingleUserOAuthProvider, campaign: str):
             "Retry the connection from claude.ai.",
             status_code=400, headers=no_store)
 
-    def page(txn: str, client_name: str, error: str = "") -> HTMLResponse:
+    def page(txn: str, client_name: str, redirect_host: str,
+             error: str = "") -> HTMLResponse:
         body = _CONSENT_PAGE.format(
             client=html.escape(client_name),
             campaign=html.escape(campaign),
+            redirect_host=html.escape(redirect_host),
             txn=html.escape(txn),
             error=f"<p><strong>{error}</strong></p>\n" if error else "")
         return HTMLResponse(body, headers=no_store)
@@ -305,7 +326,7 @@ def consent_endpoint(provider: SingleUserOAuthProvider, campaign: str):
             ctx = provider.consent_context(txn)
             if ctx is None:
                 return dead_txn()
-            return page(txn, ctx["client_name"])
+            return page(txn, ctx["client_name"], ctx["redirect_host"])
         form = await request.form()
         txn = str(form.get("txn", ""))
         ctx = provider.consent_context(txn)
@@ -313,7 +334,8 @@ def consent_endpoint(provider: SingleUserOAuthProvider, campaign: str):
             return dead_txn()
         if not provider.check_key(str(form.get("key", ""))):
             await anyio.sleep(_KEY_DELAY)
-            return page(txn, ctx["client_name"], "Wrong key — try again.")
+            return page(txn, ctx["client_name"], ctx["redirect_host"],
+                       "Wrong key — try again.")
         url = provider.grant(txn)
         if url is None:
             return dead_txn()

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -68,11 +68,18 @@ class _BearerAuth:
         await self._app(scope, receive, send)
 
 
-def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False):
+def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
+                 oauth=None):
     """Assemble the MCP server over one workspace store.
 
     Imports the SDK, so a caller without the extra gets ModuleNotFoundError;
     main() translates that into the install hint.
+
+    With `oauth` (a SingleUserOAuthProvider), the SDK mounts the OAuth
+    bootstrap routes publicly and guards /mcp — passing the provider alone
+    is deliberate: MCPServer refuses a provider AND a token_verifier, and
+    wraps the provider in its own ProviderTokenVerifier. With oauth=None
+    the app is unauthenticated (--no-auth semantics).
 
     Tool docstrings are not decoration — they are what the remote agent reads
     to decide whether to call a tool, so they say when to use it, not merely
@@ -80,7 +87,25 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False):
     """
     from mcp.server import MCPServer
 
-    server = MCPServer("bunnyforge")
+    if oauth is None:
+        server = MCPServer("bunnyforge")
+    else:
+        from mcp.server.auth.settings import (AuthSettings,
+                                              ClientRegistrationOptions)
+        from bunnyforge._mcp_auth import consent_endpoint
+
+        server = MCPServer(
+            "bunnyforge",
+            auth_server_provider=oauth,
+            auth=AuthSettings(
+                issuer_url=oauth.issuer_url,
+                resource_server_url=f"{oauth.issuer_url}/mcp",
+                client_registration_options=ClientRegistrationOptions(
+                    enabled=True),
+            ),
+        )
+        server.custom_route("/consent", methods=["GET", "POST"])(
+            consent_endpoint(oauth, store.ws.config.name))
 
     @server.tool()
     def campaign_overview() -> dict:

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -11,12 +11,13 @@ function bodies. cli.py imports every subcommand module unconditionally: a
 bare Python must be able to import this one, print its --help, and get a
 friendly install hint, with no other subcommand affected.
 
-Everything served here is GM-eyes-only, so auth is default-deny: no token
-and no explicit --no-auth means the server refuses to start. _BearerAuth is
-deliberately pure ASGI rather than starlette middleware — it must work
-whatever the SDK builds its app from, and it is short enough to read in one
-sitting, which is what you want of the only thing between a tunnel and the
-campaign's secrets.
+Everything served here is GM-eyes-only, so auth is default-deny: no GM key
+and no explicit --no-auth means the server refuses to start. Auth itself is
+delegated to the SDK (design: docs/superpowers/specs/
+2026-08-16-serve-mcp-oauth-design.md): bunnyforge runs the smallest OAuth
+authorization server that satisfies claude.ai's connector — SDK handlers
+for registration, authorize, and token; bunnyforge owns one decision, a
+consent page checking a pre-shared GM key (_mcp_auth.py).
 
 Publishing is structurally absent, not merely forbidden: no tool here
 touches Export/ or the wiki, so a remote agent cannot leak GM material to
@@ -33,7 +34,7 @@ from bunnyforge import _config
 from bunnyforge._config import ConfigError, WorkspaceError
 from bunnyforge._store import StoreError, WorkspaceStore
 
-TOKEN_ENV = "BUNNYFORGE_MCP_TOKEN"
+KEY_ENV = "BUNNYFORGE_MCP_KEY"
 
 # Workspace doctrine, offered as MCP resources so a fresh conversation can
 # load the house rules before it writes anything. Absent files are simply
@@ -42,30 +43,6 @@ DOCTRINE_FILES = ("style-guide.md", "situation-design.md", "AGENTS.md")
 
 _INSTALL_HINT = ("serve-mcp needs its optional dependencies:\n"
                  "  pip install 'bunnyforge[mcp]'")
-
-
-class _BearerAuth:
-    """Require `Authorization: Bearer <token>` on every HTTP request.
-
-    Non-HTTP scopes (lifespan) pass through untouched: they carry no headers,
-    and answering them with 401 would stop the app from starting.
-    """
-
-    def __init__(self, app, token: str):
-        self._app = app
-        self._expected = f"Bearer {token}".encode()
-
-    async def __call__(self, scope, receive, send):
-        if scope["type"] == "http":
-            headers = {k.lower(): v for k, v in scope.get("headers") or []}
-            if headers.get(b"authorization") != self._expected:
-                await send({"type": "http.response.start", "status": 401,
-                            "headers": [(b"content-type", b"text/plain"),
-                                        (b"www-authenticate", b"Bearer")]})
-                await send({"type": "http.response.body",
-                            "body": b"unauthorized"})
-                return
-        await self._app(scope, receive, send)
 
 
 def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
@@ -170,9 +147,14 @@ def build_parser() -> argparse.ArgumentParser:
                              "through a tunnel, not by binding wider)")
     parser.add_argument("--port", type=int, default=8765,
                         help="bind port (default: %(default)s)")
-    parser.add_argument("--token",
-                        help=f"bearer token, or set {TOKEN_ENV}; required "
-                             "unless --no-auth")
+    parser.add_argument("--auth-key",
+                        help="pre-shared GM key typed on the OAuth consent "
+                             f"page, or set {KEY_ENV}; required unless "
+                             "--no-auth")
+    parser.add_argument("--public-host",
+                        help="public hostname the tunnel serves this host "
+                             "as; the OAuth issuer becomes https://HOST "
+                             "(default: the local bind address)")
     parser.add_argument("--no-auth", action="store_true",
                         help="serve with no authentication — local testing "
                              "only; everything served is GM-only material")
@@ -191,28 +173,46 @@ def main(argv: list[str] | None = None) -> int:
         print(exc, file=sys.stderr)
         return 1
 
-    token = (args.token or os.environ.get(TOKEN_ENV, "")).strip()
-    if not token and not args.no_auth:
-        print("refusing to start without auth: pass --token, set "
-              f"{TOKEN_ENV}, or (local testing only) pass --no-auth",
+    key = (args.auth_key or os.environ.get(KEY_ENV, "")).strip()
+    if key and args.no_auth:
+        print(f"--no-auth contradicts --auth-key/{KEY_ENV}; pick one",
+              file=sys.stderr)
+        return 1
+    if not key and not args.no_auth:
+        print("refusing to start without auth: pass --auth-key, set "
+              f"{KEY_ENV}, or (local testing only) pass --no-auth",
               file=sys.stderr)
         return 1
 
+    # Issue #46 will also plumb --public-host into transport_security;
+    # here it only names the OAuth issuer.
+    issuer = (f"https://{args.public_host}" if args.public_host
+              else f"http://127.0.0.1:{args.port}")
+
     try:
         import uvicorn
+
+        oauth = None
+        if key:
+            from bunnyforge._mcp_auth import (SingleUserOAuthProvider,
+                                              default_state_path)
+            oauth = SingleUserOAuthProvider(
+                gm_key=key, issuer_url=issuer,
+                state_path=default_state_path())
         server = build_server(WorkspaceStore(ws),
-                              allow_direct_edits=args.allow_direct_edits)
+                              allow_direct_edits=args.allow_direct_edits,
+                              oauth=oauth)
     except ModuleNotFoundError:
         print(_INSTALL_HINT, file=sys.stderr)
         return 1
 
     app = server.streamable_http_app(stateless_http=True)
-    if token:
-        app = _BearerAuth(app, token)
-    else:
+    if not key:
         print("WARNING: serving with no authentication", file=sys.stderr)
 
-    print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp")
+    print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp "
+          f"(OAuth issuer: {issuer})" if key else
+          f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp")
     uvicorn.run(app, host=args.host, port=args.port)
     return 0
 

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -234,3 +234,67 @@ class TestConsentAndTokens(unittest.IsolatedAsyncioTestCase):
         await self.provider.revoke_token(at)
         self.assertIsNone(
             await self.provider.load_access_token(tokens.access_token))
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestConsentEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url="http://127.0.0.1:8000",
+            state_path=root / "state.json")
+        endpoint = _mcp_auth.consent_endpoint(self.provider, "Testmere")
+        app = Starlette(routes=[
+            Route("/consent", endpoint, methods=["GET", "POST"])])
+        self.client = TestClient(app, follow_redirects=False)
+        self.enterContext(
+            mock.patch("bunnyforge._mcp_auth._KEY_DELAY", 0))
+
+    def _txn(self):
+        import asyncio
+        record = client_record("c1")
+        asyncio.run(self.provider.register_client(record))
+        url = asyncio.run(self.provider.authorize(record, auth_params()))
+        return url.split("txn=")[1]
+
+    def test_get_unknown_txn_is_400_with_recovery_text(self):
+        resp = self.client.get("/consent", params={"txn": "bogus"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("claude.ai", resp.text)
+        self.assertEqual(resp.headers["cache-control"], "no-store")
+
+    def test_get_renders_form_naming_client_and_campaign(self):
+        resp = self.client.get("/consent", params={"txn": self._txn()})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Claude", resp.text)
+        self.assertIn("Testmere", resp.text)
+        self.assertIn('name="key"', resp.text)
+        self.assertEqual(resp.headers["cache-control"], "no-store")
+
+    def test_post_wrong_key_rerenders_and_mints_nothing(self):
+        txn = self._txn()
+        resp = self.client.post("/consent",
+                                data={"txn": txn, "key": "wrong"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("try again", resp.text.lower())
+        self.assertEqual(self.provider._codes, {})
+        # the txn survives a wrong key: the GM can retry
+        self.assertIsNotNone(self.provider.consent_context(txn))
+
+    def test_post_right_key_redirects_with_code_and_state(self):
+        resp = self.client.post(
+            "/consent", data={"txn": self._txn(), "key": "sekrit"})
+        self.assertEqual(resp.status_code, 302)
+        location = resp.headers["location"]
+        self.assertTrue(location.startswith("http://localhost:9999/cb?"))
+        self.assertIn("code=", location)
+        self.assertIn("state=st8", location)
+
+    def test_post_dead_txn_is_400(self):
+        resp = self.client.post("/consent",
+                                data={"txn": "bogus", "key": "sekrit"})
+        self.assertEqual(resp.status_code, 400)

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -119,8 +119,9 @@ class TestConsentAndTokens(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             url.startswith("http://127.0.0.1:8000/consent?txn="), url)
         txn = url.split("txn=")[1]
-        self.assertEqual(self.provider.consent_context(txn),
-                         {"client_name": "Claude"})
+        self.assertEqual(
+            self.provider.consent_context(txn),
+            {"client_name": "Claude", "redirect_host": "localhost:9999"})
 
     async def test_consent_context_unknown_or_expired_is_none(self):
         client = await self._register()
@@ -274,6 +275,13 @@ class TestConsentEndpoint(unittest.TestCase):
         self.assertIn("Testmere", resp.text)
         self.assertIn('name="key"', resp.text)
         self.assertEqual(resp.headers["cache-control"], "no-store")
+
+    def test_get_renders_the_redirect_targets_host(self):
+        # client_record()'s redirect_uri is http://localhost:9999/cb; the
+        # GM should see that host so they can tell it apart from an
+        # attacker-registered client pointing somewhere unfamiliar.
+        resp = self.client.get("/consent", params={"txn": self._txn()})
+        self.assertIn("localhost:9999", resp.text)
 
     def test_post_wrong_key_rerenders_and_mints_nothing(self):
         txn = self._txn()

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -3,6 +3,7 @@ import json
 import os
 import stat
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -88,3 +89,148 @@ class TestDefaultStatePath(unittest.TestCase):
             self.assertEqual(
                 _mcp_auth.default_state_path(),
                 Path.home() / ".local/state/bunnyforge/mcp-oauth-state.json")
+
+
+def auth_params():
+    from mcp.server.auth.provider import AuthorizationParams
+    return AuthorizationParams(
+        state="st8", scopes=[], code_challenge="chal",
+        redirect_uri="http://localhost:9999/cb",
+        redirect_uri_provided_explicitly=True)
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestConsentAndTokens(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url="http://127.0.0.1:8000",
+            state_path=root / "state.json")
+
+    async def _register(self, cid="c1"):
+        record = client_record(cid)
+        await self.provider.register_client(record)
+        return record
+
+    async def test_authorize_parks_txn_and_points_at_consent(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        self.assertTrue(
+            url.startswith("http://127.0.0.1:8000/consent?txn="), url)
+        txn = url.split("txn=")[1]
+        self.assertEqual(self.provider.consent_context(txn),
+                         {"client_name": "Claude"})
+
+    async def test_consent_context_unknown_or_expired_is_none(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        txn = url.split("txn=")[1]
+        self.assertIsNone(self.provider.consent_context("bogus"))
+        future = time.time() + _mcp_auth.TXN_TTL + 1
+        with mock.patch("bunnyforge._mcp_auth.time.time",
+                        return_value=future):
+            self.assertIsNone(self.provider.consent_context(txn))
+
+    def test_check_key_right_wrong_and_near_miss(self):
+        self.assertTrue(self.provider.check_key("sekrit"))
+        self.assertFalse(self.provider.check_key("wrong"))
+        self.assertFalse(self.provider.check_key("sek"))
+        self.assertFalse(self.provider.check_key(""))
+
+    async def test_grant_consumes_txn_and_mints_single_use_code(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        txn = url.split("txn=")[1]
+        redirect = self.provider.grant(txn)
+        self.assertIn("code=", redirect)
+        self.assertIn("state=st8", redirect)
+        self.assertTrue(redirect.startswith("http://localhost:9999/cb?"))
+        self.assertIsNone(self.provider.grant(txn))  # consumed
+
+    async def _grant_code(self, client):
+        url = await self.provider.authorize(client, auth_params())
+        redirect = self.provider.grant(url.split("txn=")[1])
+        code = redirect.split("code=")[1].split("&")[0]
+        return await self.provider.load_authorization_code(client, code)
+
+    async def test_code_exchange_and_replay(self):
+        from mcp.server.auth.provider import TokenError
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        self.assertEqual(auth_code.code_challenge, "chal")
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        self.assertEqual(tokens.token_type, "Bearer")
+        self.assertEqual(tokens.expires_in, _mcp_auth.ACCESS_TTL)
+        with self.assertRaises(TokenError):
+            await self.provider.exchange_authorization_code(client, auth_code)
+
+    async def test_code_expires(self):
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        future = time.time() + _mcp_auth.CODE_TTL + 1
+        with mock.patch("bunnyforge._mcp_auth.time.time",
+                        return_value=future):
+            self.assertIsNone(await self.provider.load_authorization_code(
+                client, auth_code.code))
+
+    async def test_wrong_client_cannot_load_anothers_code(self):
+        client = await self._register()
+        other = await self._register("c2")
+        auth_code = await self._grant_code(client)
+        self.assertIsNone(await self.provider.load_authorization_code(
+            other, auth_code.code))
+
+    async def test_access_token_verifies_then_expires(self):
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        at = await self.provider.load_access_token(tokens.access_token)
+        self.assertEqual(at.client_id, "c1")
+        future = time.time() + _mcp_auth.ACCESS_TTL + 1
+        with mock.patch("bunnyforge._mcp_auth.time.time",
+                        return_value=future):
+            self.assertIsNone(await self.provider.load_access_token(
+                tokens.access_token))
+
+    async def test_refresh_rotates(self):
+        from mcp.server.auth.provider import TokenError
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        first = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        rt = await self.provider.load_refresh_token(
+            client, first.refresh_token)
+        second = await self.provider.exchange_refresh_token(client, rt, [])
+        self.assertNotEqual(first.refresh_token, second.refresh_token)
+        # the old refresh token died with the rotation
+        self.assertIsNone(await self.provider.load_refresh_token(
+            client, first.refresh_token))
+        with self.assertRaises(TokenError):
+            await self.provider.exchange_refresh_token(client, rt, [])
+
+    async def test_tokens_survive_restart_but_txns_do_not(self):
+        client = await self._register()
+        url = await self.provider.authorize(client, auth_params())
+        txn = url.split("txn=")[1]
+        auth_code = await self._grant_code(client)
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        reborn = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url="http://127.0.0.1:8000",
+            state_path=self.provider._state_path)
+        self.assertIsNotNone(
+            await reborn.load_access_token(tokens.access_token))
+        self.assertIsNone(reborn.consent_context(txn))
+
+    async def test_revoke_deletes(self):
+        client = await self._register()
+        auth_code = await self._grant_code(client)
+        tokens = await self.provider.exchange_authorization_code(
+            client, auth_code)
+        at = await self.provider.load_access_token(tokens.access_token)
+        await self.provider.revoke_token(at)
+        self.assertIsNone(
+            await self.provider.load_access_token(tokens.access_token))

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -298,3 +298,168 @@ class TestConsentEndpoint(unittest.TestCase):
         resp = self.client.post("/consent",
                                 data={"txn": "bogus", "key": "sekrit"})
         self.assertEqual(resp.status_code, 400)
+
+
+def scaffold_store(case: unittest.TestCase):
+    """Minimal workspace, same shape as test_serve_mcp.scaffold."""
+    from bunnyforge import _config, _store
+    root = Path(case.enterContext(tempfile.TemporaryDirectory()))
+    (root / "campaign.toml").write_text(
+        '[campaign]\nnamespace = "testwiki"\nname = "Testmere"\n',
+        encoding="utf-8")
+    (root / "NPCs").mkdir()
+    return _store.WorkspaceStore(_config.open_workspace(root))
+
+
+def pkce_pair():
+    import base64
+    import hashlib
+    verifier = "v" * 43
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestOAuthOverHTTP(unittest.TestCase):
+    """The discovery sequence from issue #42, now ending in tokens."""
+
+    ISSUER = "http://127.0.0.1:8000"
+
+    def setUp(self):
+        from starlette.testclient import TestClient
+        from bunnyforge import serve_mcp
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url=self.ISSUER,
+            state_path=root / "state.json")
+        server = serve_mcp.build_server(scaffold_store(self),
+                                        oauth=self.provider)
+        app = server.streamable_http_app(stateless_http=True)
+        self.client = self.enterContext(
+            TestClient(app, base_url=self.ISSUER, follow_redirects=False))
+        self.enterContext(
+            mock.patch("bunnyforge._mcp_auth._KEY_DELAY", 0))
+
+    def test_discovery_documents_are_public(self):
+        for path in ("/.well-known/oauth-authorization-server",
+                     "/.well-known/oauth-protected-resource/mcp"):
+            resp = self.client.get(path)
+            self.assertEqual(resp.status_code, 200, path)
+        meta = self.client.get(
+            "/.well-known/oauth-authorization-server").json()
+        self.assertEqual(meta["issuer"].rstrip("/"), self.ISSUER)
+        self.assertTrue(meta["registration_endpoint"].endswith("/register"))
+
+    def test_mcp_without_token_is_401_pointing_at_metadata(self):
+        resp = self.client.post("/mcp", json={})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("resource_metadata",
+                      resp.headers.get("www-authenticate", ""))
+
+    def test_full_flow_register_to_authenticated_mcp(self):
+        # 1. Dynamic Client Registration (blank form fields in claude.ai)
+        reg = self.client.post("/register", json={
+            "client_name": "Claude",
+            "redirect_uris": ["http://localhost:9999/cb"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        })
+        self.assertEqual(reg.status_code, 201, reg.text)
+        info = reg.json()
+
+        # 2. Authorize → 302 to the consent page
+        verifier, challenge = pkce_pair()
+        auth = self.client.get("/authorize", params={
+            "client_id": info["client_id"],
+            "response_type": "code",
+            "redirect_uri": "http://localhost:9999/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "st8",
+        })
+        self.assertEqual(auth.status_code, 302, auth.text)
+        consent_url = auth.headers["location"]
+        self.assertIn("/consent?txn=", consent_url)
+
+        # 3. GM types the key on the consent page
+        self.assertEqual(self.client.get(consent_url).status_code, 200)
+        txn = consent_url.split("txn=")[1]
+        granted = self.client.post(
+            "/consent", data={"txn": txn, "key": "sekrit"})
+        self.assertEqual(granted.status_code, 302)
+        code = granted.headers["location"].split("code=")[1].split("&")[0]
+
+        # 4. Code + PKCE verifier + minted client secret → tokens
+        tok = self.client.post("/token", data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "http://localhost:9999/cb",
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+            "code_verifier": verifier,
+        })
+        self.assertEqual(tok.status_code, 200, tok.text)
+        tokens = tok.json()
+
+        # 5. The bearer token opens /mcp (anything but 401 proves auth;
+        #    protocol-level responses are the SDK's business)
+        resp = self.client.post(
+            "/mcp", json={},
+            headers={"Authorization": f"Bearer {tokens['access_token']}"})
+        self.assertNotEqual(resp.status_code, 401)
+
+        # 6. Refresh rotates
+        ref = self.client.post("/token", data={
+            "grant_type": "refresh_token",
+            "refresh_token": tokens["refresh_token"],
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+        })
+        self.assertEqual(ref.status_code, 200, ref.text)
+        self.assertNotEqual(ref.json()["refresh_token"],
+                            tokens["refresh_token"])
+        replay = self.client.post("/token", data={
+            "grant_type": "refresh_token",
+            "refresh_token": tokens["refresh_token"],
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+        })
+        self.assertEqual(replay.status_code, 400)
+
+    def test_wrong_pkce_verifier_is_rejected(self):
+        reg = self.client.post("/register", json={
+            "client_name": "Claude",
+            "redirect_uris": ["http://localhost:9999/cb"],
+        }).json()
+        _, challenge = pkce_pair()
+        auth = self.client.get("/authorize", params={
+            "client_id": reg["client_id"], "response_type": "code",
+            "redirect_uri": "http://localhost:9999/cb",
+            "code_challenge": challenge, "code_challenge_method": "S256",
+        })
+        txn = auth.headers["location"].split("txn=")[1]
+        granted = self.client.post(
+            "/consent", data={"txn": txn, "key": "sekrit"})
+        code = granted.headers["location"].split("code=")[1].split("&")[0]
+        tok = self.client.post("/token", data={
+            "grant_type": "authorization_code", "code": code,
+            "redirect_uri": "http://localhost:9999/cb",
+            "client_id": reg["client_id"],
+            "client_secret": reg["client_secret"],
+            "code_verifier": "x" * 43,
+        })
+        self.assertEqual(tok.status_code, 400)
+
+    def test_no_oauth_means_no_auth_routes_and_open_mcp(self):
+        from starlette.testclient import TestClient
+        from bunnyforge import serve_mcp
+        server = serve_mcp.build_server(scaffold_store(self))
+        app = server.streamable_http_app(stateless_http=True)
+        with TestClient(app, base_url=self.ISSUER,
+                        follow_redirects=False) as client:
+            self.assertEqual(
+                client.get("/.well-known/oauth-authorization-server")
+                .status_code, 404)
+            self.assertNotEqual(client.post("/mcp", json={})
+                                .status_code, 401)

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# The MCP SDK is an optional extra; _mcp_auth imports it at module top, so
+# every test here skips on a bare Python, matching test_serve_mcp.py.
+HAVE_MCP = importlib.util.find_spec("mcp") is not None
+if HAVE_MCP:
+    from bunnyforge import _mcp_auth
+    from bunnyforge._mcp_auth import SingleUserOAuthProvider
+
+
+def client_record(client_id: str):
+    from mcp.shared.auth import OAuthClientInformationFull
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret="s3cret",
+        client_name="Claude",
+        redirect_uris=["http://localhost:9999/cb"],
+    )
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestClientRegistry(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.state = root / "state" / "mcp-oauth-state.json"
+        self.provider = SingleUserOAuthProvider(
+            gm_key="k", issuer_url="http://127.0.0.1:8000/",
+            state_path=self.state)
+
+    def test_issuer_url_is_rstripped(self):
+        self.assertEqual(self.provider.issuer_url, "http://127.0.0.1:8000")
+
+    async def test_register_then_get_roundtrips(self):
+        await self.provider.register_client(client_record("c1"))
+        got = await self.provider.get_client("c1")
+        self.assertEqual(got.client_name, "Claude")
+        self.assertIsNone(await self.provider.get_client("nope"))
+
+    async def test_registration_capped_evicts_oldest(self):
+        for i in range(_mcp_auth.MAX_CLIENTS + 1):
+            await self.provider.register_client(client_record(f"c{i}"))
+        self.assertIsNone(await self.provider.get_client("c0"))
+        self.assertIsNotNone(await self.provider.get_client("c1"))
+        self.assertEqual(len(self.provider._clients), _mcp_auth.MAX_CLIENTS)
+
+    async def test_state_file_is_0600_and_survives_restart(self):
+        await self.provider.register_client(client_record("c1"))
+        mode = stat.S_IMODE(os.stat(self.state).st_mode)
+        self.assertEqual(mode, 0o600)
+        reborn = SingleUserOAuthProvider(
+            gm_key="k", issuer_url="http://127.0.0.1:8000",
+            state_path=self.state)
+        got = await reborn.get_client("c1")
+        self.assertEqual(got.client_secret, "s3cret")
+
+    async def test_corrupt_state_file_starts_empty_not_crashed(self):
+        self.state.parent.mkdir(parents=True)
+        self.state.write_text("{not json", encoding="utf-8")
+        with mock.patch("sys.stderr"):
+            provider = SingleUserOAuthProvider(
+                gm_key="k", issuer_url="http://127.0.0.1:8000",
+                state_path=self.state)
+        self.assertIsNone(await provider.get_client("c1"))
+        # first successful save replaces the corrupt file
+        await provider.register_client(client_record("c1"))
+        json.loads(self.state.read_text(encoding="utf-8"))
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestDefaultStatePath(unittest.TestCase):
+
+    def test_honours_xdg_state_home(self):
+        with mock.patch.dict(os.environ, {"XDG_STATE_HOME": "/x/state"}):
+            self.assertEqual(_mcp_auth.default_state_path(),
+                             Path("/x/state/bunnyforge/mcp-oauth-state.json"))
+
+    def test_defaults_under_home(self):
+        with mock.patch.dict(os.environ, clear=False) as env:
+            os.environ.pop("XDG_STATE_HOME", None)
+            self.assertEqual(
+                _mcp_auth.default_state_path(),
+                Path.home() / ".local/state/bunnyforge/mcp-oauth-state.json")

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -354,8 +354,17 @@ class TestOAuthOverHTTP(unittest.TestCase):
     def test_mcp_without_token_is_401_pointing_at_metadata(self):
         resp = self.client.post("/mcp", json={})
         self.assertEqual(resp.status_code, 401)
-        self.assertIn("resource_metadata",
-                      resp.headers.get("www-authenticate", ""))
+        www_auth = resp.headers.get("www-authenticate", "")
+        self.assertIn("resource_metadata", www_auth)
+        self.assertIn(
+            f"{self.ISSUER}/.well-known/oauth-protected-resource/mcp",
+            www_auth)
+
+    def test_mcp_with_bad_token_is_401(self):
+        resp = self.client.post(
+            "/mcp", json={},
+            headers={"Authorization": "Bearer not-a-real-token"})
+        self.assertEqual(resp.status_code, 401)
 
     def test_full_flow_register_to_authenticated_mcp(self):
         # 1. Dynamic Client Registration (blank form fields in claude.ai)
@@ -458,8 +467,9 @@ class TestOAuthOverHTTP(unittest.TestCase):
         app = server.streamable_http_app(stateless_http=True)
         with TestClient(app, base_url=self.ISSUER,
                         follow_redirects=False) as client:
-            self.assertEqual(
-                client.get("/.well-known/oauth-authorization-server")
-                .status_code, 404)
+            for path in ("/.well-known/oauth-authorization-server",
+                        "/.well-known/oauth-protected-resource/mcp",
+                        "/register", "/authorize", "/token", "/consent"):
+                self.assertEqual(client.get(path).status_code, 404, path)
             self.assertNotEqual(client.post("/mcp", json={})
                                 .status_code, 401)

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -1,4 +1,7 @@
+import contextlib
 import importlib.util
+import io
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -31,70 +34,6 @@ def scaffold(case: unittest.TestCase) -> _store.WorkspaceStore:
     return _store.WorkspaceStore(_config.open_workspace(root))
 
 
-class TestBearerAuth(unittest.IsolatedAsyncioTestCase):
-    """Pure ASGI, so this runs without the mcp extra installed."""
-
-    async def _call(self, auth, headers):
-        sent = []
-
-        async def send(message):
-            sent.append(message)
-
-        await auth({"type": "http", "headers": headers}, None, send)
-        return sent
-
-    async def test_missing_token_is_401_and_never_reaches_the_app(self):
-        async def inner(scope, receive, send):
-            raise AssertionError("unauthenticated request reached the app")
-
-        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"), [])
-        self.assertEqual(sent[0]["status"], 401)
-
-    async def test_wrong_token_is_401(self):
-        async def inner(scope, receive, send):
-            raise AssertionError("unauthenticated request reached the app")
-
-        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
-                                [(b"authorization", b"Bearer wrong")])
-        self.assertEqual(sent[0]["status"], 401)
-
-    async def test_near_miss_token_is_401(self):
-        # A prefix of the real token must not pass: the comparison is of the
-        # whole header value, not a startswith.
-        async def inner(scope, receive, send):
-            raise AssertionError("unauthenticated request reached the app")
-
-        sent = await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
-                                [(b"authorization", b"Bearer sek")])
-        self.assertEqual(sent[0]["status"], 401)
-
-    async def test_right_token_passes_through(self):
-        seen = []
-
-        async def inner(scope, receive, send):
-            seen.append(scope)
-
-        await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
-                         [(b"authorization", b"Bearer sekrit")])
-        self.assertEqual(len(seen), 1)
-
-    async def test_non_http_scope_passes_through_untouched(self):
-        # Lifespan events carry no headers and must not be answered with 401,
-        # or the app never starts.
-        seen = []
-
-        async def inner(scope, receive, send):
-            seen.append(scope)
-
-        await self._call(serve_mcp._BearerAuth(inner, "sekrit"),
-                         [])  # headers ignored for a lifespan scope
-        self.assertEqual(len(seen), 0)  # the http scope above was rejected
-
-        auth = serve_mcp._BearerAuth(inner, "sekrit")
-        await auth({"type": "lifespan"}, None, None)
-        self.assertEqual(len(seen), 1)
-
-
 class TestMainGuards(unittest.TestCase):
     """argparse and the refusals — no mcp extra needed for any of these."""
 
@@ -108,15 +47,51 @@ class TestMainGuards(unittest.TestCase):
             serve_mcp.main(["--help"])
         self.assertEqual(ctx.exception.code, 0)
 
-    def test_refuses_to_start_without_token_or_no_auth(self):
-        # A token in the invoking environment must not leak into the test.
-        with mock.patch.dict("os.environ", {serve_mcp.TOKEN_ENV: ""}):
-            self.assertEqual(
-                serve_mcp.main(["--workspace", str(self._ws())]), 1)
-
     def test_bad_workspace_is_one_error_line_not_a_traceback(self):
         empty = Path(self.enterContext(tempfile.TemporaryDirectory()))
         self.assertEqual(serve_mcp.main(["--workspace", str(empty)]), 1)
+
+
+class TestStartupContract(unittest.TestCase):
+    """Default-deny: the spec's startup matrix, refusal rows.
+
+    These run on bare Python: every refusal fires before the SDK import.
+    """
+
+    def setUp(self):
+        store = scaffold(self)
+        self.ws_args = ["--workspace", str(store.ws.root)]
+        self.enterContext(mock.patch.dict(
+            os.environ, {"BUNNYFORGE_MCP_KEY": ""}))
+
+    def _main(self, extra):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = serve_mcp.main(self.ws_args + extra)
+        return rc, stderr.getvalue()
+
+    def test_refuses_without_key_or_no_auth(self):
+        rc, err = self._main([])
+        self.assertEqual(rc, 1)
+        self.assertIn("--auth-key", err)
+        self.assertIn("BUNNYFORGE_MCP_KEY", err)
+        self.assertIn("--no-auth", err)
+
+    def test_refuses_key_and_no_auth_together(self):
+        rc, err = self._main(["--auth-key", "k", "--no-auth"])
+        self.assertEqual(rc, 1)
+        self.assertIn("contradict", err)
+
+    def test_env_key_counts_as_key_for_the_contradiction(self):
+        with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "k"}):
+            rc, err = self._main(["--no-auth"])
+        self.assertEqual(rc, 1)
+        self.assertIn("contradict", err)
+
+    def test_token_flag_is_gone(self):
+        with self.assertRaises(SystemExit):
+            with contextlib.redirect_stderr(io.StringIO()):
+                serve_mcp.build_parser().parse_args(["--token", "t"])
 
 
 @unittest.skipUnless(HAVE_MCP, "mcp extra not installed")
@@ -192,11 +167,10 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         uris = {str(r.uri) for r in await server.list_resources()}
         self.assertNotIn("bunnyforge://doctrine/situation-design.md", uris)
 
-    async def test_streamable_app_is_asgi_and_wrappable(self):
+    async def test_streamable_app_is_asgi(self):
         server = serve_mcp.build_server(scaffold(self))
         app = server.streamable_http_app(stateless_http=True)
         self.assertTrue(callable(app))
-        self.assertTrue(callable(serve_mcp._BearerAuth(app, "t")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> ## ⚠️ STACKED PR — DO NOT MERGE UNTIL THE BASE IS `main`
>
> **This PR's base is `docs/serve-mcp-oauth-design`, not `main`.**
>
> That branch holds the spec and plan this work implements. It is pushed but
> has **no PR of its own**, so it cannot merge yet. Per AGENTS.md, merging a
> stacked PR before its base has actually become `main` lands the commits on
> the *base branch* and strands the work off `main` — GitHub still says
> "Merged".
>
> **Recommended order:**
> 1. Open and merge a PR for `docs/serve-mcp-oauth-design` → `main`.
> 2. Retarget this PR to `main` (and rebase).
> 3. Only then merge this one, and verify `main` actually contains the change.
>
> If you would rather not ship the spec/plan separately, retarget this PR to
> `main` now — the branch contains those two doc commits already, so nothing
> is lost, the diff just grows by them.

Implements `docs/superpowers/plans/2026-08-16-serve-mcp-oauth.md` against
`docs/superpowers/specs/2026-08-16-serve-mcp-oauth-design.md`. Closes the
gap found in #42.

## Why

Testing the real claude.ai custom-connector form over a live tunnel (#42)
disproved phase 1's assumption that it would carry a static bearer token.
The form offers only **OAuth Client ID / Client Secret** and no custom-header
field, and with both blank claude.ai walks the standard discovery sequence
(`/.well-known/oauth-protected-resource/mcp` →
`/.well-known/oauth-authorization-server` → `POST /register`) and gives up
when every probe 401s.

`_BearerAuth` was not merely missing a feature — it was structurally
incompatible. It wraps the whole ASGI app and 401s everything without a
token, but OAuth bootstrap is by definition unauthenticated: a client cannot
present a token before discovering how to obtain one.

So `bunnyforge serve-mcp` now runs the smallest OAuth authorization server
that satisfies the connector. The SDK's handlers do every protocol step
(registration, authorize, token, PKCE, redirect validation). The one identity
decision bunnyforge owns is a consent page where the GM types a pre-shared key.

## Files changed

| file | |
|---|---|
| `src/bunnyforge/_mcp_auth.py` | **(new)** the provider, consent page, and state persistence |
| `tests/test_mcp_auth.py` | **(new)** 30 tests: provider units + full OAuth-over-HTTP |
| `docs/serve-mcp.md` | **(new)** operator guide for connector setup |
| `src/bunnyforge/serve_mcp.py` | (modified) `build_server` takes `oauth=`; CLI rewritten; `_BearerAuth` **deleted** |
| `tests/test_serve_mcp.py` | (modified) `TestBearerAuth` deleted, startup-contract tests rewritten |
| `.github/workflows/tests.yml` | (modified) new additive `mcp-suite` job — see Operational impact |
| `docs/superpowers/specs/2026-08-16-serve-mcp-design.md` | (modified) supersession pointer only |

## Work breakdown

1. **Provider skeleton** — `SingleUserOAuthProvider` over four in-process
   dicts, with clients and tokens persisted to a `0600` JSON state file
   (atomic write, parent dirs `0700`). Registration is capped at 32 with
   oldest-eviction, since `/register` is public by RFC 7591.
2. **Consent transactions, codes, tokens** — the rest of the nine-method
   provider contract. Codes are single-use and client-bound; refresh tokens
   rotate; all identifiers are `secrets.token_urlsafe(32)` looked up
   server-side. No JWTs, so no signing keys to rotate or leak.
3. **The consent page** — `GET/POST /consent`, inline HTML, `no-store`,
   constant-time key comparison, delayed re-render on a wrong key. A wrong key
   does *not* consume the transaction, so the GM can retry.
4. **SDK wiring** — `MCPServer` receives the provider plus `AuthSettings`;
   it mounts the bootstrap routes publicly and guards `/mcp` itself. The
   provider is passed *alone* deliberately: supplying a `token_verifier` too
   raises `ValueError`, and the SDK wraps the provider in its own
   `ProviderTokenVerifier`.
5. **CLI** — `--auth-key` / `BUNNYFORGE_MCP_KEY` replace `--token` /
   `BUNNYFORGE_MCP_TOKEN`; `--public-host` added; `--no-auth` kept;
   `_BearerAuth` deleted. Default-deny is preserved: no key and no explicit
   `--no-auth` still refuses to start.
6. **Docs** — operator guide; every claim in it was traced back to the code
   rather than to the plan.

### Beyond the plan

Three changes were made that the plan did not specify. Each is called out
here because they are mine, not the plan's:

- **A consent-page hardening.** `/register` is public, so anyone who learns
  the tunnel hostname can register a client named "Claude" with their *own*
  redirect URI and send the GM the consent link; the SDK's redirect validation
  checks against the attacker's own registered URIs and so raises no
  objection. The design knowingly rejected phishing-resistant login as
  disproportionate for one user, so no login flow was added — but the consent
  page now **names the host the access code would be sent to**, so the GM's
  one decision is an informed one. The docs gained a matching caution.
- **The `mcp-suite` CI job** (see Operational impact).
- **Two plan defects fixed in passing**: the plan missed a third
  `_BearerAuth` reference in `TestBuildServer`, and wrongly claimed `os` was
  already imported in `tests/test_serve_mcp.py`. Both would have broken the
  suite.

## Test expectations

No failures expected. `771 tests, OK` both with the `[mcp]` extra (4 skips)
and on a bare Python with none of it (40 skips), verified in a **fresh
worktree with a fresh venv**, not just in the working tree.

The full OAuth flow was also driven against a **real uvicorn server** — a
path the unittest suite never exercises, since it only ever uses Starlette's
`TestClient`: DCR with blank ID/secret → 201; `/authorize` → 302 to consent;
consent page names client and campaign; wrong key re-renders and mints
nothing; right key → 302 with `code` + `state`; `/token` with a PKCE S256
verifier → tokens; `/mcp initialize` with the token → 200; refresh rotates;
replaying the old refresh token → 400. Unauthenticated, `/mcp` 401s with a
`WWW-Authenticate` naming the correct `resource_metadata` URL, and a bogus
token 401s too. The state file landed `0600` outside any repo.

## Operational impact

- **Breaking: `--token` and `BUNNYFORGE_MCP_TOKEN` are gone**, with no
  aliases. Use `--auth-key` / `BUNNYFORGE_MCP_KEY`. The design argues the
  rename is the point: the GM key is *not* a bearer token — it is never sent
  by the MCP client, it is typed into a form once per grant — and keeping the
  old name would preserve the wrong mental model. Anyone with the old env var
  exported will hit the default-deny refusal, which names the new spelling.
- **New state file** at `$XDG_STATE_HOME/bunnyforge/mcp-oauth-state.json`
  (default `~/.local/state/…`), mode `0600`, outside every git repo by
  construction. It holds registered clients and live tokens. Deleting it and
  restarting is the documented "log everyone out" move.
- **New CI job `mcp-suite`.** The existing `suite` matrix installs *without*
  the `[mcp]` extra, so every one of this branch's OAuth tests would have been
  `HAVE_MCP`-skipped in CI — 40 skipped on bare Python vs 4 with the extra, so
  36 tests that never run. The new job installs `.[mcp]` on 3.13 and runs the
  suite. It is **additive**: the `suite` job and its `3.11/3.12/3.13` matrix
  are byte-identical, so the required check names branch protection depends on
  are untouched. **You may want to add `mcp-suite` to the required checks.**
- **Coordination with #47.** That PR (open, from a fork) also adds
  `--public-host`, for issue #46's DNS-rebinding fix. The spec anticipated the
  collision — "whichever lands first defines it, the other consumes it". This
  branch defines the flag for **issuer derivation only** and leaves the
  `transport_security` plumbing to #46. If this merges first, #47 should
  rebase and consume the existing flag rather than re-adding it; the conflict
  is one `add_argument` plus folding its transport lines into `main()`.

### Live claude.ai smoke test: **deferred**

The tunnel + claude.ai connector leg needs the owner's Cloudflare and
claude.ai accounts, and is the part #46's 421 may block until that fix lands.
Everything *below* the tunnel was exercised against a real server (above), so
what remains unverified is specifically: the public HTTPS issuer through a
tunnel hostname, and claude.ai's own client behavior.

## Known trade-offs (reviewed, deliberately shipped)

- 32 unauthenticated `POST /register` calls evict claude.ai's client and force
  re-consent. The cap is what keeps a public endpoint's memory bounded; the
  trade is now noted in a code comment.
- Pending consent transactions have no cap analogous to `MAX_CLIENTS` —
  bounded only by request rate × 600 s, memory-only, cleared by a restart.
- Two concurrent `serve-mcp` processes sharing one state file would
  last-write-wins. Single-operator tool; not exercised.

## Provenance

- **Agent:** Claude Code (subagent-driven development — a fresh implementer
  per task, an independent reviewer after each, and a whole-branch review at
  the end)
- **Model / version:** the session transcript requested **Opus 5**; per
  AGENTS.md the running model cannot be observed from inside, so this records
  what was asked for rather than asserting what ran.
