### PR TITLE
feat: serve-mcp read-only staging access — list_staged, read_staged

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -91,8 +91,8 @@ are missing.
 
 ## What the agent can do
 
-**Read:** `campaign_overview`, `list_entities`, `read_entity`, `search`,
-`generate_names`. Workspace doctrine (`style-guide.md`,
+**Read canon:** `campaign_overview`, `list_entities`, `read_entity`,
+`search`, `generate_names`. Workspace doctrine (`style-guide.md`,
 `situation-design.md`, `AGENTS.md`) is served as MCP *resources* — tell
 the agent to load them before it writes anything for this campaign.
 
@@ -105,11 +105,21 @@ the agent to load them before it writes anything for this campaign.
 
 Both land in the workspace's staging directory (`staging_dir`, default
 `_ExtractInbound`) and go no further. That directory is one of
-`exclude_dirs`, so staged material is invisible to the read tools and to
-every other bunnyforge command until you promote it by hand — it flows
-through whatever extraction workflow your `AGENTS.md` already defines.
-**In the default configuration the agent cannot alter canon at all.** The
-server stages; deciding what becomes canon stays yours.
+`exclude_dirs`, so staged material stays invisible to the canon read tools
+above and to every other bunnyforge command until you promote it by hand —
+it flows through whatever extraction workflow your `AGENTS.md` already
+defines. **In the default configuration the agent cannot alter canon at
+all.** The server stages; deciding what becomes canon stays yours.
+
+**Read back its own staging:** `list_staged()` gives every staged file with
+its kind (`draft` or `revision`); `read_staged(path)` returns one in full.
+They are the one deliberate window into the staging directory, and they say
+so — their tool descriptions tell the agent the material is unreviewed and
+not canon. They exist so it can pick up its own drafts from an earlier
+session and merge them rather than write them again; without them it could
+write into staging and never see the result, not even its own work. They
+reach nothing else: a canonical path handed to `read_staged` is refused.
+Promotion is unchanged — still manual, still yours.
 
 **Write back, into canon — only if you ask for it:**
 

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -65,8 +65,10 @@ class WorkspaceStore:
         directories.
 
         The staging directory is one of the excluded ones, so a draft written
-        there is not readable back through this method: the read tools serve
-        canon, and staged material is not canon until a human promotes it.
+        there is not readable back through this method: the canon read tools
+        serve canon, and staged material is not canon until a human promotes
+        it. Staging has its own labelled door — read_staged, below — which
+        guards the inverse condition and reaches nothing else.
         """
         root = self.ws.root
         p = (root / path).resolve()
@@ -199,15 +201,64 @@ class WorkspaceStore:
                 "places": [_names.place_name(rng, inv, key)
                            for _ in range(count)]}
 
-    # -- write side ---------------------------------------------------------
-    # Staging paths are built directly rather than through _canonical: the
-    # staging directory is excluded from reads BY DESIGN, and these two
-    # methods are the only writers. Traversal is impossible by construction
-    # -- section is validated against config, and _DRAFT_NAME_RE admits no
-    # separator.
+    # -- staging ------------------------------------------------------------
 
     def _staging(self) -> Path:
         return self.ws.root / self.ws.config.staging_dir
+
+    # Reading staging back is the agent's own inbox, not a second door into
+    # canon: these two are the only way in, they reach nothing else, and the
+    # tool docstrings say the material is unreviewed. read_staged's guard is
+    # the exact inverse of _canonical() -- inside the staging directory
+    # rather than outside it -- so it cannot be talked into serving canon.
+    # Its messages name the TOOL the agent can call next, which is what it
+    # can act on; list_staging is what the tool layer registers as that.
+
+    def list_staging(self) -> list[dict]:
+        """Every staged markdown file: its workspace path and what it is.
+
+        "revision" means the mirrored canonical file exists, so the GM reads
+        it as a diff; "draft" means new content with nothing to compare
+        against. Sorted, so two calls agree.
+        """
+        staging = self._staging()
+        out = []
+        for p in sorted(staging.rglob("*.md")):
+            if not p.is_file():
+                continue
+            mirrored = self.ws.root / p.relative_to(staging)
+            out.append({"path": p.relative_to(self.ws.root).as_posix(),
+                        "kind": "revision" if mirrored.is_file() else "draft"})
+        return out
+
+    def read_staged(self, path: str) -> str:
+        """Full text of one staged file — unreviewed material, not canon."""
+        root = self.ws.root
+        staging = self._staging()
+        p = (root / path).resolve()
+        if not p.is_relative_to(root):
+            raise StoreError(f"path escapes the workspace: {path}")
+        if not p.is_relative_to(staging):
+            raise StoreError(
+                f"not a staged path: {path} — read_staged serves "
+                f"{self.ws.config.staging_dir}/ only; canonical files are "
+                "read with read_entity")
+        if p.suffix != ".md":
+            raise StoreError(
+                f"not a staged markdown file: {path} — staging holds .md "
+                "drafts and revisions")
+        if not p.is_file():
+            raise StoreError(
+                f"no such staged file: {path} — list_staged shows what is "
+                "currently staged")
+        return p.read_text(encoding="utf-8")
+
+    # -- write side ---------------------------------------------------------
+    # Staging paths are built directly rather than through _canonical: the
+    # staging directory is excluded from the canon reads BY DESIGN, and these
+    # two methods are the only writers. Traversal is impossible by
+    # construction -- section is validated against config, and _DRAFT_NAME_RE
+    # admits no separator.
 
     def stage_draft(self, section: str, name: str, content: str) -> str:
         self._check_section(section)

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -134,6 +134,24 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         path."""
         return store.stage_revision(path, content)
 
