### PR TITLE
serve-mcp: declare the tunnel hostname to DNS-rebinding protection (#46)

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -21,6 +21,11 @@ consent page in your own browser — it is never stored by claude.ai.
     cloudflared tunnel run <name>           # named tunnel, stable hostname
     bunnyforge serve-mcp --public-host <name>.example.com
 
+`--public-host` does two jobs, and behind a tunnel it is not optional:
+it anchors the OAuth issuer, and it declares the hostname to the
+server's DNS-rebinding protection. Omit it and every tunnelled request
+is refused with `421` before it reaches authentication.
+
 A **named tunnel** (free with a Cloudflare-managed domain) is the
 recommended recipe: the hostname — and therefore the connector URL in
 claude.ai and the OAuth trust it anchors — survives restarts. A quick
@@ -64,8 +69,10 @@ but not already-issued tokens — delete the state file for that.
 
 - **401 from `/mcp`:** no or expired token — reconnect from claude.ai.
 - **421 Invalid Host header through a tunnel:** DNS-rebinding protection
-  does not know your public hostname — issue #46 tracks the
-  `--public-host` transport fix.
+  does not know your public hostname. Pass `--public-host <hostname>` —
+  the same hostname the tunnel serves, with no scheme and no port. The
+  protection stays on and allows exactly that host, so a mismatch here
+  still shows as 421 rather than opening the server to any `Host`.
 - **"Couldn't register with sign-in service":** the server is not
   reachable at the connector URL, or it was started `--no-auth` (no OAuth
   routes exist in that mode).

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -164,6 +164,31 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def build_app(server, public_host: str | None = None):
+    """The ASGI app, told which hostname it is served as (#46).
+
+    The SDK enables DNS-rebinding protection by default and, given no
+    settings, allows only the bind address. Through a tunnel the `Host`
+    header carries the public hostname instead, so every request was
+    refused with `421 Invalid Host header` before it reached auth -- and
+    a tunnel is the only deployment the design describes.
+
+    The contract is "declare your hostname", not "turn the guard off":
+    protection stays ENABLED and only the named host is allowed, so an
+    undeclared Host is still refused. Without a public host the safe
+    localhost-only default is left exactly as it was.
+    """
+    if not public_host:
+        return server.streamable_http_app(stateless_http=True)
+    from mcp.server.transport_security import TransportSecuritySettings
+    return server.streamable_http_app(
+        stateless_http=True,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=[public_host],
+            allowed_origins=[f"https://{public_host}"]))
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
@@ -184,8 +209,8 @@ def main(argv: list[str] | None = None) -> int:
               file=sys.stderr)
         return 1
 
-    # Issue #46 will also plumb --public-host into transport_security;
-    # here it only names the OAuth issuer.
+    # --public-host does double duty: it names the OAuth issuer, and it
+    # declares the hostname to DNS-rebinding protection in build_app (#46).
     issuer = (f"https://{args.public_host}" if args.public_host
               else f"http://127.0.0.1:{args.port}")
 
@@ -206,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
         print(_INSTALL_HINT, file=sys.stderr)
         return 1
 
