### PR TITLE
serve-mcp: cover the tunnelled OAuth configuration, and stop tests bypassing build_app

### DIFF
--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -343,7 +343,11 @@ class TestOAuthOverHTTP(unittest.TestCase):
             state_path=root / "state.json")
         server = serve_mcp.build_server(scaffold_store(self),
                                         oauth=self.provider)
-        app = server.streamable_http_app(stateless_http=True)
+        # Through build_app, as main() does. No public host here, so this
+        # is the localhost default -- the point is that these tests keep
+        # exercising the construction the command actually uses, rather
+        # than drifting from it. TestTunnelledOAuth covers the tunnel.
+        app = serve_mcp.build_app(server)
         self.client = self.enterContext(
             TestClient(app, base_url=self.ISSUER, follow_redirects=False))
         self.enterContext(
@@ -472,7 +476,7 @@ class TestOAuthOverHTTP(unittest.TestCase):
         from starlette.testclient import TestClient
         from bunnyforge import serve_mcp
         server = serve_mcp.build_server(scaffold_store(self))
-        app = server.streamable_http_app(stateless_http=True)
+        app = serve_mcp.build_app(server)
         with TestClient(app, base_url=self.ISSUER,
                         follow_redirects=False) as client:
             for path in ("/.well-known/oauth-authorization-server",
@@ -481,3 +485,151 @@ class TestOAuthOverHTTP(unittest.TestCase):
                 self.assertEqual(client.get(path).status_code, 404, path)
             self.assertNotEqual(client.post("/mcp", json={})
                                 .status_code, 401)
+
+
+@unittest.skipUnless(HAVE_MCP, "requires bunnyforge[mcp]")
+class TestTunnelledOAuth(unittest.TestCase):
+    """The configuration a GM actually runs, which nothing covered.
+
+    Behind a tunnel both halves are live at once: the OAuth server (#42)
+    and DNS-rebinding protection with a declared hostname (#46), on the
+    https issuer the tunnel provides. Each half is well covered alone --
+    TestOAuthOverHTTP builds its app with no transport security, and
+    test_serve_mcp's TestTunnelHost builds its app with no OAuth -- so
+    the one arrangement that ships was the one arrangement untested.
+
+    That matters because the place it would otherwise surface is a live
+    tunnel with a connector half-configured, which is the most expensive
+    place to find out.
+    """
+
+    HOST = "campaign.example.com"
+    ISSUER = f"https://{HOST}"
+
+    def setUp(self):
+        self.client = self.enterContext(self._client_for(self.ISSUER))
+        self.enterContext(mock.patch("bunnyforge._mcp_auth._KEY_DELAY", 0))
+
+    def _client_for(self, base_url):
+        """A client over a FRESH app, built exactly as main() builds it
+        behind a tunnel.
+
+        Fresh per call rather than shared: TestClient runs the app's
+        lifespan, and the SDK's session manager refuses a second run on
+        one instance -- so the foreign-host check needs its own app.
+        """
+        from starlette.testclient import TestClient
+        from bunnyforge import serve_mcp
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.provider = SingleUserOAuthProvider(
+            gm_key="sekrit", issuer_url=self.ISSUER,
+            state_path=root / "state.json")
+        server = serve_mcp.build_server(scaffold_store(self),
+                                        oauth=self.provider)
+        app = serve_mcp.build_app(server, public_host=self.HOST)
+        return TestClient(app, base_url=base_url, follow_redirects=False)
+
+    def _token_via_full_flow(self) -> str:
+        """Register → authorize → consent → token on the declared host,
+        asserting every step, and return the access token."""
+        reg = self.client.post("/register", json={
+            "client_name": "Claude",
+            "redirect_uris": ["http://localhost:9999/cb"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        })
+        self.assertEqual(reg.status_code, 201, reg.text)
+        info = reg.json()
+
+        verifier, challenge = pkce_pair()
+        auth = self.client.get("/authorize", params={
+            "client_id": info["client_id"],
+            "response_type": "code",
+            "redirect_uri": "http://localhost:9999/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "st8",
+        })
+        self.assertEqual(auth.status_code, 302, auth.text)
+        consent_url = auth.headers["location"]
+
+        self.assertEqual(self.client.get(consent_url).status_code, 200)
+        txn = consent_url.split("txn=")[1]
+        granted = self.client.post(
+            "/consent", data={"txn": txn, "key": "sekrit"})
+        self.assertEqual(granted.status_code, 302, granted.text)
+        code = granted.headers["location"].split("code=")[1].split("&")[0]
+
+        tok = self.client.post("/token", data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "http://localhost:9999/cb",
+            "client_id": info["client_id"],
+            "client_secret": info["client_secret"],
+            "code_verifier": verifier,
+        })
+        self.assertEqual(tok.status_code, 200, tok.text)
+        return tok.json()["access_token"]
+
+    def test_the_whole_flow_completes_on_the_tunnel_hostname(self):
+        resp = self.client.post(
+            "/mcp", json={},
+            headers={"Authorization": f"Bearer {self._token_via_full_flow()}"})
+        # Anything but 401/421 proves both layers passed it through;
+        # protocol-level responses are the SDK's business.
+        self.assertNotEqual(resp.status_code, 401, "auth rejected the token")
+        self.assertNotEqual(resp.status_code, 421,
+                            "the declared tunnel host was refused")
+
+    def test_the_issuer_advertised_is_the_tunnel_https_url(self):
+        # What claude.ai fetches first. If this said 127.0.0.1 the
+        # connector would walk off to an address it cannot reach.
+        meta = self.client.get(
+            "/.well-known/oauth-authorization-server").json()
+        self.assertEqual(meta["issuer"].rstrip("/"), self.ISSUER)
+        for key in ("registration_endpoint", "authorization_endpoint",
+                    "token_endpoint"):
+            self.assertTrue(meta[key].startswith(self.ISSUER + "/"),
+                            f"{key} points off the tunnel host: {meta[key]}")
+
+    def test_a_valid_token_from_a_foreign_host_is_still_refused(self):
+        """The security-relevant half, and the non-vacuity check.
+
+        Measured rather than assumed: with OAuth mounted, an
+        *unauthenticated* foreign-Host request to /mcp surfaces as 401,
+        because the auth middleware runs before the transport check. That
+        ordering makes 401 a useless probe here -- it would pass even if
+        DNS-rebinding protection had been switched off entirely.
+
+        So this presents a genuinely valid token, minted through the real
+        flow on the declared host, and asserts the foreign Host is refused
+        anyway. That is what proves the #46 guard still covers /mcp once
+        the #48 OAuth layer is in front of it.
+        """
+        token = self._token_via_full_flow()
+        auth = {"Authorization": f"Bearer {token}"}
+        served = self.client.post("/mcp", json={}, headers=auth)
+        self.assertNotEqual(served.status_code, 421,
+                            "the declared host should be served")
+        for foreign in ("evil.example.com", "127.0.0.1"):
+            with self.subTest(host=foreign):
+                self.assertEqual(
+                    self.client.post("/mcp", json={},
+                                     headers={**auth, "Host": foreign})
+                    .status_code, 421)
+
+    def test_discovery_stays_public_on_any_host(self):
+        # Deliberate, not an oversight: OAuth bootstrap is unauthenticated
+        # by definition and the SDK mounts it outside the transport
+        # wrapper, so discovery answers whatever Host asks. It carries no
+        # campaign data -- only the issuer URL a client needs before it
+        # can hold a token. Pinned so a future reader does not "harden"
+        # it and silently break the connector's first request.
+        for foreign in ("evil.example.com", "127.0.0.1"):
+            with self.subTest(host=foreign):
+                resp = self.client.get(
+                    "/.well-known/oauth-authorization-server",
+                    headers={"Host": foreign})
+                self.assertEqual(resp.status_code, 200)
+                self.assertEqual(resp.json()["issuer"].rstrip("/"),
+                                 self.ISSUER)

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -169,8 +169,7 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
 
     async def test_streamable_app_is_asgi(self):
         server = serve_mcp.build_server(scaffold(self))
-        app = server.streamable_http_app(stateless_http=True)
-        self.assertTrue(callable(app))
+        self.assertTrue(callable(serve_mcp.build_app(server)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Test-only. No production code changes. Closes the last mechanically-verifiable gap before #42's live observation.

Base branch: **`main`** (not stacked on anything).

## Files changed
- `tests/test_mcp_auth.py` (modified) — new `TestTunnelledOAuth` (4 tests); `TestOAuthOverHTTP` and the no-OAuth test now build through `build_app`.
- `tests/test_serve_mcp.py` (modified) — `test_streamable_app_is_asgi` now builds through `build_app`.

## Work breakdown

Behind a tunnel both halves are live at once: the OAuth server (#42) and DNS-rebinding protection with a declared hostname (#46). Each was well covered alone — `TestOAuthOverHTTP` built its app with no transport security, `TestTunnelHost` built its app with no OAuth — so **the one arrangement that actually ships was the one arrangement untested**. The place that gap would have surfaced is a live tunnel with a connector half-configured, which is the most expensive place to find out.

`TestTunnelledOAuth` runs register → authorize → consent → token → authenticated `/mcp` on the tunnel hostname, over an `https` issuer, through an app built exactly as `main()` builds it. It also asserts the advertised issuer and every endpoint in the discovery document point at the tunnel host — if that said `127.0.0.1`, the connector would walk off to an address it cannot reach.

**Two behaviours were measured rather than assumed**, and the first one falsified my initial assumption, which is why the tests look the way they do:

- **A foreign `Host` with no token surfaces as `401`, not `421`.** The auth middleware runs before the transport check. That makes an unauthenticated probe worthless as a guard test — it would pass even with DNS-rebinding protection switched off entirely. So the test mints a **real token** through the full flow on the declared host and asserts the foreign `Host` is refused anyway. That is what proves #46's guard still covers `/mcp` with #48's OAuth layer in front of it.
- **Discovery documents answer any `Host`.** Deliberate, not an oversight: OAuth bootstrap is unauthenticated by definition and the SDK mounts it outside the transport wrapper. It carries no campaign data — only the issuer URL a client needs before it can hold a token. Pinned with that reasoning so a later reader doesn't "harden" it and silently break the connector's first request.

**Second change: no test builds the app by hand any more.** `streamable_http_app(...)` appeared in three tests, so they had drifted from the construction `main()` uses and would not have exercised `build_app` at all. All now go through `build_app`; `grep -rn 'streamable_http_app' tests/` returns nothing.

## Test expectations
None expected to fail.

## Verification

The guard test was proven non-vacuous by perturbation — the plausible wrong fix is to widen the allow-list, so that was injected:

```
allowed_hosts=[public_host, "evil.example.com"]
→ AssertionError: <HTTPStatus.BAD_REQUEST: 400> != 421
```

The foreign host was served, and the test caught it. Reverted, back to green.

(Disabling the guard outright was tried first and made the request hang inside the streaming session manager rather than fail cleanly — a widened allow-list is the sharper probe, and the one a careless change would actually produce.)

- `python3 -m unittest discover -s tests -t .` **with** the `mcp` extra → **777 tests, OK** (was 773; +4).
- Same on a **bare** Python → **777, OK, 46 skips** (was 42), so the new class skips where the SDK is absent.
- Both runs asserted `bunnyforge.__file__` pointed at this checkout before being trusted.
- Secret scan: clean (the fixtures' `sekrit` key is test data).

**Still not verified, and not verifiable here:** claude.ai's own client behaviour against a live tunnel. That is #42's remaining observation. What this PR removes is the risk that the two halves fail to compose — which was previously unknown and is now pinned.

## Operational impact
None. Test-only.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)