+    @server.tool()
+    def list_staged() -> list[dict]:
+        """List everything you have staged and not yet had promoted: each
+        path, and whether it is a "draft" (new content) or a "revision" (a
+        proposed rewrite of an existing file). This is your own inbox, NOT
+        canon — nothing here has been reviewed, and it may never be. Use it
+        to pick up drafts from an earlier session instead of starting them
+        again."""
+        return store.list_staging()
+
+    @server.tool()
+    def read_staged(path: str) -> str:
+        """Read one staged file in full. Paths come from list_staged.
+        Staged material is UNREVIEWED and is not canon — do not treat it as
+        established fact about the campaign; read it to revisit or merge
+        your own earlier drafts. For canonical files, use read_entity."""
+        return store.read_staged(path)
+
     if allow_direct_edits:
         @server.tool()
         def write_entity(path: str, content: str) -> str:

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -112,6 +112,41 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         names = {t.name for t in await server.list_tools()}
         self.assertLessEqual({"save_draft", "propose_revision"}, names)
 
+    async def test_staging_read_tools_always_registered(self):
+        # Staging is the agent's own inbox, so reading it back needs no flag:
+        # nothing here can reach canon.
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual({"list_staged", "read_staged"}, names)
+
+    async def test_list_staged_reports_what_was_staged(self):
+        store = scaffold(self)
+        server = serve_mcp.build_server(store)
+        await server.call_tool(
+            "save_draft", {"section": "NPCs", "name": "Cho", "content": "x"})
+        payload = await self._text(await server.call_tool("list_staged", {}))
+        self.assertIn("_ExtractInbound/NPCs/Cho.md", payload)
+        self.assertIn("draft", payload)
+
+    async def test_read_staged_round_trips_a_draft(self):
+        store = scaffold(self)
+        server = serve_mcp.build_server(store)
+        await server.call_tool(
+            "save_draft", {"section": "NPCs", "name": "Cho",
+                           "content": "---\ntitle: Cho\n---\nthe smuggler\n"})
+        payload = await self._text(await server.call_tool(
+            "read_staged", {"path": "_ExtractInbound/NPCs/Cho.md"}))
+        self.assertIn("the smuggler", payload)
+
+    async def test_read_staged_refuses_a_canonical_path(self):
+        # The two read doors stay separate: read_staged must not become a
+        # second way into canon.
+        server = serve_mcp.build_server(scaffold(self))
+        with self.assertRaises(Exception) as ctx:
+            await server.call_tool(
+                "read_staged", {"path": "NPCs/kim-ha-eun.md"})
+        self.assertIn("read_entity", str(ctx.exception))
+
     async def test_write_entity_only_with_the_flag(self):
         # The gate is the whole safety story: staging is always available
         # because it cannot reach canon, and canon is reachable only

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -114,7 +114,8 @@ class TestReadEntity(StoreCase):
 
     def test_excluded_dir_is_refused(self):
         # The staging directory is excluded by default, so drafts written
