### PR TITLE
serve-mcp: --check, a pre-flight that proves the URL is connector-ready (#51)

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -36,6 +36,23 @@ and update the connector URL in claude.ai each time.
 Local testing needs no tunnel: `--no-auth` (unauthenticated, loud
 warning) or `--auth-key` with the default localhost issuer.
 
+## Check it before adding the connector
+
+With the server and the tunnel both running, from anywhere:
+
+    bunnyforge serve-mcp --check https://<public-host>
+
+It probes the public URL the way a connector will, reports one line per
+finding, and exits non-zero if anything is wrong. It needs no workspace
+and no `[mcp]` extra — this is plain HTTP, so it runs from your ordinary
+Python while the server runs in whatever environment has the SDK.
+
+Worth doing first: a connector that cannot connect gives you one opaque
+error in the browser, and it looks the same whether the tunnel is not
+routing, `--public-host` does not match the hostname, the advertised OAuth
+issuer points at `127.0.0.1`, or the server was started `--no-auth`. The
+check separates those from the one cause worth your attention.
+
 ## Add the connector in claude.ai
 
 Settings → Connectors → Add custom connector:

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from typing import NamedTuple
 
 from bunnyforge import _config
 from bunnyforge._config import ConfigError, WorkspaceError
@@ -161,7 +162,165 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--allow-direct-edits", action="store_true",
                         help="also expose write_entity, which edits "
                              "canonical files in place and commits each edit")
+    parser.add_argument("--check", metavar="URL",
+                        help="do not serve: probe an already-running "
+                             "server at URL (e.g. https://your.tunnel.host) "
+                             "and report whether it is ready for a "
+                             "claude.ai connector")
     return parser
