### PR TITLE
docs(serve-mcp): granting the tools is a step, and its failure is silent

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -75,6 +75,20 @@ one gets a fresh 30-day TTL, so silent refresh continues indefinitely as
 long as the connector is used at least once a month; the consent page
 reappears only after 30 days of disuse.
 
+### Then grant the tools — adding the connector is not the last step
+
+Once it is connected, claude.ai still asks before letting the agent call
+anything. In the connector's window, click **Always Allow** for its
+tools, and then **return to your chat from that window**. Going back some
+other way — a new tab, or the chat you already had open — did not carry
+the grant through when this was last tested.
+
+Worth knowing because the symptom is silent: the server is running,
+`--check` says ready, the connector shows as added, and the agent simply
+never calls a tool. Nothing appears in the server log either, because
+nothing reaches it. If that is what you are seeing, this is the step you
+are missing.
+
 ## What the agent can do
 
 **Read:** `campaign_overview`, `list_entities`, `read_entity`, `search`,
@@ -136,6 +150,9 @@ but not already-issued tokens — delete the state file for that.
 - **"Couldn't register with sign-in service":** the server is not
   reachable at the connector URL, or it was started `--no-auth` (no OAuth
   routes exist in that mode).
+- **The connector is added, but the agent never calls a tool** — and the
+  server log shows nothing arriving: the tools have not been granted. See
+  "Then grant the tools" above.
 
 ## One command
 

--- a/scripts/mcp-session.py
+++ b/scripts/mcp-session.py
@@ -512,6 +512,10 @@ def _run_session(args, url, key, server) -> int:
 
       {key}
 
+  Then click ALWAYS ALLOW for the tools, and go back to your chat
+  FROM THAT WINDOW. Skip it and the agent never calls a tool —
+  with nothing in the server log, because nothing reaches it.
+
   Leave this terminal running. The hostname dies with the tunnel,
   and the connector must be re-added if it changes.
 ================================================================""")


### PR DESCRIPTION
Documentation only. Records a field finding from verifying #41's write-back through a live claude.ai connector.

Base branch: **`main`** (not stacked on anything).

Raised on #54, which is already merged and so cannot carry the change — hence a separate PR.

## Files changed
- `docs/serve-mcp.md` (modified) — a "Then grant the tools" subsection under "Add the connector in claude.ai", and a matching troubleshooting entry.

## Work breakdown

Adding the connector is not the last step. claude.ai then asks before letting the agent call anything, and the maintainer found the grant has to be made **from the connector's own window** — click **Always Allow**, then return to the chat from there. Going back another way did not carry it through.

**The reason this is worth documenting is that its symptom is silence.** The server is running, `--check` reports ready, the connector shows as added, and the agent simply never calls a tool. The server log shows nothing either, because nothing reaches it. Every diagnostic this feature ships — the pre-flight check, the session script's `--verify`, the logs — points at a completely healthy system while the thing plainly does not work. That is exactly the shape of problem `docs/serve-mcp.md` exists to absorb, and the same reasoning behind #51.

The troubleshooting entry is keyed to the symptom rather than the cause ("the connector is added, but the agent never calls a tool"), because that is what someone can observe when they go looking.

The wording is hedged to what was actually seen — "did not carry the grant through when this was last tested" — since this is claude.ai UI behaviour that we neither control nor can pin with a test, and it may change.

## Test expectations
None expected to fail.

## Verification
- `unittest discover` → **813 tests, OK**. Documentation-only; no test asserts this prose.
- The surrounding claims were already verified against the running code when the section above it was written (#54).

## Operational impact
None.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)