### PR TITLE
serve-mcp phase 2: write-back — staged drafts, shadow revisions, gated direct edits (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ entity files from the templates in `_Templates/`.
 | `build-sheets` | build one-page HTML reference sheets for a session |
 | `names` | generate culture-appropriate names |
 | `vscode` | install the preview extension and toggle editor colouring |
-| `serve-mcp` | serve the workspace to a remote AI agent over MCP (needs `bunnyforge[mcp]`) |
+| `serve-mcp` | serve the workspace to a remote AI agent over MCP — [guide](docs/serve-mcp.md) (needs `bunnyforge[mcp]`) |
 | `test` | run the workspace test suite |
 
 Run `bunnyforge <command> --help` for a command's own options.

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -75,6 +75,45 @@ one gets a fresh 30-day TTL, so silent refresh continues indefinitely as
 long as the connector is used at least once a month; the consent page
 reappears only after 30 days of disuse.
 
+## What the agent can do
+
+**Read:** `campaign_overview`, `list_entities`, `read_entity`, `search`,
+`generate_names`. Workspace doctrine (`style-guide.md`,
+`situation-design.md`, `AGENTS.md`) is served as MCP *resources* — tell
+the agent to load them before it writes anything for this campaign.
+
+**Write back, into staging:**
+
+| tool | writes to |
+|---|---|
+| `save_draft(section, name, content)` | `<staging_dir>/<section>/<name>.md` — new content only, never overwrites |
+| `propose_revision(path, content)` | `<staging_dir>/<path>`, mirroring the canonical path, so you review it as a diff |
+
+Both land in the workspace's staging directory (`staging_dir`, default
+`_ExtractInbound`) and go no further. That directory is one of
+`exclude_dirs`, so staged material is invisible to the read tools and to
+every other bunnyforge command until you promote it by hand — it flows
+through whatever extraction workflow your `AGENTS.md` already defines.
+**In the default configuration the agent cannot alter canon at all.** The
+server stages; deciding what becomes canon stays yours.
+
+**Write back, into canon — only if you ask for it:**
+
+    bunnyforge serve-mcp --allow-direct-edits ...
+
+registers a third tool, `write_entity(path, content)`, which edits a
+canonical file in place and commits each edit with a
+`serve-mcp: edit <path>` message. It refuses outside a git repository:
+without history there is no review and no undo, and that is the only
+thing that makes editing canon defensible. It is a per-run flag rather
+than a config key on purpose — trading the staging boundary for git
+history should be a decision you make when starting the server, not a
+setting that quietly persists.
+
+Publishing is structurally absent in every mode: no tool here can reach
+`Export/` or the wiki, so a remote agent cannot leak GM-only material to
+players even by accident.
+
 ## Resetting access
 
 Delete the token state file and restart the server:

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -20,6 +20,8 @@ belongs on the class, never in free functions serve_mcp.py calls directly.
 from __future__ import annotations
 
 import random
+import re
+import subprocess
 from pathlib import Path
 
 from bunnyforge import _common
@@ -29,6 +31,11 @@ from bunnyforge._config import Workspace
 SEARCH_CAP = 50       # hits per search reply; the reply says when it truncated
 SNIPPET_RADIUS = 80   # characters of context on each side of a match
 NAME_COUNT_CAP = 50   # names per request; a brainstorm needs a handful, not a page
+
+# Draft names become filenames. No path separators, no leading dot or
+# underscore (dot-files hide; the _-prefix is the workspace's own marker
+# for machinery directories).
+_DRAFT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9 _'-]*")
 
 
 class StoreError(Exception):
@@ -191,3 +198,63 @@ class WorkspaceStore:
                            for _ in range(count)],
                 "places": [_names.place_name(rng, inv, key)
                            for _ in range(count)]}