-        # there are not readable back: the read tools serve canon.
+        # there are not readable back through read_entity: it serves canon.
+        # Staging is reached through read_staged instead (TestStagingReads).
         ws = self.make_ws()
         staged = ws.root / "_ExtractInbound"
         staged.mkdir()
@@ -287,6 +288,82 @@ class TestStageRevision(StoreCase):
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError):
             store.stage_revision("../outside.md", "x")
+
+
+class TestStagingReads(StoreCase):
+    """The agent's own inbox. Staging stays invisible to the canon read
+    tools; these two methods are the one labelled way back in, so that a
+    draft written last session can be revisited rather than re-invented.
+    """
+
+    def test_listing_distinguishes_a_draft_from_a_revision(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.stage_draft("NPCs", "Cho", "x")
+        store.stage_revision("NPCs/kim-ha-eun.md", "y")
+        found = {e["path"]: e["kind"] for e in store.list_staging()}
+        self.assertEqual(found, {
+            "_ExtractInbound/NPCs/Cho.md": "draft",
+            "_ExtractInbound/NPCs/kim-ha-eun.md": "revision",
+        })
+
+    def test_nothing_staged_is_an_empty_list_not_an_error(self):
+        # The staging directory does not exist until something is staged.
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.list_staging(), [])
+
+    def test_listing_ignores_non_markdown(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.stage_draft("NPCs", "Cho", "x")
+        (ws.root / "_ExtractInbound" / "notes.txt").write_text(
+            "scratch", encoding="utf-8")
+        self.assertEqual([e["path"] for e in store.list_staging()],
+                         ["_ExtractInbound/NPCs/Cho.md"])
+
+    def test_listing_honors_a_configured_staging_dir(self):
+        ws = self.make_ws('\n[workspace]\nstaging_dir = "_Inbox"\n')
+        store = _store.WorkspaceStore(ws)
+        store.stage_draft("NPCs", "Cho", "x")
+        self.assertEqual([e["path"] for e in store.list_staging()],
+                         ["_Inbox/NPCs/Cho.md"])
+
+    def test_read_round_trips_a_staged_file(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        rel = store.stage_draft("NPCs", "Cho", "---\ntitle: Cho\n---\nbody\n")
+        self.assertEqual(store.read_staged(rel),
+                         "---\ntitle: Cho\n---\nbody\n")
+
+    def test_escape_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_staged("_ExtractInbound/../../outside.md")
+
+    def test_absolute_path_outside_the_workspace_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_staged("/etc/hosts")
+
+    def test_a_canonical_path_is_refused_and_points_at_read_entity(self):
+        # The inverse guard: read_staged serves staging and nothing else, so
+        # canon reaches the agent through one method only.
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.read_staged("NPCs/kim-ha-eun.md")
+        self.assertIn("read_entity", str(ctx.exception))
+
+    def test_missing_file_is_refused_pointing_at_the_listing(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.read_staged("_ExtractInbound/NPCs/nobody.md")
+        self.assertIn("list_staged", str(ctx.exception))
+
+    def test_a_non_markdown_staged_file_is_refused(self):
+        ws = self.make_ws()
+        (ws.root / "_ExtractInbound").mkdir()
+        (ws.root / "_ExtractInbound" / "notes.txt").write_text(
+            "scratch", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).read_staged("_ExtractInbound/notes.txt")
 
 
 class TestWriteEntity(StoreCase):


### PR DESCRIPTION
Closes #59.

The MCP agent could write drafts into the staging directory but never read them back — not even its own work from an earlier session. `staging_dir` (`_ExtractInbound`) is one of `exclude_dirs`, so `_canonical()` refuses every path under it, and all four canon read tools with it. This adds one explicitly labelled window into staging and changes nothing else: the canon read tools are untouched, and promotion stays manual and GM-only.

## Files changed

- `src/bunnyforge/_store.py` (modified) — `list_staging()` and `read_staged()`; `_staging()` moved under a new `-- staging --` section header so the `-- write side --` comment stays attached to the writers it describes; `_canonical()`'s docstring amended to point at the new door.
- `src/bunnyforge/serve_mcp.py` (modified) — `list_staged()` and `read_staged(path)` tools, registered unconditionally alongside the other read tools.
- `docs/serve-mcp.md` (modified) — "What the agent can do": the claim that staged material is invisible to *the read tools* is now scoped to the **canon** read tools, plus a paragraph on the two new ones.
- `tests/test_store.py` (modified) — `TestStagingReads` (10 tests).
- `tests/test_serve_mcp.py` (modified) — 4 tests in `TestBuildServer`.

## Work breakdown

**`list_staging() -> list[dict]`** walks the staging directory for `.md` files and reports each as `{path, kind}`, with `path` workspace-relative — the same string `stage_draft` and `stage_revision` return, so a path from the listing can be fed straight back. `kind` is `"revision"` when the mirrored canonical file exists (the GM reads it as a diff) and `"draft"` otherwise: the same distinction the two writers make, re-derived from the filesystem rather than recorded anywhere. Sorted, so two calls agree. Non-markdown is skipped; nothing staged is an empty list, not an error — the directory does not exist until something is staged.

**`read_staged(path) -> str`** guards the exact inverse of `_canonical()`: resolve, refuse escapes, then require the result to be *inside* the staging directory rather than outside it. A canonical path, a non-`.md` file, and a missing file are each refused separately, and each refusal names the tool that does serve what was asked for (`read_entity`, `list_staged`) rather than merely saying no — matching the existing `StoreError` style.

**The boundary is the tool descriptions, not just the guard.** Both say the material is UNREVIEWED and not canon, and frame staging as the agent's own inbox for revisiting and merging its own drafts. That is what stops the agent treating a draft it wrote last session as established fact about the campaign. `read_staged` reaches nothing but staging, so it cannot become a second door into canon — pinned by a test at both the store and server layers.

Written test-first: each test was watched failing (store: `AttributeError`, no such method; server: tool not registered / `Unknown tool: read_staged`) before the implementation existed.

Out of scope, as designed: search over staging, and any write or delete capability for staged files. `import_perceptions.py` needs no change — wiki perceptions already land in the readable `Perceptions/` section.

## Test expectations

None — everything passes. Verified on a clean checkout of the committed tree (`git archive`), not the working directory, in both CI configurations:

- without the `mcp` extra: `Ran 833 tests ... OK (skipped=52)`
- with the `mcp` extra: `Ran 833 tests ... OK` (0 skipped)
- `tests/check_portability.py`: `PASSED (seed=20260729)`

Baseline before the change was 819 passing; the 14 new tests are the difference. Worth noting for anyone reproducing locally: this repo's venv has an editable install pointing at the primary clone, so a run from a worktree silently tests the *other* checkout unless `PYTHONPATH` names the worktree's `src/`. Both CI jobs `pip install -e .` from the checkout under test, so CI is unaffected.

## Operational impact

None. No new dependency, no config key, no flag. Two tools appear in the connector's tool list, so claude.ai will ask to grant them — an existing connector needs **Always Allow** clicked for `list_staged` and `read_staged` before the agent will call them (docs/serve-mcp.md, "Then grant the tools").

## Provenance

- **Agent:** Claude Code (VS Code extension), `superpowers` skills — `using-git-worktrees`, `test-driven-development`, `opening-a-pr`
- **Model / version:** the session was set to Claude Opus 5 via `/model`; the harness environment reported Fable 5. Stating what the transcript asked for rather than asserting which model actually ran.