### PR TITLE
mcp-session: take the workspace from $BUNNYFORGE_MCP_WORKSPACE

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -146,8 +146,11 @@ passes. It then prints the URL and key to paste.
 
     scripts/mcp-session.py --workspace ~/campaigns/my-campaign --verify
 
-Set `DEFAULT_WORKSPACE` near the top of the script and it needs no
-arguments at all. Other flags: `--fresh` (drop every registered client and
+Export `BUNNYFORGE_MCP_WORKSPACE` from your shell profile and it needs no
+arguments at all — the workspace comes from `--workspace`, else that
+variable, else the `DEFAULT_WORKSPACE` constant near the top of the
+script. Prefer the variable: it survives `git pull` without leaving a
+local edit in `git status` forever. Other flags: `--fresh` (drop every registered client and
 token first), `--status`, `--down`, `--port`, `--bunnyforge` (the console
 script that has the `[mcp]` extra, if it is not on your PATH).
 

--- a/scripts/mcp-session.py
+++ b/scripts/mcp-session.py
@@ -16,8 +16,10 @@ no public API for that -- connectors are added through Settings in the web
 UI. Everything up to that point is automated, and --verify proves the
 server is genuinely working, so the manual step is reduced to one paste.
 
-Pass --workspace, or edit DEFAULT_WORKSPACE below to your own campaign and
-then run it with no arguments at all.
+The workspace comes from --workspace, else $BUNNYFORGE_MCP_WORKSPACE, else
+the DEFAULT_WORKSPACE constant below. Export the variable from your shell
+profile and the script needs no arguments at all, with no local edit to
+carry.
 
 Usage:
     scripts/mcp-session.py --workspace ~/campaigns/my-campaign --verify
@@ -43,8 +45,9 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-# Set this to your own campaign and the script needs no arguments at all.
-# Left unset here because it ships for everyone; --workspace always works.
+# A fallback for people who would rather edit the script than set an
+# environment variable. Prefer $BUNNYFORGE_MCP_WORKSPACE: it survives
+# `git pull` without leaving a local edit in `git status` forever.
 #
 #   DEFAULT_WORKSPACE = str(Path.home() / "campaigns" / "my-campaign")
 #
@@ -57,9 +60,22 @@ SERVER_LOG = STATE / "bunnyforge" / "server.log"
 OAUTH_STATE = STATE / "bunnyforge" / "mcp-oauth-state.json"
 TUNNEL_RE = re.compile(r"https://[a-z0-9-]+\.trycloudflare\.com")
 KEY_ENV = "BUNNYFORGE_MCP_KEY"
+WORKSPACE_ENV = "BUNNYFORGE_MCP_WORKSPACE"
 
 
 # ── session memory ──────────────────────────────────────────────────────
+
+def chosen_workspace(cli_value=None, environ=None):
+    """--workspace beats $BUNNYFORGE_MCP_WORKSPACE beats DEFAULT_WORKSPACE.
+
+    The flag wins so a one-off run needs no unsetting; the variable beats
+    the constant so the shipped copy can be used as-is, with the campaign
+    named in a shell profile rather than in a local edit that shows up in
+    `git status` forever.
+    """
+    env = os.environ if environ is None else environ
+    return cli_value or env.get(WORKSPACE_ENV) or DEFAULT_WORKSPACE
+
 
 def load_session() -> dict:
     try:
@@ -388,10 +404,10 @@ def verify(url: str, key: str) -> bool:
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Bring up a claude.ai-ready bunnyforge MCP session.")
-    parser.add_argument("--workspace", default=DEFAULT_WORKSPACE,
-                        help="campaign workspace path"
-                             + (" (default: %(default)s)"
-                                if DEFAULT_WORKSPACE else ""))
+    parser.add_argument("--workspace",
+                        help=f"campaign workspace path (default: "
+                             f"${WORKSPACE_ENV}, else the DEFAULT_WORKSPACE "
+                             f"constant in this script)")
     parser.add_argument("--bunnyforge",
                         default=str(Path.home() / ".venvs" / "bunnyforge-mcp"
                                     / "bin" / "bunnyforge"),
@@ -435,10 +451,12 @@ def main() -> int:
         save_session(tunnel_pid=None, server_pid=None)
         return 0
 
-    if not args.workspace:
-        parser.error("--workspace is required (or set DEFAULT_WORKSPACE "
-                     "near the top of this script)")
-    workspace = str(Path(args.workspace).expanduser().resolve())
+    chosen = chosen_workspace(args.workspace)
+    if not chosen:
+        parser.error(f"no workspace: pass --workspace, export "
+                     f"${WORKSPACE_ENV}, or set DEFAULT_WORKSPACE near the "
+                     f"top of this script")
+    workspace = str(Path(chosen).expanduser().resolve())
     if not (Path(workspace) / "campaign.toml").is_file():
         parser.error(f"{workspace} is not a campaign workspace "
                      f"(no campaign.toml) — pass --workspace")

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -14,10 +14,12 @@ against a local one-shot server on an ephemeral port.
 
 import contextlib
 import http.server
+import os
 import importlib.util
 import socket
 import subprocess
 import sys
+import tempfile
 import threading
 import unittest
 from pathlib import Path
@@ -51,10 +53,17 @@ class TestShipsGeneric(unittest.TestCase):
         self.assertIn("#   DEFAULT_WORKSPACE = ", body)
 
     def test_refuses_without_a_workspace_rather_than_guessing(self):
+        # The environment is scrubbed deliberately. This test inherited the
+        # caller's environment until BUNNYFORGE_MCP_WORKSPACE existed, at
+        # which point anyone who exported it in a shell profile -- the
+        # entire point of the variable -- would have seen this test start
+        # failing on their machine and nowhere else.
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_MCP_WORKSPACE"}
         proc = subprocess.run([sys.executable, str(SCRIPT)],
-                              capture_output=True, text=True)
+                              capture_output=True, text=True, env=env)
         self.assertEqual(proc.returncode, 2)
-        self.assertIn("--workspace is required", proc.stderr)
+        self.assertIn("--workspace", proc.stderr)
 
 
 class TestTunnelBannerParsing(unittest.TestCase):
@@ -160,6 +169,60 @@ class TestPortGuard(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             session.clear_port(port)
         self.assertIn("not a serve-mcp", str(ctx.exception))
+
+
+
+class TestWorkspaceResolution(unittest.TestCase):
+    """--workspace beats $BUNNYFORGE_MCP_WORKSPACE beats DEFAULT_WORKSPACE.
+
+    The order is the whole feature: the variable exists so the shipped
+    copy can be used unedited, and the flag has to still win so a one-off
+    run against another campaign needs no unsetting.
+    """
+
+    def test_the_flag_wins(self):
+        self.assertEqual(
+            session.chosen_workspace("/from/flag",
+                                     {"BUNNYFORGE_MCP_WORKSPACE": "/from/env"}),
+            "/from/flag")
+
+    def test_the_env_var_is_used_when_the_flag_is_absent(self):
+        self.assertEqual(
+            session.chosen_workspace(None,
+                                     {"BUNNYFORGE_MCP_WORKSPACE": "/from/env"}),
+            "/from/env")
+
+    def test_nothing_set_is_none_rather_than_a_guess(self):
+        # DEFAULT_WORKSPACE ships as None, so an unconfigured run must
+        # refuse rather than pick a directory nobody named.
+        self.assertIsNone(session.chosen_workspace(None, {}))
+
+    def test_an_empty_env_var_does_not_count_as_set(self):
+        # `export BUNNYFORGE_MCP_WORKSPACE=` in a profile is a common way
+        # to end up here, and treating "" as configured would resolve to
+        # the current directory.
+        self.assertIsNone(
+            session.chosen_workspace(None, {"BUNNYFORGE_MCP_WORKSPACE": ""}))
+
+    def test_the_refusal_names_all_three_sources(self):
+        env = {k: v for k, v in os.environ.items()
+               if k != "BUNNYFORGE_MCP_WORKSPACE"}
+        proc = subprocess.run([sys.executable, str(SCRIPT)],
+                              capture_output=True, text=True, env=env)
+        self.assertEqual(proc.returncode, 2)
+        for source in ("--workspace", "BUNNYFORGE_MCP_WORKSPACE",
+                       "DEFAULT_WORKSPACE"):
+            self.assertIn(source, proc.stderr)
+
+    def test_the_env_var_reaches_the_real_cli(self):
+        # Not just the helper: the wiring has to actually be in main().
+        tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (tmp / "campaign.toml").write_text('[campaign]\nnamespace = "t"\n',
+                                           encoding="utf-8")
+        env = {**os.environ, "BUNNYFORGE_MCP_WORKSPACE": str(tmp)}
+        proc = subprocess.run([sys.executable, str(SCRIPT), "--status"],
+                              capture_output=True, text=True, env=env)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lets the shipped script be used unedited, so a personal copy is no longer needed.

Base branch: **`main`** (not stacked on anything).

**Sequencing:** #55 is open and also touches `scripts/mcp-session.py` (a different region — the closing banner). Whichever merges second may want a trivial rebase; happy to do it.

## Files changed
- `scripts/mcp-session.py` (modified) — `WORKSPACE_ENV`, `chosen_workspace()`, and the wiring in `main()`.
- `tests/test_mcp_session.py` (modified) — 6 new tests, and an environment scrub on an existing one.
- `docs/serve-mcp.md` (modified) — the "One command" section now leads with the variable.

## Work breakdown

The workspace now resolves `--workspace` → `$BUNNYFORGE_MCP_WORKSPACE` → `DEFAULT_WORKSPACE`, and **the order is the feature**:

- The **variable** exists so the shipped copy can be used as-is. Naming your campaign in a shell profile leaves nothing in `git status`; editing the constant leaves a local diff to carry across every pull.
- The **flag still wins**, so a one-off run against a different campaign needs no unsetting.
- The **constant stays** for anyone who would rather edit a file than set a variable.

This came from a real maintenance problem rather than a preference: a personal copy of this script had drifted 26 lines from the repository's, and each fix — the DNS-resolver ordering, the log files, the port guard, the redirect handling — had to be applied twice or silently applied to the copy that was not being run. The variable removes the reason to keep a second copy at all.

**An empty variable does not count as set.** `export BUNNYFORGE_MCP_WORKSPACE=` in a profile is an easy way to end up with one, and treating `""` as configured would resolve the workspace to the current directory — which for this script means serving whatever directory you happened to be standing in.

## A test that would have broken on other people's machines

`test_refuses_without_a_workspace_rather_than_guessing` ran the script with the caller's environment inherited. The moment anyone exported `BUNNYFORGE_MCP_WORKSPACE` — the entire point of this change — the script would have found a workspace, not refused, and that test would have failed **on their machine and nowhere else**, including in CI where the variable is unset. It now scrubs the variable explicitly, with the reason recorded.

Verified by running the suite twice: once normally, and once with `BUNNYFORGE_MCP_WORKSPACE` set to a junk path. Green both ways.

## Test expectations
None expected to fail.

## Verification

- `unittest discover` → **819 tests, OK** (was 813; +6).
- The same suite with `BUNNYFORGE_MCP_WORKSPACE=/tmp/not-a-workspace` → **819, OK**, proving the scrub works.
- End to end through the real CLI, not just the helper: with the variable pointing at a scaffolded temp workspace, `mcp-session.py --status` exits 0; with everything unset, it exits 2 and the refusal names all three sources.
- Precedence covered directly: flag beats variable, variable beats unset, empty variable is not "set".

## Operational impact
Additive and backward compatible. Existing invocations with `--workspace` are unaffected, and an unset variable behaves exactly as before.

## Provenance
- Agent: Claude Code (VS Code extension), inline execution in an isolated git worktree
- Model / version: the session requested Opus 5 (`claude-opus-5[1m]`)