+
+    # -- write side ---------------------------------------------------------
+    # Staging paths are built directly rather than through _canonical: the
+    # staging directory is excluded from reads BY DESIGN, and these two
+    # methods are the only writers. Traversal is impossible by construction
+    # -- section is validated against config, and _DRAFT_NAME_RE admits no
+    # separator.
+
+    def _staging(self) -> Path:
+        return self.ws.root / self.ws.config.staging_dir
+
+    def stage_draft(self, section: str, name: str, content: str) -> str:
+        self._check_section(section)
+        if not _DRAFT_NAME_RE.fullmatch(name):
+            raise StoreError(
+                f"bad draft name {name!r} — letters, digits, spaces, "
+                "- _ ' only, starting with a letter or digit")
+        dest = self._staging() / section / f"{name}.md"
+        if dest.exists():
+            rel = dest.relative_to(self.ws.root).as_posix()
+            raise StoreError(f"{rel} already exists — pick another name")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+        return dest.relative_to(self.ws.root).as_posix()
+
+    def stage_revision(self, path: str, content: str) -> str:
+        target = self._canonical(path)
+        if not target.is_file() or target.suffix != ".md":
+            raise StoreError(
+                f"no such content file: {path} — stage_revision proposes "
+                "changes to an existing file; use stage_draft for new "
+                "content")
+        dest = self._staging() / target.relative_to(self.ws.root)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")  # latest proposal wins
+        return dest.relative_to(self.ws.root).as_posix()
+
+    def write_entity(self, path: str, content: str) -> str:
+        target = self._canonical(path)
+        if not target.is_file() or target.suffix != ".md":
+            raise StoreError(f"no such content file: {path}")
+        rel = target.relative_to(self.ws.root).as_posix()
+        if target.read_text(encoding="utf-8") == content:
+            return rel  # nothing to change, nothing to commit
+        probe = subprocess.run(
+            ["git", "-C", str(self.ws.root), "rev-parse",
+             "--is-inside-work-tree"], capture_output=True, text=True)
+        if probe.returncode != 0:
+            raise StoreError(
+                "direct edits require the workspace to be a git repository "
+                "— refusing to edit canon without history")
+        target.write_text(content, encoding="utf-8")
+        for sub in (["add", "--", rel],
+                    ["commit", "-m", f"serve-mcp: edit {rel}"]):
+            done = subprocess.run(["git", "-C", str(self.ws.root)] + sub,
+                                  capture_output=True, text=True)
+            if done.returncode != 0:
+                raise StoreError(f"git {sub[0]} failed: "
+                                 f"{done.stderr.strip() or done.stdout.strip()}")
+        return rel

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -119,6 +119,29 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         first if you are unsure which cultures exist."""
         return store.generate_names(culture, count)
 
+    @server.tool()
+    def save_draft(section: str, name: str, content: str) -> str:
+        """Stage NEW content (a full markdown file, front matter included)
+        into the workspace's staging area for the GM to review and promote.
+        Never overwrites; returns the staged path."""
+        return store.stage_draft(section, name, content)
+
+    @server.tool()
+    def propose_revision(path: str, content: str) -> str:
+        """Stage a full-file revision of an EXISTING workspace file as a
+        shadow copy in the staging area. The GM reviews it as a diff.
+        Re-proposing replaces the earlier proposal; returns the staged
+        path."""
+        return store.stage_revision(path, content)
+
+    if allow_direct_edits:
+        @server.tool()
+        def write_entity(path: str, content: str) -> str:
+            """Edit a canonical workspace file in place. Each edit is
+            auto-committed to git. Available only because this server was
+            started with --allow-direct-edits."""
+            return store.write_entity(path, content)
+
     def _reader(path):
         def read() -> str:
             return path.read_text(encoding="utf-8")

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -107,11 +107,29 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
             {"campaign_overview", "list_entities", "read_entity", "search",
              "generate_names"}, names)
 
-    async def test_write_tools_absent_in_phase_1(self):
+    async def test_staging_tools_always_registered(self):
         server = serve_mcp.build_server(scaffold(self))
         names = {t.name for t in await server.list_tools()}
-        self.assertFalse({"save_draft", "propose_revision", "write_entity"}
-                         & names)
+        self.assertLessEqual({"save_draft", "propose_revision"}, names)
+
+    async def test_write_entity_only_with_the_flag(self):
+        # The gate is the whole safety story: staging is always available
+        # because it cannot reach canon, and canon is reachable only
+        # because someone passed a per-run flag.
+        store = scaffold(self)
+        off = {t.name for t in await serve_mcp.build_server(store).list_tools()}
+        on = {t.name for t in await serve_mcp.build_server(
+            store, allow_direct_edits=True).list_tools()}
+        self.assertNotIn("write_entity", off)
+        self.assertIn("write_entity", on)
+
+    async def test_save_draft_lands_in_staging(self):
+        store = scaffold(self)
+        await serve_mcp.build_server(store).call_tool(
+            "save_draft", {"section": "NPCs", "name": "Cho",
+                           "content": "---\ntitle: Cho\n---\n"})
+        self.assertTrue(
+            (store.ws.root / "_ExtractInbound/NPCs/Cho.md").is_file())
 
     async def test_every_tool_carries_a_description(self):
         # The description is how the remote agent decides to call a tool at

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -228,3 +229,105 @@ class TestGenerateNames(StoreCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStageDraft(StoreCase):
+    def test_writes_into_staging_and_creates_dirs(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.stage_draft("NPCs", "Old Man Cho", "---\ntitle: Cho\n---\n")
+        self.assertEqual(rel, "_ExtractInbound/NPCs/Old Man Cho.md")
+        self.assertTrue((ws.root / rel).is_file())
+
+    def test_refuses_overwrite(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.stage_draft("NPCs", "Cho", "x")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.stage_draft("NPCs", "Cho", "y")
+        self.assertIn("another name", str(ctx.exception))
+
+    def test_refuses_unknown_section_and_bad_names(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.stage_draft("Nope", "Cho", "x")
+        for bad in ("../escape", "a/b", ".hidden", "_underscore"):
+            with self.assertRaises(_store.StoreError):
+                store.stage_draft("NPCs", bad, "x")
+
+    def test_honors_configured_staging_dir(self):
+        ws = self.make_ws('\n[workspace]\nstaging_dir = "_Inbox"\n')
+        rel = _store.WorkspaceStore(ws).stage_draft("NPCs", "Cho", "x")
+        self.assertEqual(rel, "_Inbox/NPCs/Cho.md")
+
+
+class TestStageRevision(StoreCase):
+    def test_shadow_mirrors_the_canonical_path(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.stage_revision("NPCs/kim-ha-eun.md", "new text")
+        self.assertEqual(rel, "_ExtractInbound/NPCs/kim-ha-eun.md")
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
+                         "new text")
+
+    def test_latest_proposal_wins(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.stage_revision("NPCs/kim-ha-eun.md", "first")
+        rel = store.stage_revision("NPCs/kim-ha-eun.md", "second")
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
+                         "second")
+
+    def test_requires_an_existing_target(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.stage_revision("NPCs/nobody.md", "x")
+        self.assertIn("stage_draft", str(ctx.exception))  # points at the fix
+
+    def test_refuses_escapes(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.stage_revision("../outside.md", "x")
+
+
+class TestWriteEntity(StoreCase):
+    def make_git_ws(self):
+        ws = self.make_ws()
+        for cmd in (["init", "-q"], ["config", "user.email", "t@t"],
+                    ["config", "user.name", "t"], ["add", "-A"],
+                    ["commit", "-qm", "seed"]):
+            subprocess.run(["git", "-C", str(ws.root)] + cmd, check=True)
+        return ws
+
+    def test_edits_and_commits(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        store.write_entity("NPCs/kim-ha-eun.md", "---\ntitle: X\n---\nnew\n")
+        self.assertIn("new", (ws.root / "NPCs/kim-ha-eun.md").read_text(
+            encoding="utf-8"))
+        log = subprocess.run(
+            ["git", "-C", str(ws.root), "log", "-1", "--format=%s"],
+            capture_output=True, text=True, check=True).stdout
+        self.assertIn("serve-mcp: edit NPCs/kim-ha-eun.md", log)
+        status = subprocess.run(
+            ["git", "-C", str(ws.root), "status", "--porcelain"],
+            capture_output=True, text=True, check=True).stdout
+        self.assertEqual(status.strip(), "")  # nothing left uncommitted
+
+    def test_identical_content_is_a_quiet_no_op(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        original = (ws.root / "NPCs/kim-ha-eun.md").read_text(encoding="utf-8")
+        store.write_entity("NPCs/kim-ha-eun.md", original)  # must not raise
+
+    def test_refuses_outside_a_git_repo(self):
+        store = _store.WorkspaceStore(self.make_ws())  # no git init
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.write_entity("NPCs/kim-ha-eun.md", "x")
+        self.assertIn("git", str(ctx.exception))
+
+    def test_refuses_missing_target_and_escapes(self):
+        store = _store.WorkspaceStore(self.make_git_ws())
+        with self.assertRaises(_store.StoreError):
+            store.write_entity("NPCs/nobody.md", "x")
+        with self.assertRaises(_store.StoreError):
+            store.write_entity("../outside.md", "x")


### PR DESCRIPTION
Closes #41. Executes tasks 6–8 of `docs/superpowers/plans/2026-08-16-serve-mcp.md`.

Base branch: **`main`** (not stacked on anything — phase 1 is already merged).

## Files changed
- `src/bunnyforge/_store.py` (modified) — the write side: `stage_draft`, `stage_revision`, `write_entity`.
- `tests/test_store.py` (modified) — 12 tests across three new classes.
- `src/bunnyforge/serve_mcp.py` (modified) — three MCP tools inside `build_server`.
- `tests/test_serve_mcp.py` (modified) — the phase-1 "no write tools" test replaced by three write-tool tests.
- `docs/serve-mcp.md` (modified) — a "What the agent can do" section.
- `README.md` (modified) — the `serve-mcp` row now links the guide.

## Work breakdown

This is the milestone that makes the feature usable. Phase 1 could read a campaign but hand nothing back, which left the GM copying prose out of a chat window.

Three writers, and **the boundary between them is the point**:

| tool | writes to | gate |
|---|---|---|
| `save_draft(section, name, content)` | `<staging_dir>/<section>/<name>.md` | always on; refuses to overwrite |
| `propose_revision(path, content)` | `<staging_dir>/<path>`, mirroring the canonical path | always on; re-proposing replaces |
| `write_entity(path, content)` | the canonical file, in place | **only under `--allow-direct-edits`**; auto-commits each edit |

**Canon is mechanically out of reach by default**, not merely discouraged. Staged material lands in `staging_dir` (default `_ExtractInbound`), which is one of `exclude_dirs` — so it is invisible to the read tools and to every other bunnyforge command until a human promotes it. Verified rather than asserted: `staging_dir in exclude_dirs` → `True`, and the default tool list contains no writer that can reach canon.

`write_entity` **refuses outside a git repository**. Without history there is no review and no undo, and that is the only thing making in-place edits to canon defensible. It is a per-run flag rather than a config key on purpose: trading the staging boundary for git history should be a decision made when starting the server, not a setting that quietly persists.

Traversal is impossible by construction rather than by check-at-each-handler: staging paths are built from a section validated against config and a draft-name pattern that admits no separator, and the two path-taking methods go through the existing `_canonical` guard the read side already uses.

## A deviation from the plan, and why

**Task 8 said to *create* `docs/serve-mcp.md`.** That file already exists — created by #48 and extended by #46, #51 and #53 — and the plan's draft content is superseded: it describes the `--token` bearer flag that #48 deleted, and tells the reader to "file the finding and we wire up the SDK's OAuth support," which is exactly what #42 already settled. Following it verbatim would have regressed the operator guide badly.

I implemented the task's *intent* against the guide as it stands. Both gaps it identified were real: nothing documented what the agent can do, and the README's `serve-mcp` row did not link the guide. The new section leads with the boundary rather than the tool list, since that is the part a GM has to trust.

## Test expectations
None expected to fail.

## Verification

- `unittest discover` with the `mcp` extra → **813 tests, OK** (was 799; +14).
- Bare Python without the extra → **813, OK, 48 skips** (was 46; the two new MCP-layer tests skip correctly).
- Re-run in a **clean detached worktree with its own venv**: 813, OK.
- Every run asserts `bunnyforge.__file__` resolves inside the checkout first — the plan's own preflight, and worth keeping given this machine resolves `bunnyforge` three different ways depending on the shell.
- Each of the three commits was TDD'd red→green: `AttributeError: no attribute 'stage_draft'` for the store, then the two registration assertions failing against the phase-1 tool set.
- The doc's claims were checked against the running code, not just written: default `staging_dir`, its presence in `exclude_dirs`, the exact default tool list, what `--allow-direct-edits` adds, and the commit-message format.
- Secret scan: clean.

**Exercised after merge:** a live claude.ai agent called `save_draft` through the connector against the real campaign workspace — see the field-verification comment below, which also records the Always Allow step the connector needs.

## Operational impact
Additive. An existing server gains two staging tools; nothing can reach canon unless someone passes `--allow-direct-edits`. `staging_dir` was already a config key shipped inert in phase 1, so no migration.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution per `superpowers:executing-plans` in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)
