### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.3.1"
+version = "0.4.0"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Bumps `version` in `pyproject.toml` from `0.3.1` to `0.4.0`, so `v0.4.0` can be
tagged. `publish.yml` fails a tag that disagrees with `pyproject.toml`, so this
has to land on `main` before the tag is pushed.

PyPI's newest release is **0.3.1** and `main` is **67 commits ahead** of it, so
two user-facing features are currently unreachable from the published package.
Confirmed against the tag rather than assumed — `vscode.py`, `serve_mcp.py`,
`_store.py` and `_mcp_auth.py` are all absent from `v0.3.1`, whose
`pyproject.toml` declares no `optional-dependencies` at all and therefore no
`[mcp]` extra.

**Why 0.4.0, not 0.3.2 or 1.0.0.** New features, so not a patch. Nothing breaks
for anyone already on 0.3.1, so not a major. `serve-mcp`'s `--token` →
`--auth-key`/`--public-host` change happened before that subcommand ever
shipped, so no published user is affected by it.

## Files changed

- `pyproject.toml` *(modified)* — `version = "0.3.1"` → `version = "0.4.0"`. One
  line; it is the only occurrence of the version string in the repo (grepped
  across `*.py`, `*.toml`, `*.md`, `*.yml`).

## Work breakdown

The release contents this version number covers, all already merged to `main`:

- **`bunnyforge vscode`** — install/update the preview extension, toggle the
  visibility colour language (#33, #34).
- **`bunnyforge serve-mcp`** — a workspace served to a remote AI agent over MCP:
  read tools, doctrine resources, name generation, staged write-back (#40, #41),
  self-hosted OAuth for claude.ai custom connectors (#42), a tunnel
  DNS-rebinding fix (#46), and a `--check` pre-flight (#51).
- **The new `bunnyforge[mcp]` extra** — every other subcommand stays
  zero-dependency.
- **`scripts/mcp-session.py`** and **`docs/serve-mcp.md`**.
- **A test binding the README's scaffold inventory to `MANIFEST`** (#37).

No code changes in this PR itself — it is the version bump only, kept separate
from the tag push per the "Releasing" procedure in `README.md`.

## Test expectations

No failures expected. Baseline run before the bump, on the branch's tree:
`819 tests, OK` via the discovery door
(`python3 -m unittest discover -s tests -t .`), plus
`tests/check_portability.py` **PASSED** (seed=20260729). Run in a clean venv
with the `[mcp]` extra installed, so the OAuth and MCP-server tests actually
executed rather than being `HAVE_MCP`-skipped.

## Operational impact

Merging this alone publishes nothing. It unblocks the release, which then
proceeds per `README.md` → "Releasing": tag `v0.4.0` and push it, `publish.yml`
verifies the tag against `pyproject.toml` and uploads to PyPI by trusted
publishing.

**PyPI never lets a version number be reused, even after deletion**, so this is
the irreversible step of the release and the number to get right.

Post-publish, expect index lag for a few minutes (a client may still be served
0.3.1); installability will be confirmed by what `pip show` actually reports in
a clean virtualenv on a path holding no checkout, not by the workflow's green
tick.

## Provenance

- **Agent:** Claude Code (VS Code extension)
- **Model / version:** Claude Opus 5 (1M context) — as named by this session's
  system prompt. The running model is not directly observable from inside the
  session, so this records what was requested, not a verified fact.