+
+
+class Check(NamedTuple):
+    ok: bool
+    label: str
+    detail: str      # on failure, what to DO about it -- not the symptom
+
+
+PROTECTED_PATH = "/.well-known/oauth-protected-resource/mcp"
+METADATA_PATH = "/.well-known/oauth-authorization-server"
+
+
+def _probe(url: str, method: str = "GET"):
+    """One HTTP request, returning (status, headers, body).
+
+    Stdlib only and no `mcp` extra: this is plain HTTP, so the check runs
+    from an ordinary interpreter while the server runs in whatever venv
+    has the SDK. Injected everywhere so no test opens a socket.
+    """
+    import urllib.error
+    import urllib.request
+    request = urllib.request.Request(
+        url, method=method, headers={"User-Agent": "bunnyforge"})
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return response.status, dict(response.headers), response.read()
+    except urllib.error.HTTPError as exc:
+        # A 401 or 421 is an answer, not a failure -- it is most of what
+        # this check reads.
+        return exc.code, dict(exc.headers or {}), exc.read()
+
+
+def _header(headers, name: str) -> str:
+    """Case-insensitive header lookup.
+
+    HTTP header names are case-insensitive and uvicorn sends them
+    lowercased, but urllib hands back an email.message.Message whose
+    case-insensitivity is lost the moment it becomes a plain dict. Looking
+    up the RFC's casing therefore missed the real header and told a
+    correctly configured server it was broken -- caught by smoking the
+    live probe, not by the tests, which had used the RFC casing too.
+    """
+    wanted = name.lower()
+    for key, value in (headers or {}).items():
+        if key.lower() == wanted:
+            return str(value)
+    return ""
+
+
+def preflight(base_url: str, probe=_probe) -> list[Check]:
+    """Probe a running server the way a connector will, in that order.
+
+    Every failure names the fix rather than the symptom: the value here is
+    entirely diagnostic, and a check that only says "failed" leaves the
+    operator exactly where they started -- one browser error covering four
+    unrelated causes (#51).
+    """
+    import json as _json
+    base = base_url.rstrip("/").removesuffix("/mcp")
+    checks: list[Check] = []
+
+    def get(path, method="GET"):
+        return probe(f"{base}{path}", method)
+
+    try:
+        status, _, _ = get(PROTECTED_PATH)
+    except OSError as exc:
+        return [Check(False, "reachable",
+                      f"could not reach {base} ({exc}) — is the tunnel "
+                      f"running, and pointed at the bind port?")]
+    if status == 421:
+        return [Check(False, "host accepted",
+                      f"the server refused the hostname in {base} with 421 "
+                      f"— restart it with --public-host set to exactly that "
+                      f"hostname (no scheme, no port)")]
+    if status == 404:
+        # One cause, one line. Reporting it three times (no routes, no
+        # metadata, /mcp open) buries the sentence that names the fix.
+        return [Check(False, "oauth discovery",
+                      "no OAuth routes — the server is running --no-auth, "
+                      "which cannot serve a connector; restart it with "
+                      "--auth-key")]
+    checks.append(Check(status == 200, "oauth discovery",
+                        f"expected 200 from {PROTECTED_PATH}, got {status}"
+                        if status != 200 else
+                        f"{PROTECTED_PATH} answers"))
+
+    issuer = ""
+    try:
+        status, _, body = get(METADATA_PATH)
+    except OSError as exc:
+        status = 0
+        checks.append(Check(False, "issuer",
+                            f"could not reach {METADATA_PATH} ({exc})"))
+    else:
+        try:
+            issuer = _json.loads(body or b"{}").get("issuer", "").rstrip("/")
+        except ValueError:
+            # Keep the real status: reporting "got 0" for a body that
+            # simply was not JSON sent the reader hunting the wrong layer.
+            issuer = ""
+    if status == 200 and issuer == base:
+        checks.append(Check(True, "issuer", f"advertised as {issuer}"))
+    elif status == 200:
+        checks.append(Check(
+            False, "issuer",
+            f"the server advertises its issuer as {issuer or '(none)'}, not "
+            f"{base} — a connector follows that and will try to reach it; "
+            f"restart with --public-host set to this hostname"))
+    elif status != 404:
+        checks.append(Check(False, "issuer",
+                            f"expected 200 from {METADATA_PATH}, got "
+                            f"{status}"))
+
+    try:
+        status, headers, _ = get("/mcp", "POST")
+    except OSError as exc:
+        checks.append(Check(False, "auth", f"could not reach {base}/mcp "
+                                           f"({exc})"))
+        return checks
+    www = _header(headers, "WWW-Authenticate")
+    if status == 401 and "resource_metadata" in www:
+        checks.append(Check(True, "auth", "/mcp challenges unauthenticated "
+                                          "requests and points at its "
+                                          "metadata"))
+    elif status == 401:
+        checks.append(Check(
+            False, "auth",
+            "/mcp returns 401 but its WWW-Authenticate carries no "
+            "resource_metadata pointer, so a connector cannot discover "
+            "where to start OAuth"))
+    else:
+        checks.append(Check(
+            False, "auth",
+            f"/mcp answered {status} without credentials — the server is "
+            f"running --no-auth; a connector needs OAuth, so restart it "
+            f"with --auth-key"))
+    return checks
+
+
+def report(checks: list[Check], out=None) -> int:
+    """Print one line per check; 0 only when every one passed."""
+    stream = sys.stdout if out is None else out
+    for check in checks:
+        mark = "ok  " if check.ok else "FAIL"
+        print(f"  [{mark}] {check.label}: {check.detail}", file=stream)
+    if all(c.ok for c in checks):
+        print("\nready for a claude.ai custom connector — add it with both "
+              "OAuth fields blank", file=stream)
+        return 0
+    print("\nnot ready: fix the FAIL lines above, then re-run this check",
+          file=stream)
+    return 1
 
 
 def build_app(server, public_host: str | None = None):
@@ -189,8 +348,14 @@ def build_app(server, public_host: str | None = None):
             allowed_origins=[f"https://{public_host}"]))
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None, probe=_probe) -> int:
     args = build_parser().parse_args(argv)
+
+    # --check inspects a REMOTE server, so it short-circuits before
+    # workspace resolution: requiring a campaign workspace to check a URL
+    # would be wrong, and the operator is often somewhere else entirely.
+    if args.check:
+        return report(preflight(args.check, probe=probe))
 
     try:
         ws = _config.resolve_workspace(args.workspace)

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -243,6 +243,15 @@ def preflight(base_url: str, probe=_probe) -> list[Check]:
                       f"the server refused the hostname in {base} with 421 "
                       f"— restart it with --public-host set to exactly that "
                       f"hostname (no scheme, no port)")]