-    app = server.streamable_http_app(stateless_http=True)
+    app = build_app(server, public_host=args.public_host)
     if not key:
         print("WARNING: serving with no authentication", file=sys.stderr)
 

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -175,3 +175,40 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@unittest.skipUnless(HAVE_MCP, "mcp extra not installed")
+class TestTunnelHost(unittest.TestCase):
+    """Issue #46: the only deployment the design describes is through a
+    tunnel, and through one the `Host` header carries the public hostname
+    rather than the bind address. The SDK enables DNS-rebinding protection
+    by default and, given no settings, allows only the bind address -- so
+    every tunnelled request was rejected with 421 before it reached auth.
+
+    The contract is "declare your hostname", not "turn the guard off":
+    an undeclared host must still be refused.
+    """
+
+    HOST = "campaign.example.com"
+
+    def _client(self, **kwargs):
+        from starlette.testclient import TestClient
+        server = serve_mcp.build_server(scaffold(self))
+        app = serve_mcp.build_app(server, **kwargs)
+        return self.enterContext(
+            TestClient(app, base_url=f"https://{self.HOST}",
+                       follow_redirects=False))
+
+    def test_a_declared_public_host_is_served(self):
+        response = self._client(public_host=self.HOST).post("/mcp", json={})
+        self.assertNotEqual(
+            response.status_code, 421,
+            "a tunnel hostname passed as --public-host was still refused by "
+            "DNS-rebinding protection")
+
+    def test_an_undeclared_host_is_still_refused(self):
+        # The guard stays ON. If this ever passes, the fix has been
+        # implemented by disabling the protection rather than declaring
+        # the hostname, which would accept any Host on the public internet.
+        self.assertEqual(self._client().post("/mcp", json={}).status_code,
+                         421)


### PR DESCRIPTION
Closes #46.

Base branch: **`main`** (not stacked on anything).

## Files changed
- `src/bunnyforge/serve_mcp.py` (modified) — new `build_app()`; `main()` calls it; the stale `#46 will…` marker replaced.
- `tests/test_serve_mcp.py` (modified) — new `TestTunnelHost` (2 tests).
- `docs/serve-mcp.md` (modified) — the tunnel section and the 421 troubleshooting entry.

## Work breakdown

`bunnyforge serve-mcp` could not be reached through a tunnel, which is the only deployment the design describes. Every request came back `421 Invalid Host header` before it reached auth. The MCP SDK enables DNS-rebinding protection by default and, with no settings supplied, allows only the bind address — but a tunnel's `Host` header carries the public hostname. Every earlier test went to `127.0.0.1`, which is exactly the case that works.

#48 added `--public-host` to derive the OAuth issuer and left an explicit marker saying the transport-security half belonged to this issue. This plumbs it: `build_app()` passes `TransportSecuritySettings` naming the host, and `main()` calls it. The flag now does both jobs from one definition, as the OAuth design anticipated.

**The contract is "declare your hostname", not "turn the guard off".** Protection stays enabled and allows only the named host. That second property carries its own test, deliberately: a fix that simply disabled the protection would pass the first test while opening the server to any `Host` on the public internet, so the test asserts an undeclared host is *still* refused.

Without `--public-host`, the safe localhost-only default is untouched.

## Test expectations
None expected to fail.

## Verification

The symptom is HTTP-level, so the tests are too — `TestClient(app, base_url="https://campaign.example.com")` puts the tunnel hostname in the `Host` header, reproducing the reported condition rather than approximating it.

TDD, with the defect reproduced first: a `build_app` that ignored `public_host` (today's construction) was written so the test would fail on the **bug** rather than on a missing name —

```
AssertionError: 421 == 421 : a tunnel hostname passed as --public-host was
still refused by DNS-rebinding protection
```

— and the real implementation then turned it green.

- `python3 -m unittest discover -s tests -t .` **with** the `mcp` extra → **773 tests, OK** (was 771; +2).
- The same on a **bare** Python without the extra → **773, OK, 42 skips** (was 40), confirming the new class skips rather than fails where the SDK is absent.
- Both runs asserted `bunnyforge.__file__` pointed at this checkout before being trusted.
- `main()` verified separately to pass the flag through — spying on `build_app` while stubbing `uvicorn.run`, since the tests exercise `build_app` directly and that alone would not prove the command reaches it.
- Secret scan: clean.

**Not verified here:** the live tunnel + claude.ai leg, which needs the owner's Cloudflare and claude.ai accounts. That is the observation #42 is still waiting on, and this PR is what unblocks it.

## Operational impact
Behind a tunnel, `--public-host` is now required rather than merely recommended — without it the 421 persists, which is the pre-existing behaviour. `docs/serve-mcp.md` says so in both the recipe and the troubleshooting entry.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)