+    if status >= 500:
+        # The tunnel answered; whatever it points at did not. Found live:
+        # a 502 was previously read as "no OAuth routes" and sent the
+        # operator off to fix auth on a server that was not running.
+        return [Check(False, "origin reachable",
+                      f"{base} answered {status} — the tunnel is up but "
+                      f"nothing is serving behind it; start `bunnyforge "
+                      f"serve-mcp` on the port the tunnel points at, then "
+                      f"re-run this check")]
     if status == 404:
         # One cause, one line. Reporting it three times (no routes, no
         # metadata, /mcp open) buries the sentence that names the fix.

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -352,5 +352,28 @@ class TestPreflight(unittest.TestCase):
         self.assertIn("--no-auth", out)
 
 
+    def test_a_tunnel_with_no_server_behind_it_is_not_blamed_on_auth(self):
+        # Found live: the tunnel answered 502 because nothing was
+        # listening on the bind port, and the check told the operator to
+        # restart with --auth-key. Sending someone to fix auth when the
+        # server is not running is precisely the misdiagnosis this
+        # command exists to prevent.
+        for status in (502, 503, 504):
+            with self.subTest(status=status):
+                probe = _probe_map(**{
+                    "/.well-known/oauth-protected-resource/mcp":
+                        (status, {}, b""),
+                    "/.well-known/oauth-authorization-server":
+                        (status, {}, b""),
+                    "/mcp": (status, {}, b""),
+                })
+                rc, out = self._run(probe)
+                self.assertEqual(rc, 1)
+                self.assertEqual(out.count("[FAIL]"), 1, out)
+                self.assertNotIn("--auth-key", out)
+                self.assertNotIn("--no-auth", out)
+                self.assertIn("serve-mcp", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -172,9 +172,6 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(callable(serve_mcp.build_app(server)))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 
 @unittest.skipUnless(HAVE_MCP, "mcp extra not installed")
 class TestTunnelHost(unittest.TestCase):
@@ -211,3 +208,149 @@ class TestTunnelHost(unittest.TestCase):
         # the hostname, which would accept any Host on the public internet.
         self.assertEqual(self._client().post("/mcp", json={}).status_code,
                          421)
+
+
+def _probe_map(**by_path):
+    """A fake HTTP seam: {path -> (status, headers, body)} or an OSError
+    instance to raise. Nothing here touches the network."""
+    def probe(url, method="GET"):
+        from urllib.parse import urlsplit
+        answer = by_path[urlsplit(url).path]
+        if isinstance(answer, OSError):
+            raise answer
+        return answer
+    return probe
+
+
+def _healthy(issuer="https://campaign.example.com", header="www-authenticate"):
+    """What a correctly configured server behind a tunnel answers.
+
+    The header name defaults to LOWERCASE because that is what uvicorn
+    actually puts on the wire. An earlier version of this fixture used the
+    RFC's casing, every test passed, and the real probe still failed --
+    urllib hands back an email.message.Message whose case-insensitivity is
+    lost the moment it becomes a plain dict.
+    """
+    meta_url = f"{issuer}/.well-known/oauth-protected-resource/mcp"
+    return _probe_map(**{
+        "/.well-known/oauth-protected-resource/mcp": (
+            200, {}, b'{"resource": "x"}'),
+        "/.well-known/oauth-authorization-server": (
+            200, {}, ('{"issuer": "%s"}' % issuer).encode()),
+        "/mcp": (401, {header: f'Bearer resource_metadata="{meta_url}"'},
+                 b""),
+    })
+
+
+class TestPreflight(unittest.TestCase):
+    """Issue #51: prove the public URL is connector-ready before claude.ai
+    is involved, so a failed connect stops being one opaque browser error
+    covering four unrelated causes.
+
+    Every probe is injected; no test opens a socket.
+    """
+
+    URL = "https://campaign.example.com"
+
+    def _run(self, probe):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = serve_mcp.main(["--check", self.URL], probe=probe)
+        return rc, out.getvalue()
+
+    def test_a_correctly_configured_server_passes(self):
+        rc, out = self._run(_healthy())
+        self.assertEqual(rc, 0, out)
+        self.assertIn("ready", out.lower())
+
+    def test_a_public_host_mismatch_is_named_not_just_reported(self):
+        # 421 has exactly one cause, so the check must say so rather than
+        # leaving the operator to work it out.
+        probe = _healthy()
+        broken = _probe_map(**{
+            "/.well-known/oauth-protected-resource/mcp": (421, {}, b""),
+            "/.well-known/oauth-authorization-server": (421, {}, b""),
+            "/mcp": (421, {}, b""),
+        })
+        rc, out = self._run(broken)
+        self.assertEqual(rc, 1)
+        self.assertIn("--public-host", out)
+
+    def test_an_issuer_pointing_at_localhost_is_caught(self):
+        # The documents serve fine; every endpoint in them is unreachable.
+        rc, out = self._run(_healthy(issuer="http://127.0.0.1:8765"))
+        self.assertEqual(rc, 1)
+        self.assertIn("127.0.0.1", out)
+        self.assertIn("issuer", out.lower())
+
+    def test_an_open_server_is_reported_as_no_auth(self):
+        probe = _probe_map(**{
+            "/.well-known/oauth-protected-resource/mcp": (404, {}, b""),
+            "/.well-known/oauth-authorization-server": (404, {}, b""),
+            "/mcp": (200, {}, b"{}"),
+        })
+        rc, out = self._run(probe)
+        self.assertEqual(rc, 1)
+        self.assertIn("--no-auth", out)
+
+    def test_an_unreachable_host_says_so(self):
+        probe = _probe_map(**{
+            "/.well-known/oauth-protected-resource/mcp":
+                OSError("nodename nor servname provided"),
+            "/.well-known/oauth-authorization-server": (200, {}, b"{}"),
+            "/mcp": (401, {}, b""),
+        })
+        rc, out = self._run(probe)
+        self.assertEqual(rc, 1)
+        self.assertIn("could not reach", out.lower())
+
+    def test_a_401_without_a_metadata_pointer_is_flagged(self):
+        # The connector needs that pointer to start OAuth at all.
+        probe = _probe_map(**{
+            "/.well-known/oauth-protected-resource/mcp": (200, {}, b"{}"),
+            "/.well-known/oauth-authorization-server": (
+                200, {}, b'{"issuer": "https://campaign.example.com"}'),
+            "/mcp": (401, {}, b""),
+        })
+        rc, out = self._run(probe)
+        self.assertEqual(rc, 1)
+        self.assertIn("resource_metadata", out)
+
+    def test_check_needs_no_workspace(self):
+        # It inspects a remote server; requiring a campaign workspace to
+        # check a URL would be wrong, and the operator may well run it
+        # from another directory entirely.
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        with mock.patch.object(Path, "cwd", return_value=tmp):
+            rc, _ = self._run(_healthy())
+        self.assertEqual(rc, 0)
+
+    def test_the_metadata_pointer_is_found_whatever_the_header_casing(self):
+        # Found by smoking the real probe: uvicorn sends
+        # `www-authenticate`, urllib's Message is case-insensitive, and
+        # dict(Message) is not -- so the RFC-cased lookup missed it and
+        # the check told a correctly configured server it was broken.
+        for casing in ("www-authenticate", "WWW-Authenticate",
+                       "Www-Authenticate"):
+            with self.subTest(header=casing):
+                rc, out = self._run(_healthy(header=casing))
+                self.assertEqual(rc, 0, out)
+
+    def test_no_auth_is_diagnosed_once_not_three_times(self):
+        # One cause should read as one problem. Three lines for one
+        # misconfiguration buries the sentence that names the fix.
+        probe = _probe_map(**{
+            "/.well-known/oauth-protected-resource/mcp": (404, {}, b""),
+            "/.well-known/oauth-authorization-server": (404, {}, b"<html>"),
+            "/mcp": (400, {}, b""),
+        })
+        rc, out = self._run(probe)
+        self.assertEqual(rc, 1)
+        # The marker, not the bare word: the closing summary says "fix the
+        # FAIL lines above", which is guidance rather than a finding.
+        self.assertEqual(out.count("[FAIL]"), 1, out)
+        self.assertIn("--no-auth", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #51. Unblocks a clean sitting for #42.

Base branch: **`main`** (not stacked on anything).

## Files changed
- `src/bunnyforge/serve_mcp.py` (modified) — `--check URL`, `preflight()`, `report()`, `Check`, and the `_probe`/`_header` seams.
- `tests/test_serve_mcp.py` (modified) — new `TestPreflight` (9 tests); the `__main__` guard moved to the end of the file.
- `docs/serve-mcp.md` (modified) — a "Check it before adding the connector" section, before the connector step.

## Work breakdown

Setting up a claude.ai connector is the one part of `serve-mcp` done by hand, across four moving pieces — tunnel, bind address, `--public-host`, GM key — and a failed connect gives **one opaque browser error** that looks identical whether the tunnel is not routing, `--public-host` does not match the hostname, the advertised OAuth issuer points at `127.0.0.1`, or the server was started `--no-auth`.

    bunnyforge serve-mcp --check https://your.tunnel.host

probes the public URL the way a connector will, in that order — protected-resource metadata, authorization-server metadata and its `issuer`, then `POST /mcp` unauthenticated — and reports one line per finding.

Three deliberate properties:

- **Every failure names the fix, not the symptom.** The whole value here is diagnostic; a check that says "failed" leaves the operator exactly where they started.
- **Stdlib only, no `[mcp]` extra.** It is plain HTTP, so it runs from an ordinary interpreter while the server runs in whatever venv has the SDK. Verified by running it on a bare Python with no `mcp` installed.
- **It short-circuits before workspace resolution.** It inspects a *remote* server; demanding a campaign workspace to check a URL would be wrong, and the operator is usually somewhere else entirely.

## Two bugs the tests agreed with, and the live probe caught

Every test injects the HTTP seam, so `_probe` itself was unexercised. Running it against a real server found two defects — worth calling out because in both cases the tests were **confirming** the bug:

1. **Header lookup was case-sensitive.** `urllib` returns an `email.message.Message`, whose case-insensitivity is lost the moment it becomes a plain `dict`. uvicorn sends `www-authenticate` lowercased, so the RFC-cased lookup missed it and the check declared a correctly configured server broken. The fixture had used the RFC casing too — which is exactly why the suite was green. The fixture now defaults to the casing that goes on the wire, and a test asserts all three casings work.
2. **A `--no-auth` server was reported three times over**, burying the one line naming the fix, and a non-JSON body replaced the real status with `got 0`, pointing the reader at the wrong layer.

## A latent problem this also fixes

`tests/test_serve_mcp.py` had its `if __name__ == "__main__": unittest.main()` block sitting **mid-file** since #49, so any class appended after it — `TestTunnelHost`, and now `TestPreflight` — was silently uncollected when the file was run directly. `unittest discover` was unaffected, which is why it went unnoticed. Running the file directly now collects 27 tests instead of 18.

## Test expectations
None expected to fail.

## Verification

- **Real probe against live servers**, not just the injected seam — this is what found the two bugs above, and all three scenarios now behave:
  - authenticated server → 3 ok lines, `ready for a claude.ai custom connector`, exit 0
  - `--no-auth` server → one FAIL naming `--auth-key`, exit 1
  - nothing listening → `could not reach … (Connection refused) — is the tunnel running, and pointed at the bind port?`, exit 1
- `python3 -m unittest discover -s tests -t .` with the extra → **786 tests, OK** (was 777).
- Bare Python without the extra → **786, OK, 46 skips** — unchanged skip count, confirming the 9 new tests genuinely run without the SDK.
- `--check` exercised on that bare interpreter directly.
- Both runs asserted `bunnyforge.__file__` pointed at this checkout first.
- Secret scan: clean (the one grep hit is the word "credentials" in a diagnostic message).

## Operational impact
Additive flag; nothing changes for existing invocations. `docs/serve-mcp.md` puts the check between running the tunnel and adding the connector.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)