### PR TITLE
feat: split serve-mcp's staging directory into _AgentDrafts/ and _ExtractInbound/

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -119,6 +119,9 @@ returns one in full. They exist so the agent picks up its own earlier
 work and merges rather than re-writing; a `_`-prefixed subdirectory
 (say, `_AgentDrafts/_Rejected/`, if you use rejection-by-moving) is
 never listed or read, so rejected material stays rejected.
+`campaign_overview`'s `drafts_pending` count is the discovery hook for
+this — it tells the agent there is earlier work worth resuming before it
+calls `list_drafts()`.
 
 **The inbound queue — read only when you ask:** `_ExtractInbound/`
 (`inbound_dir`, also always excluded from the canon read tools regardless

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -108,7 +108,9 @@ All of it lands in the agents' drafts directory (`drafts_dir`, default
 `_AgentDrafts`) and goes no further. That directory is always excluded
 from the canon read tools — whatever `exclude_dirs` says — so drafts stay
 invisible to every other bunnyforge command until you promote them.
-**In the default configuration the agent cannot alter canon at all.**
+**In the default configuration the agent cannot alter canon at all** —
+promotion is manual and yours, done by hand outside any tool, unless you
+start the server with `--allow-direct-edits`.
 
 **Read drafts back:** `list_drafts()` gives every pending draft with its
 kind (`new` or `revision`), title, summary, and — for revisions — whether
@@ -119,7 +121,8 @@ work and merges rather than re-writing; a `_`-prefixed subdirectory
 never listed or read, so rejected material stays rejected.
 
 **The inbound queue — read only when you ask:** `_ExtractInbound/`
-(`inbound_dir`) is yours: material you authored elsewhere, awaiting
+(`inbound_dir`, also always excluded from the canon read tools regardless
+of `exclude_dirs`) is yours: material you authored elsewhere, awaiting
 extraction. `list_inbound()` lists every live file — all formats, each
 marked `readable` or not — and `read_inbound(path)` returns text formats
 (`.md`, `.txt`, `.html`, `.htm`; anything else is listed but refused

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -96,43 +96,60 @@ are missing.
 `situation-design.md`, `AGENTS.md`) is served as MCP *resources* — tell
 the agent to load them before it writes anything for this campaign.
 
-**Write back, into staging:**
+**Write drafts:**
 
 | tool | writes to |
 |---|---|
-| `save_draft(section, name, content)` | `<staging_dir>/<section>/<name>.md` — new content only, never overwrites |
-| `propose_revision(path, content)` | `<staging_dir>/<path>`, mirroring the canonical path, so you review it as a diff |
+| `save_draft(section, name, content, subdir=None)` | `<drafts_dir>/<section>/[<subdir>/]<slug>.md` — new content; names are slugged to kebab-case; never overwrites |
+| `propose_revision(path, content)` | `<drafts_dir>/<path>`, mirroring the canonical path, so you review it as a diff; one pending proposal per file |
+| `update_draft(path, content)` | an existing draft — the one deliberate overwrite door, for iterating across sessions |
 
-Both land in the workspace's staging directory (`staging_dir`, default
-`_ExtractInbound`) and go no further. That directory is one of
-`exclude_dirs`, so staged material stays invisible to the canon read tools
-above and to every other bunnyforge command until you promote it by hand —
-it flows through whatever extraction workflow your `AGENTS.md` already
-defines. **In the default configuration the agent cannot alter canon at
-all.** The server stages; deciding what becomes canon stays yours.
+All of it lands in the agents' drafts directory (`drafts_dir`, default
+`_AgentDrafts`) and goes no further. That directory is always excluded
+from the canon read tools — whatever `exclude_dirs` says — so drafts stay
+invisible to every other bunnyforge command until you promote them.
+**In the default configuration the agent cannot alter canon at all.**
 
-**Read back its own staging:** `list_staged()` gives every staged file with
-its kind (`draft` or `revision`); `read_staged(path)` returns one in full.
-They are the one deliberate window into the staging directory, and they say
-so — their tool descriptions tell the agent the material is unreviewed and
-not canon. They exist so it can pick up its own drafts from an earlier
-session and merge them rather than write them again; without them it could
-write into staging and never see the result, not even its own work. They
-reach nothing else: a canonical path handed to `read_staged` is refused.
-Promotion is unchanged — still manual, still yours.
+**Read drafts back:** `list_drafts()` gives every pending draft with its
+kind (`new` or `revision`), title, summary, and — for revisions — whether
+canon changed underneath the proposal (`stale`). `read_draft(path)`
+returns one in full. They exist so the agent picks up its own earlier
+work and merges rather than re-writing; a `_`-prefixed subdirectory
+(say, `_AgentDrafts/_Rejected/`, if you use rejection-by-moving) is
+never listed or read, so rejected material stays rejected.
+
+**The inbound queue — read only when you ask:** `_ExtractInbound/`
+(`inbound_dir`) is yours: material you authored elsewhere, awaiting
+extraction. `list_inbound()` lists every live file — all formats, each
+marked `readable` or not — and `read_inbound(path)` returns text formats
+(`.md`, `.txt`, `.html`, `.htm`; anything else is listed but refused
+with a convert-it hint, and undecodable bytes are replaced rather than
+crashing). Both tools' descriptions carry your AGENTS.md contract: the
+agent calls them **only when you ask it to extract**. It learns the
+queue is non-empty from `campaign_overview`'s `inbound_pending` count —
+which permits noticing and offering, never unbidden reading.
+`_ExtractInbound/_Done/` and any other `_`-prefixed area are invisible
+to both tools, exactly like `_Ignore/`.
 
 **Write back, into canon — only if you ask for it:**
 
     bunnyforge serve-mcp --allow-direct-edits ...
 
-registers a third tool, `write_entity(path, content)`, which edits a
+registers two more tools. `write_entity(path, content)` edits a
 canonical file in place and commits each edit with a
-`serve-mcp: edit <path>` message. It refuses outside a git repository:
-without history there is no review and no undo, and that is the only
-thing that makes editing canon defensible. It is a per-run flag rather
-than a config key on purpose — trading the staging boundary for git
-history should be a decision you make when starting the server, not a
-setting that quietly persists.
+`serve-mcp: edit <path>` message. `promote_draft(path)` moves a draft
+you have just approved in chat to its canonical location (derived from
+the draft path — slugged drafts mirror canon) and commits it as
+`serve-mcp: promote <path>`; a revision whose base no longer matches
+canon is refused, never silently applied over your interim edits.
+Promotion deliberately does not touch `compendium.md` or
+`front-burner.md` — index updates flow through `propose_revision` as
+ever. Both tools refuse outside a git repository: without history there
+is no review and no undo, and that is the only thing that makes
+changing canon defensible. It is a per-run flag rather than a config
+key on purpose — trading the review boundary for git history should be
+a decision you make when starting the server, not a setting that
+quietly persists.
 
 Publishing is structurally absent in every mode: no tool here can reach
 `Export/` or the wiki, so a remote agent cannot leak GM-only material to

--- a/docs/superpowers/plans/2026-08-17-inbound-drafts-split.md
+++ b/docs/superpowers/plans/2026-08-17-inbound-drafts-split.md
@@ -1,0 +1,1522 @@
+# Inbound/Drafts Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split serve-mcp's conflated staging directory into `_AgentDrafts/` (agent output with a full draft lifecycle: save, propose, update, list, read, promote) and `_ExtractInbound/` (the GM's inbound queue, read-only under an only-when-asked contract).
+
+**Architecture:** All behaviour lands on `WorkspaceStore` (`src/bunnyforge/_store.py`) — it is the swap seam for a future hosted backend (issue #43), so the MCP layer (`serve_mcp.py`) only registers thin tools over store methods. Config (`_config.py`) renames `staging_dir` → `inbound_dir`, adds `drafts_dir`, and auto-excludes both from canon walks at load time. Revision provenance lives in one JSON manifest inside the drafts directory.
+
+**Tech Stack:** Python 3.11+, stdlib only in `_store.py`/`_config.py`. The `mcp` SDK is an optional extra imported only inside function bodies of `serve_mcp.py`. Tests are stdlib `unittest`.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-inbound-drafts-split-design.md` — read it before starting; every task below argues from it.
+
+## Global Constraints
+
+- Python 3.11+; `_store.py` and `_config.py` import nothing outside the stdlib and the `bunnyforge` package.
+- The `mcp` SDK is imported only inside function bodies in `serve_mcp.py`.
+- The words "staging"/"staged" must not survive in any tool name, config key, store method, docstring, error message, or in `docs/serve-mcp.md`. (`deploy_export.py`'s wiki-staging vocabulary is a different concept — leave it alone.)
+- TDD: every step-pair is failing-test-first. Run tests as `PYTHONPATH=src python3 -m unittest tests.test_store -v` (substitute the module).
+- The `mcp` extra is NOT installed in this environment: `test_serve_mcp.py` classes guarded by `HAVE_MCP` **skip locally** and run in CI. Write them anyway; verify they at least import (`PYTHONPATH=src python3 -m unittest tests.test_serve_mcp -v` must end `OK (skipped=…)`).
+- Baseline before Task 1: `PYTHONPATH=src python3 -m unittest discover -s tests` → `Ran 833 tests … OK (skipped=52)`. After every task the suite must be green (test counts will grow; skips grow with new SDK-gated tests).
+- Work on branch `feat/inbound-drafts-split` (already created). Commit after each task with a `Co-Authored-By: Claude <model> <noreply@anthropic.com>` trailer naming the executing model.
+- Error-message style: every `StoreError`/`ConfigError` names the valid next move (an alternative tool, the key to rename), never merely "no".
+
+---
+
+### Task 1: Config — `inbound_dir` / `drafts_dir` split
+
+**Files:**
+- Modify: `src/bunnyforge/_config.py` (Config namedtuple ~line 34; `_DEFAULTS` ~line 111; `load()` ~line 319)
+- Modify: `src/bunnyforge/data/campaign.toml.in` (commented `[workspace]` block)
+- Modify: `src/bunnyforge/_store.py` (only the two `config.staging_dir` attribute reads, lines ~207 and ~244 — method names change in Task 2, not here)
+- Modify: `tests/test_config.py` (replace the three `staging_dir` tests at lines 249–267)
+- Modify: `tests/test_store.py` (two `staging_dir = "_Inbox"` TOML strings, lines ~259 and ~324 → `inbound_dir = "_Inbox"`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `Config.inbound_dir: str` (default `"_ExtractInbound"`), `Config.drafts_dir: str` (default `"_AgentDrafts"`); `Config.staging_dir` is gone. `Config.exclude_dirs` always contains both values. Every later task relies on these exact field names.
+
+- [ ] **Step 1: Write the failing tests** — in `tests/test_config.py`, delete `test_staging_dir_defaults_to_extract_inbound`, `test_staging_dir_honours_explicit_override`, `test_staging_dir_wrong_type_raises` (lines 249–267) and put this in their place:
+
+```python
+    def test_inbound_dir_defaults_to_extract_inbound(self):
+        # The GM's inbound queue: material authored elsewhere, awaiting
+        # extraction. Excluded from every walk unconditionally (below).
+        cfg = _config.load(self._ws(MINIMAL))
+        self.assertEqual(cfg.inbound_dir, "_ExtractInbound")
+        self.assertIn(cfg.inbound_dir, cfg.exclude_dirs)
+
+    def test_drafts_dir_defaults_to_agent_drafts(self):
+        cfg = _config.load(self._ws(MINIMAL))
+        self.assertEqual(cfg.drafts_dir, "_AgentDrafts")
+        self.assertIn(cfg.drafts_dir, cfg.exclude_dirs)
+
+    def test_special_dirs_are_excluded_even_when_exclude_dirs_omits_them(self):
+        # No configuration may un-exclude either special directory: a
+        # workspace that customised exclude_dirs without them would silently
+        # serve agent drafts as canon.
+        cfg = _config.load(self._ws(
+            MINIMAL + '\n[workspace]\nexclude_dirs = ["docs"]\n'))
+        self.assertIn("_ExtractInbound", cfg.exclude_dirs)
+        self.assertIn("_AgentDrafts", cfg.exclude_dirs)
+
+    def test_overridden_special_dirs_are_auto_excluded_too(self):
+        cfg = _config.load(self._ws(
+            MINIMAL +
+            '\n[workspace]\ninbound_dir = "_Inbox"\ndrafts_dir = "_Outbox"\n'))
+        self.assertEqual(cfg.inbound_dir, "_Inbox")
+        self.assertEqual(cfg.drafts_dir, "_Outbox")
+        self.assertIn("_Inbox", cfg.exclude_dirs)
+        self.assertIn("_Outbox", cfg.exclude_dirs)
+
+    def test_staging_dir_key_is_refused_naming_the_rename(self):
+        # load() ignores unknown keys, so without this check an old
+        # staging_dir key would be silently dropped — a behaviour change
+        # with no error.
+        with self.assertRaises(_config.ConfigError) as ctx:
+            _config.load(self._ws(
+                MINIMAL + '\n[workspace]\nstaging_dir = "_Inbox"\n'))
+        self.assertIn("inbound_dir", str(ctx.exception))
+
+    def test_inbound_and_drafts_dir_wrong_type_raises(self):
+        for key in ("inbound_dir", "drafts_dir"):
+            with self.assertRaises(_config.ConfigError) as ctx:
+                _config.load(self._ws(
+                    MINIMAL + f'\n[workspace]\n{key} = ["x"]\n'))
+            self.assertIn(key, str(ctx.exception))
+
+    def test_special_dir_naming_a_section_raises(self):
+        # drafts_dir = "Ideas" would auto-exclude a canon section from
+        # every walker — silently, since auto-exclusion happens at load.
+        for key, section in (("drafts_dir", "Ideas"), ("inbound_dir", "Briefs")):
+            with self.assertRaises(_config.ConfigError) as ctx:
+                _config.load(self._ws(
+                    MINIMAL + f'\n[workspace]\n{key} = "{section}"\n'))
+            self.assertIn(section, str(ctx.exception))
+
+    def test_inbound_and_drafts_dir_must_differ(self):
+        # Identical values would recreate the conflation this split kills.
+        with self.assertRaises(_config.ConfigError) as ctx:
+            _config.load(self._ws(
+                MINIMAL +
+                '\n[workspace]\ninbound_dir = "_X"\ndrafts_dir = "_X"\n'))
+        self.assertIn("_X", str(ctx.exception))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_config -v`
+Expected: the new tests FAIL/ERROR (`AttributeError: 'Config' object has no attribute 'inbound_dir'`, missing ConfigError, etc.).
+
+- [ ] **Step 3: Implement in `_config.py`**
+
+In the `Config` namedtuple field string, replace `type_dirs staging_dir wiki_url` with `type_dirs inbound_dir drafts_dir wiki_url` (the `defaults=` list still maps onto the last five fields — do not touch it).
+
+In `_DEFAULTS`: remove `"_ExtractInbound"` from the `exclude_dirs` list; replace the `staging_dir` entry and its comment with:
+
+```python
+    # The GM's inbound queue (material authored elsewhere, awaiting
+    # extraction) and the agents' drafts directory (output awaiting GM
+    # review). Both are appended to exclude_dirs at load time, so neither
+    # appears in the default list above — a second copy would be a second
+    # thing to drift, and no configuration may un-exclude them.
+    "inbound_dir": "_ExtractInbound",
+    "drafts_dir": "_AgentDrafts",
+```
+
+In `load()`, after the `ws` table is validated (near the `entity_dirs` block), add:
+
+```python
+    if "staging_dir" in ws:
+        raise ConfigError(
+            f"{path}: workspace.staging_dir was renamed — use inbound_dir "
+            "for the GM's inbound queue. Agent drafts now live separately "
+            "under drafts_dir (default _AgentDrafts).")
+
+    inbound_dir = _str(ws, "inbound_dir")
+    drafts_dir = _str(ws, "drafts_dir")
+    if inbound_dir == drafts_dir:
+        raise ConfigError(
+            f"{path}: workspace.inbound_dir and workspace.drafts_dir are "
+            f"both {inbound_dir!r} — they must name different directories; "
+            "one is the GM's inbound queue, the other the agents' drafts")
+    for key, val in (("inbound_dir", inbound_dir), ("drafts_dir", drafts_dir)):
+        if val in entity_dirs or val in inherit_dirs:
+            raise ConfigError(
+                f"{path}: workspace.{key} = {val!r} names a content section "
+                "— it would be excluded from every walk; pick a directory "
+                "of its own (convention: a _-prefixed name)")
+```
+
+(Place this after `entity_dirs`/`inherit_dirs` are computed.) Then in the `return Config(...)` call: replace `staging_dir=_str(ws, "staging_dir"),` with `inbound_dir=inbound_dir, drafts_dir=drafts_dir,` and change the `exclude_dirs=` line to:
+
+```python
+        exclude_dirs=(frozenset(_str_tuple(ws, "exclude_dirs"))
+                      | MANDATORY_EXCLUDES | {inbound_dir, drafts_dir}),
+```
+
+- [ ] **Step 4: Update the other reference sites**
+
+`src/bunnyforge/_store.py`: change `self.ws.config.staging_dir` → `self.ws.config.inbound_dir` in `_staging()` (~line 207) and in `read_staged`'s error message (~line 244). Nothing else in this file yet.
+
+`src/bunnyforge/data/campaign.toml.in`: in the commented `[workspace]` block, remove `"_ExtractInbound",` from the `exclude_dirs` example and append below `perceptions_dir`:
+
+```
+# inbound_dir     = "_ExtractInbound"  # the GM's inbound queue; always
+#                                      # excluded from canon, listed or not
+# drafts_dir      = "_AgentDrafts"     # agent output awaiting review; always
+#                                      # excluded from canon, listed or not
+```
+
+`tests/test_store.py`: change both `'\n[workspace]\nstaging_dir = "_Inbox"\n'` strings (lines ~259, ~324) to `'\n[workspace]\ninbound_dir = "_Inbox"\n'`.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK, zero failures (853+ tests; skips unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/_config.py src/bunnyforge/_store.py src/bunnyforge/data/campaign.toml.in tests/test_config.py tests/test_store.py
+git commit -m "feat: split staging_dir into inbound_dir and drafts_dir in config"
+```
+
+---
+
+### Task 2: Store + tools — the drafts family
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (module docstring; `_DRAFT_NAME_RE` area; replace the `-- staging --` and write-side sections wholesale)
+- Modify: `src/bunnyforge/serve_mcp.py` (tool registrations, lines ~123–153)
+- Modify: `tests/test_store.py` (replace `TestStageDraft`, `TestStageRevision`, `TestStagingReads`)
+- Modify: `tests/test_serve_mcp.py` (replace the staging tool tests, lines ~110–167)
+
+**Interfaces:**
+- Consumes: `Config.drafts_dir`, `Config.perceptions_dir` (Task 1), `_common.split_front_matter`.
+- Produces (later tasks call these exact signatures):
+  - `WorkspaceStore.save_draft(section: str, name: str, content: str, subdir: str | None = None) -> str`
+  - `WorkspaceStore.propose_revision(path: str, content: str) -> str`
+  - `WorkspaceStore.list_drafts() -> list[dict]` — rows `{path, kind: "new"|"revision", title, summary}` plus `stale: bool|None` on revision rows only
+  - `WorkspaceStore.read_draft(path: str) -> str`
+  - Private helpers Tasks 3/6 reuse: `_drafts() -> Path`, `_draft_path(path: str) -> Path`, `_load_bases() -> dict[str, str]`, `_save_bases(dict) -> None`, `_set_base(shadow_rel: str, canon: Path) -> None`, module constant `BASES_NAME = ".proposal-bases.json"`.
+- Removes: `stage_draft`, `stage_revision`, `list_staging`, `read_staged` (store); `list_staged`, `read_staged` (tools).
+
+- [ ] **Step 1: Write the failing store tests** — in `tests/test_store.py`, add `import hashlib`, `import json` to the imports, then delete classes `TestStageDraft`, `TestStageRevision`, `TestStagingReads` and write in their place:
+
+```python
+class TestSaveDraft(StoreCase):
+    def test_writes_into_drafts_and_slugs_the_name(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("NPCs", "Old Man Cho", "---\ntitle: Cho\n---\n")
+        self.assertEqual(rel, "_AgentDrafts/NPCs/old-man-cho.md")
+        self.assertTrue((ws.root / rel).is_file())
+
+    def test_slug_drops_apostrophes_and_collapses_separators(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        rel = store.save_draft("NPCs", "Mara's  Old_Friend", "x")
+        self.assertEqual(rel, "_AgentDrafts/NPCs/maras-old-friend.md")
+
+    def test_subdir_nests_one_level_and_is_slugged(self):
+        # Briefs live at Briefs/session-NNN/<name>.md; a draft brief must be
+        # able to take its canonical shape, or every promotion re-nests by
+        # hand.
+        ws = self.make_ws()
+        rel = _store.WorkspaceStore(ws).save_draft(
+            "Briefs", "Kim Ha-eun", "x", subdir="Session 15")
+        self.assertEqual(rel, "_AgentDrafts/Briefs/session-15/kim-ha-eun.md")
+
+    def test_existing_draft_refusal_names_update_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.save_draft("NPCs", "Cho", "x")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.save_draft("NPCs", "Cho", "y")
+        self.assertIn("update_draft", str(ctx.exception))
+
+    def test_canonical_collision_refusal_names_propose_revision(self):
+        # A new draft shadowing an existing canonical file would be
+        # misreported as a revision and reviewed as a diff against the
+        # wrong entity.
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.save_draft("NPCs", "Kim Ha-eun", "x")  # slug: kim-ha-eun
+        self.assertIn("propose_revision", str(ctx.exception))
+
+    def test_refuses_unknown_section_and_bad_names(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.save_draft("Nope", "Cho", "x")
+        for bad in ("../escape", "a/b", ".hidden", "_underscore"):
+            with self.assertRaises(_store.StoreError):
+                store.save_draft("NPCs", bad, "x")
+            with self.assertRaises(_store.StoreError):
+                store.save_draft("NPCs", "Cho", "x", subdir=bad)
+
+    def test_perceptions_are_not_draftable(self):
+        # The perception record is by contract never agent-authored.
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.save_draft("Perceptions", "Cho", "x")
+        listed = str(ctx.exception).split("one of:")[1]
+        self.assertNotIn("Perceptions", listed)
+        self.assertIn("Briefs", listed)
+
+    def test_honours_configured_drafts_dir(self):
+        ws = self.make_ws('\n[workspace]\ndrafts_dir = "_Outbox"\n')
+        rel = _store.WorkspaceStore(ws).save_draft("NPCs", "Cho", "x")
+        self.assertEqual(rel, "_Outbox/NPCs/cho.md")
+
+
+class TestProposeRevision(StoreCase):
+    def test_shadow_mirrors_the_canonical_path_and_records_a_base(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.propose_revision("NPCs/kim-ha-eun.md", "new text")
+        self.assertEqual(rel, "_AgentDrafts/NPCs/kim-ha-eun.md")
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
+                         "new text")
+        bases = json.loads(
+            (ws.root / "_AgentDrafts" / ".proposal-bases.json")
+            .read_text(encoding="utf-8"))
+        canon_hash = hashlib.sha256(
+            (ws.root / "NPCs/kim-ha-eun.md").read_bytes()).hexdigest()
+        self.assertEqual(bases[rel], canon_hash)
+
+    def test_second_proposal_is_refused_and_the_first_survives(self):
+        # The old latest-wins rule silently destroyed pending proposals —
+        # routine, not rare: the end-of-session ritual proposes front-burner
+        # updates every session.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "first")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.propose_revision("NPCs/kim-ha-eun.md", "second")
+        self.assertIn("update_draft", str(ctx.exception))
+        self.assertEqual(
+            (ws.root / "_AgentDrafts/NPCs/kim-ha-eun.md")
+            .read_text(encoding="utf-8"), "first")
+
+    def test_requires_an_existing_target_naming_save_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.propose_revision("NPCs/nobody.md", "x")
+        self.assertIn("save_draft", str(ctx.exception))
+
+    def test_refuses_escapes(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.propose_revision("../outside.md", "x")
+
+
+class TestDraftReads(StoreCase):
+    """The agents' own outbox: freely readable, so a draft written last
+    session is revisited rather than re-invented."""
+
+    def test_listing_reports_kind_title_and_summary(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.save_draft("NPCs", "Cho",
+                         "---\ntitle: Old Man Cho\n"
+                         "summary: A dockside fixer.\n---\nbody\n")
+        store.propose_revision("NPCs/kim-ha-eun.md", "y")
+        rows = {r["path"]: r for r in store.list_drafts()}
+        cho = rows["_AgentDrafts/NPCs/cho.md"]
+        self.assertEqual(cho["kind"], "new")
+        self.assertEqual(cho["title"], "Old Man Cho")
+        self.assertEqual(cho["summary"], "A dockside fixer.")
+        self.assertNotIn("stale", cho)          # stale is revision-only
+        rev = rows["_AgentDrafts/NPCs/kim-ha-eun.md"]
+        self.assertEqual(rev["kind"], "revision")
+        self.assertIs(rev["stale"], False)
+
+    def test_title_falls_back_to_the_stem(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.save_draft("NPCs", "Cho", "no front matter\n")
+        [row] = store.list_drafts()
+        self.assertEqual(row["title"], "cho")
+        self.assertEqual(row["summary"], "")
+
+    def test_revision_goes_stale_when_canon_moves(self):
+        # A pending shadow must not silently revert the GM's interim edits;
+        # stale is how the listing warns, and promote_draft later refuses.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "proposal")
+        (ws.root / "NPCs/kim-ha-eun.md").write_text("GM edit",
+                                                    encoding="utf-8")
+        [row] = store.list_drafts()
+        self.assertIs(row["stale"], True)
+
+    def test_unrecorded_base_reports_stale_none(self):
+        ws = self.make_ws()
+        shadow = ws.root / "_AgentDrafts" / "NPCs"
+        shadow.mkdir(parents=True)
+        (shadow / "kim-ha-eun.md").write_text("hand-made", encoding="utf-8")
+        [row] = _store.WorkspaceStore(ws).list_drafts()
+        self.assertIsNone(row["stale"])
+
+    def test_corrupt_manifest_reads_as_empty_not_an_error(self):
+        # The manifest is a provenance cache, not a lock file.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "proposal")
+        (ws.root / "_AgentDrafts" / ".proposal-bases.json").write_text(
+            "not json", encoding="utf-8")
+        [row] = store.list_drafts()
+        self.assertIsNone(row["stale"])
+
+    def test_listing_skips_underscore_components(self):
+        # _AgentDrafts/_Rejected/ is the GM's rejection signal — never
+        # listed, so rejected material cannot be resurrected by resume.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.save_draft("NPCs", "Cho", "x")
+        rejected = ws.root / "_AgentDrafts" / "_Rejected"
+        rejected.mkdir(parents=True)
+        (rejected / "dead.md").write_text("x", encoding="utf-8")
+        self.assertEqual([r["path"] for r in store.list_drafts()],
+                         ["_AgentDrafts/NPCs/cho.md"])
+
+    def test_nothing_drafted_is_an_empty_list_not_an_error(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.list_drafts(), [])
+
+    def test_read_round_trips_a_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        rel = store.save_draft("NPCs", "Cho", "---\ntitle: Cho\n---\nbody\n")
+        self.assertEqual(store.read_draft(rel), "---\ntitle: Cho\n---\nbody\n")
+
+    def test_escape_and_absolute_paths_are_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_draft("_AgentDrafts/../../outside.md")
+        with self.assertRaises(_store.StoreError):
+            store.read_draft("/etc/hosts")
+
+    def test_a_canonical_path_is_refused_and_points_at_read_entity(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.read_draft("NPCs/kim-ha-eun.md")
+        self.assertIn("read_entity", str(ctx.exception))
+
+    def test_an_underscore_component_is_refused(self):
+        ws = self.make_ws()
+        rejected = ws.root / "_AgentDrafts" / "_Rejected"
+        rejected.mkdir(parents=True)
+        (rejected / "dead.md").write_text("x", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).read_draft(
+                "_AgentDrafts/_Rejected/dead.md")
+
+    def test_missing_draft_is_refused_pointing_at_the_listing(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.read_draft("_AgentDrafts/NPCs/nobody.md")
+        self.assertIn("list_drafts", str(ctx.exception))
+
+    def test_canon_tools_refuse_draft_paths(self):
+        # The inverse boundary: _AgentDrafts is auto-excluded, so the
+        # canon read door must refuse it exactly as it refuses _Ignore/.
+        store = _store.WorkspaceStore(self.make_ws())
+        rel = store.save_draft("NPCs", "Cho", "x")
+        with self.assertRaises(_store.StoreError):
+            store.read_entity(rel)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Expected: new classes FAIL/ERROR (`AttributeError: … no attribute 'save_draft'` etc.); pre-existing classes still pass.
+
+- [ ] **Step 3: Implement in `_store.py`**
+
+Add `import hashlib` and `import json` to the imports. Below `_DRAFT_NAME_RE`, add:
+
+```python
+BASES_NAME = ".proposal-bases.json"
+
+
+def _slug(name: str) -> str:
+    """A _DRAFT_NAME_RE-validated name, as a canon-style filename stem:
+    lowercase, separators to single hyphens, apostrophes dropped. Canon
+    files are kebab-case, and slugs are what let the drafts tree mirror
+    canon — which is what lets promotion derive its destination."""
+    s = name.lower().replace("'", "")
+    s = re.sub(r"[\s_]+", "-", s)
+    return re.sub(r"-+", "-", s).strip("-")
+```
+
+Replace the entire `# -- staging --` section (the `_staging` helper, `list_staging`, `read_staged`, and their comment block) and the write-side section (`stage_draft`, `stage_revision` — keep `write_entity`) with:
+
+```python
+    # -- agent drafts -------------------------------------------------------
+    # The agents' outbox: drafts and proposed revisions awaiting GM review.
+    # Excluded from the canon reads BY DESIGN (config auto-excludes it), so
+    # it has its own labelled doors. _draft_path guards the inverse of
+    # _canonical() — inside the drafts directory rather than outside it —
+    # so these methods cannot be talked into serving canon. Underscore
+    # components are machinery (the workspace's own convention): a draft
+    # the GM moves to _Rejected/ is never listed or read again.
+
+    def _drafts(self) -> Path:
+        return self.ws.root / self.ws.config.drafts_dir
+
+    def _draftable_sections(self) -> tuple[str, ...]:
+        # The perception record is by contract never agent-authored.
+        return tuple(s for s in self._sections()
+                     if s != self.ws.config.perceptions_dir)
+
+    def _slugged(self, raw: str, label: str) -> str:
+        if not _DRAFT_NAME_RE.fullmatch(raw):
+            raise StoreError(
+                f"bad {label} name {raw!r} — letters, digits, spaces, "
+                "- _ ' only, starting with a letter or digit")
+        return _slug(raw)
+
+    def _draft_path(self, path: str) -> Path:
+        root = self.ws.root
+        drafts = self._drafts()
+        p = (root / path).resolve()
+        if not p.is_relative_to(root):
+            raise StoreError(f"path escapes the workspace: {path}")
+        if not p.is_relative_to(drafts):
+            raise StoreError(
+                f"not a draft path: {path} — this tool serves "
+                f"{self.ws.config.drafts_dir}/ only; canonical files are "
+                "read with read_entity")
+        if any(part.startswith("_")
+               for part in p.relative_to(drafts).parts):
+            raise StoreError(
+                f"{path} is in a _-prefixed area of the drafts directory "
+                "(the GM's machinery, e.g. _Rejected/) and is never served")
+        if p.suffix != ".md":
+            raise StoreError(
+                f"not a draft markdown file: {path} — drafts are .md only")
+        return p
+
+    # The base manifest: workspace-relative shadow path -> SHA-256 of the
+    # canonical file at proposal time. A provenance cache, not a lock file:
+    # missing or unparseable reads as empty, and every save prunes entries
+    # whose shadow is gone.
+
+    def _bases_file(self) -> Path:
+        return self._drafts() / BASES_NAME
+
+    def _load_bases(self) -> dict[str, str]:
+        try:
+            raw = json.loads(self._bases_file().read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        return {k: v for k, v in raw.items()
+                if isinstance(k, str) and isinstance(v, str)}
+
+    def _save_bases(self, bases: dict[str, str]) -> None:
+        live = {k: v for k, v in bases.items()
+                if (self.ws.root / k).is_file()}
+        f = self._bases_file()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps(live, indent=2, sort_keys=True) + "\n",
+                     encoding="utf-8")
+
+    def _set_base(self, shadow_rel: str, canon: Path) -> None:
+        bases = self._load_bases()
+        bases[shadow_rel] = hashlib.sha256(canon.read_bytes()).hexdigest()
+        self._save_bases(bases)
+
+    def save_draft(self, section: str, name: str, content: str,
+                   subdir: str | None = None) -> str:
+        if section not in self._draftable_sections():
+            raise StoreError(
+                f"unknown or undraftable section {section!r} — one of: "
+                + ", ".join(self._draftable_sections()))
+        rel = Path(section)
+        if subdir is not None:
+            rel = rel / self._slugged(subdir, "subdir")
+        rel = rel / f"{self._slugged(name, 'draft')}.md"
+        if (self.ws.root / rel).is_file():
+            raise StoreError(
+                f"{rel.as_posix()} already exists in canon — use "
+                "propose_revision to suggest changes to it, or pick "
+                "another name")
+        dest = self._drafts() / rel
+        if dest.exists():
+            drel = dest.relative_to(self.ws.root).as_posix()
+            raise StoreError(
+                f"{drel} already exists — read_draft it and revise with "
+                "update_draft, or pick another name")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+        return dest.relative_to(self.ws.root).as_posix()
+
+    def propose_revision(self, path: str, content: str) -> str:
+        target = self._canonical(path)
+        if not target.is_file() or target.suffix != ".md":
+            raise StoreError(
+                f"no such content file: {path} — propose_revision proposes "
+                "changes to an existing file; use save_draft for new "
+                "content")
+        dest = self._drafts() / target.relative_to(self.ws.root)
+        rel = dest.relative_to(self.ws.root).as_posix()
+        if dest.exists():
+            raise StoreError(
+                f"a pending proposal already exists at {rel} — read_draft "
+                "it, merge your changes into it, then update_draft")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+        self._set_base(rel, target)
+        return rel
+
+    def list_drafts(self) -> list[dict]:
+        """Every pending draft: path, kind ("new" content or a "revision"
+        of an existing file), title and summary from front matter, and —
+        for revisions — whether canon changed since it was proposed.
+        Sorted, so two calls agree."""
+        drafts = self._drafts()
+        bases = self._load_bases()
+        out = []
+        for p in sorted(drafts.rglob("*.md")):
+            if not p.is_file():
+                continue
+            inner = p.relative_to(drafts)
+            if any(part.startswith("_") for part in inner.parts):
+                continue
+            rel = p.relative_to(self.ws.root).as_posix()
+            fm, _body = _common.split_front_matter(
+                p.read_text(encoding="utf-8"))
+            mirrored = self.ws.root / inner
+            row = {"path": rel,
+                   "kind": "revision" if mirrored.is_file() else "new",
+                   "title": fm.get("title") or p.stem,
+                   "summary": fm.get("summary", "")}
+            if row["kind"] == "revision":
+                base = bases.get(rel)
+                row["stale"] = (None if base is None else
+                                hashlib.sha256(mirrored.read_bytes())
+                                .hexdigest() != base)
+            out.append(row)
+        return out
+
+    def read_draft(self, path: str) -> str:
+        """Full text of one pending draft — unreviewed material, not
+        canon."""
+        p = self._draft_path(path)
+        if not p.is_file():
+            raise StoreError(
+                f"no such draft: {path} — list_drafts shows what is "
+                "pending")
+        return p.read_text(encoding="utf-8")
+```
+
+Also update the module docstring (line ~6): replace "the staging/canonical boundary" with "the drafts/inbound/canonical boundaries", and in `_canonical()`'s docstring replace the staging paragraph with: "The drafts and inbound directories are among the excluded ones, so neither is readable through this method: the canon read tools serve canon. Each has its own labelled door — read_draft and read_inbound — guarding the inverse condition."
+
+- [ ] **Step 4: Run store tests**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update `serve_mcp.py` tool registrations** — replace the four tools `save_draft`, `propose_revision`, `list_staged`, `read_staged` (lines ~122–153) with:
+
+```python
+    @server.tool()
+    def save_draft(section: str, name: str, content: str,
+                   subdir: str | None = None) -> str:
+        """Draft NEW content (a full markdown file, front matter included)
+        into your drafts directory for the GM to review and promote. The
+        name is slugged to kebab-case (put the display title in front
+        matter); subdir nests one level, e.g. section="Briefs",
+        subdir="session-015". Never overwrites — revise existing drafts
+        with update_draft. Returns the draft's path."""
+        return store.save_draft(section, name, content, subdir)
+
+    @server.tool()
+    def propose_revision(path: str, content: str) -> str:
+        """Propose a full-file revision of an EXISTING canonical file, as
+        a shadow copy in your drafts directory; the GM reviews it as a
+        diff. One pending proposal per file: if one exists, read_draft it,
+        merge, and update_draft instead. Returns the draft's path."""
+        return store.propose_revision(path, content)
+
+    @server.tool()
+    def list_drafts() -> list[dict]:
+        """List your own unpromoted drafts from this and earlier sessions:
+        path, kind ("new" content or a "revision" of an existing file),
+        title and summary, and for revisions whether canon has changed
+        underneath them (stale). Nothing here is canon — it is your
+        unreviewed work awaiting the GM. Pick a draft up and merge rather
+        than writing it again."""
+        return store.list_drafts()
+
+    @server.tool()
+    def read_draft(path: str) -> str:
+        """Read one of your pending drafts in full. Paths come from
+        list_drafts. Draft material is UNREVIEWED and not canon — do not
+        treat it as established fact. For canonical files, use
+        read_entity."""
+        return store.read_draft(path)
+```
+
+- [ ] **Step 6: Rewrite the tool-layer tests** — in `tests/test_serve_mcp.py`, replace `test_staging_tools_always_registered`, `test_staging_read_tools_always_registered`, `test_list_staged_reports_what_was_staged`, `test_read_staged_round_trips_a_draft`, `test_read_staged_refuses_a_canonical_path`, and `test_save_draft_lands_in_staging` (keep every other test) with:
+
+```python
+    async def test_draft_tools_always_registered(self):
+        # The drafts directory is the agent's own outbox: writing to it and
+        # reading it back need no flag; nothing here can reach canon.
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual(
+            {"save_draft", "propose_revision", "list_drafts", "read_draft"},
+            names)
+
+    async def test_list_drafts_reports_what_was_drafted(self):
+        store = scaffold(self)
+        server = serve_mcp.build_server(store)
+        await server.call_tool("save_draft", {
+            "section": "NPCs", "name": "Cho", "content": "x"})
+        payload = await self._text(await server.call_tool("list_drafts", {}))
+        self.assertIn("_AgentDrafts/NPCs/cho.md", payload)
+
+    async def test_read_draft_round_trips(self):
+        store = scaffold(self)
+        server = serve_mcp.build_server(store)
+        await server.call_tool("save_draft", {
+            "section": "NPCs", "name": "Cho", "content": "draft body"})
+        payload = await self._text(await server.call_tool(
+            "read_draft", {"path": "_AgentDrafts/NPCs/cho.md"}))
+        self.assertIn("draft body", payload)
+
+    async def test_read_draft_refuses_a_canonical_path(self):
+        # The two read doors stay separate: read_draft must not become a
+        # second way into canon.
+        server = serve_mcp.build_server(scaffold(self))
+        result = await server.call_tool(
+            "read_draft", {"path": "NPCs/kim-ha-eun.md"})
+        self.assertTrue(result.isError)
+
+    async def test_save_draft_lands_in_the_drafts_dir(self):
+        store = scaffold(self)
+        server = serve_mcp.build_server(store)
+        await server.call_tool("save_draft", {
+            "section": "NPCs", "name": "Cho", "content": "x"})
+        self.assertTrue(
+            (store.ws.root / "_AgentDrafts/NPCs/cho.md").is_file())
+```
+
+(Match the surrounding file's existing call/assertion style if it differs — e.g. how error results are asserted; `test_read_staged_refuses_a_canonical_path` at line ~141 shows the current idiom. Reuse it.)
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK. `tests.test_serve_mcp` SDK-gated tests skip locally; confirm they import cleanly.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/bunnyforge/_store.py src/bunnyforge/serve_mcp.py tests/test_store.py tests/test_serve_mcp.py
+git commit -m "feat: drafts family — save/propose/list/read over _AgentDrafts with base manifest"
+```
+
+---
+
+### Task 3: `update_draft` — the single overwrite door
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (add one method after `propose_revision`)
+- Modify: `src/bunnyforge/serve_mcp.py` (register one tool after `propose_revision`)
+- Modify: `tests/test_store.py`, `tests/test_serve_mcp.py`
+
+**Interfaces:**
+- Consumes: `_draft_path`, `_drafts`, `_set_base` (Task 2).
+- Produces: `WorkspaceStore.update_draft(path: str, content: str) -> str` (Task 6's refusal messages point at it — the name must match exactly).
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_store.py`:
+
+```python
+class TestUpdateDraft(StoreCase):
+    def test_overwrites_an_existing_draft(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("NPCs", "Cho", "old")
+        self.assertEqual(store.update_draft(rel, "new"), rel)
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"), "new")
+
+    def test_missing_draft_is_refused_naming_save_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.update_draft("_AgentDrafts/NPCs/nobody.md", "x")
+        self.assertIn("save_draft", str(ctx.exception))
+
+    def test_canonical_and_escape_paths_are_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.update_draft("NPCs/kim-ha-eun.md", "x")
+        with self.assertRaises(_store.StoreError):
+            store.update_draft("../outside.md", "x")
+
+    def test_rebaselines_a_revision_shadow(self):
+        # The refusal flow that leads here forced a read-and-merge, so the
+        # agent has seen current canon: updating a shadow re-records its
+        # base, and the revision stops being stale.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "first")
+        (ws.root / "NPCs/kim-ha-eun.md").write_text("GM edit",
+                                                    encoding="utf-8")
+        self.assertIs(store.list_drafts()[0]["stale"], True)
+        store.update_draft("_AgentDrafts/NPCs/kim-ha-eun.md", "merged")
+        self.assertIs(store.list_drafts()[0]["stale"], False)
+
+    def test_underscore_component_is_refused(self):
+        ws = self.make_ws()
+        rejected = ws.root / "_AgentDrafts" / "_Rejected"
+        rejected.mkdir(parents=True)
+        (rejected / "dead.md").write_text("x", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).update_draft(
+                "_AgentDrafts/_Rejected/dead.md", "resurrect")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestUpdateDraft -v`
+Expected: ERROR, `no attribute 'update_draft'`.
+
+- [ ] **Step 3: Implement** — in `_store.py`, after `propose_revision`:
+
+```python
+    def update_draft(self, path: str, content: str) -> str:
+        """Overwrite one existing draft — the only overwrite door, so
+        clobbering is always deliberate: the path must already exist,
+        which means it came from list_drafts or read_draft."""
+        p = self._draft_path(path)
+        if not p.is_file():
+            raise StoreError(
+                f"no such draft: {path} — save_draft creates new drafts; "
+                "list_drafts shows what exists")
+        p.write_text(content, encoding="utf-8")
+        rel = p.relative_to(self.ws.root).as_posix()
+        mirrored = self.ws.root / p.relative_to(self._drafts())
+        if mirrored.is_file():
+            self._set_base(rel, mirrored)
+        return rel
+```
+
+In `serve_mcp.py`, after `propose_revision`:
+
+```python
+    @server.tool()
+    def update_draft(path: str, content: str) -> str:
+        """Overwrite one of your existing drafts with revised content —
+        the deliberate way to iterate on a draft across sessions.
+        read_draft it first and merge; updating a revision shadow also
+        re-baselines it against current canon. Paths come from
+        list_drafts."""
+        return store.update_draft(path, content)
+```
+
+In `tests/test_serve_mcp.py`, extend the registered-names assertion in `test_draft_tools_always_registered` to include `"update_draft"`.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py src/bunnyforge/serve_mcp.py tests/test_store.py tests/test_serve_mcp.py
+git commit -m "feat: update_draft — the single deliberate overwrite door for drafts"
+```
+
+---
+
+### Task 4: The inbound family — GM's queue, read-only, only-when-asked
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (new section between the drafts family and `write_entity`)
+- Modify: `src/bunnyforge/serve_mcp.py` (two tools after `read_draft`)
+- Modify: `tests/test_store.py`, `tests/test_serve_mcp.py`
+
+**Interfaces:**
+- Consumes: `Config.inbound_dir` (Task 1).
+- Produces:
+  - `WorkspaceStore.list_inbound() -> list[dict]` — rows `{path, readable}` (Task 5 counts its length)
+  - `WorkspaceStore.read_inbound(path: str) -> str`
+  - `WorkspaceStore._inbound_path(path: str) -> Path` — the resolver a future `mark_extracted` reuses
+  - Module constant `INBOUND_SUFFIXES = frozenset({".md", ".txt", ".html", ".htm"})`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_store.py`:
+
+```python
+class TestInbound(StoreCase):
+    """The GM's inbound queue. Read-only, and only when the GM asks: the
+    tool descriptions carry that contract; the store's job is that _Done/
+    (and any _-prefixed area) is unreachable and every live file is
+    honestly listed."""
+
+    def seed_queue(self, ws) -> Path:
+        q = ws.root / "_ExtractInbound"
+        (q / "anjeonggm").mkdir(parents=True)
+        (q / "anjeonggm" / "idea.txt").write_text("a harbor heist",
+                                                  encoding="utf-8")
+        (q / "page.html").write_text("<p>hi</p>", encoding="utf-8")
+        (q / "README.md").write_text("readme", encoding="utf-8")
+        (q / "scan.pdf").write_bytes(b"%PDF-1.4 not text")
+        done = q / "_Done"
+        done.mkdir()
+        (done / "spent.txt").write_text("processed", encoding="utf-8")
+        return q
+
+    def test_lists_every_live_file_marking_readability(self):
+        # ALL extensions are listed — a listing that hides files is the
+        # defect this redesign fixes (17 of 18 files were invisible). A
+        # PDF appears, honestly marked unreadable.
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        self.assertEqual(_store.WorkspaceStore(ws).list_inbound(), [
+            {"path": "_ExtractInbound/README.md", "readable": True},
+            {"path": "_ExtractInbound/anjeonggm/idea.txt", "readable": True},
+            {"path": "_ExtractInbound/page.html", "readable": True},
+            {"path": "_ExtractInbound/scan.pdf", "readable": False},
+        ])
+
+    def test_done_is_never_listed(self):
+        # _Done/ holds processed source awaiting the GM's manual cleanup —
+        # never read, exactly like _Ignore/. Tested before _Done/ exists
+        # anywhere in the wild: this was the trap in the old rglob.
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        paths = [r["path"] for r in _store.WorkspaceStore(ws).list_inbound()]
+        self.assertFalse(any("_Done" in p for p in paths))
+
+    def test_hidden_dot_files_are_skipped(self):
+        # .DS_Store and friends are machinery, not GM material; listing
+        # them would inflate inbound_pending and clutter every offer.
+        ws = self.make_ws()
+        q = self.seed_queue(ws)
+        (q / ".DS_Store").write_bytes(b"\x00")
+        paths = [r["path"] for r in _store.WorkspaceStore(ws).list_inbound()]
+        self.assertFalse(any(".DS_Store" in p for p in paths))
+
+    def test_no_queue_is_an_empty_list_not_an_error(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.list_inbound(), [])
+
+    def test_read_round_trips_text(self):
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(
+            store.read_inbound("_ExtractInbound/anjeonggm/idea.txt"),
+            "a harbor heist")
+
+    def test_undecodable_bytes_are_replaced_not_a_crash(self):
+        # Inbound material is generated elsewhere; one stray latin-1 byte
+        # in a GM's .txt must not crash the tool.
+        ws = self.make_ws()
+        q = ws.root / "_ExtractInbound"
+        q.mkdir()
+        (q / "weird.txt").write_bytes(b"caf\xe9")
+        out = _store.WorkspaceStore(ws).read_inbound(
+            "_ExtractInbound/weird.txt")
+        self.assertEqual(out, "caf\ufffd")
+
+    def test_non_text_read_is_refused_with_the_convert_hint(self):
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        with self.assertRaises(_store.StoreError) as ctx:
+            _store.WorkspaceStore(ws).read_inbound(
+                "_ExtractInbound/scan.pdf")
+        self.assertIn("convert", str(ctx.exception))
+
+    def test_done_read_is_refused(self):
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).read_inbound(
+                "_ExtractInbound/_Done/spent.txt")
+
+    def test_canonical_path_is_refused_naming_read_entity(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.read_inbound("NPCs/kim-ha-eun.md")
+        self.assertIn("read_entity", str(ctx.exception))
+
+    def test_escape_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_inbound("_ExtractInbound/../../outside.md")
+
+    def test_missing_file_is_refused_naming_the_listing(self):
+        ws = self.make_ws()
+        (ws.root / "_ExtractInbound").mkdir()
+        with self.assertRaises(_store.StoreError) as ctx:
+            _store.WorkspaceStore(ws).read_inbound(
+                "_ExtractInbound/nothing.txt")
+        self.assertIn("list_inbound", str(ctx.exception))
+
+    def test_honours_configured_inbound_dir(self):
+        ws = self.make_ws('\n[workspace]\ninbound_dir = "_Inbox"\n')
+        q = ws.root / "_Inbox"
+        q.mkdir()
+        (q / "idea.txt").write_text("x", encoding="utf-8")
+        rows = _store.WorkspaceStore(ws).list_inbound()
+        self.assertEqual(rows, [{"path": "_Inbox/idea.txt",
+                                 "readable": True}])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestInbound -v`
+Expected: ERROR, `no attribute 'list_inbound'`.
+
+- [ ] **Step 3: Implement** — in `_store.py`, add below the drafts family (module constant next to `BASES_NAME`):
+
+```python
+INBOUND_SUFFIXES = frozenset({".md", ".txt", ".html", ".htm"})
+```
+
+```python
+    # -- inbound queue ------------------------------------------------------
+    # The GM's inbound queue: material authored elsewhere, awaiting
+    # extraction into proper entity files. Read-only here, and the tool
+    # descriptions add "only when the GM asks". _inbound_path is the shared
+    # resolver a future mark_extracted() reuses — a move tool is one new
+    # method, not a rewrite (its _Done/ destination would be constructed
+    # internally, not through this reader's resolver, which refuses
+    # _-prefixed components).
+
+    def _inbound(self) -> Path:
+        return self.ws.root / self.ws.config.inbound_dir
+
+    @staticmethod
+    def _machinery(parts: tuple[str, ...]) -> bool:
+        # _-prefixed: the workspace's machinery convention (_Done/,
+        # _Rejected/). .-prefixed: hidden files (.DS_Store) — never GM
+        # material, and listing them would inflate inbound_pending.
+        return any(part.startswith(("_", ".")) for part in parts)
+
+    def _inbound_path(self, path: str) -> Path:
+        root = self.ws.root
+        inbound = self._inbound()
+        p = (root / path).resolve()
+        if not p.is_relative_to(root):
+            raise StoreError(f"path escapes the workspace: {path}")
+        if not p.is_relative_to(inbound):
+            raise StoreError(
+                f"not an inbound path: {path} — read_inbound serves "
+                f"{self.ws.config.inbound_dir}/ only; canonical files are "
+                "read with read_entity")
+        if self._machinery(p.relative_to(inbound).parts):
+            raise StoreError(
+                f"{path} is in a processed or private area of the inbound "
+                "queue (_- or .-prefixed) and is never read — _Done/ holds "
+                "spent source awaiting the GM's cleanup")
+        return p
+
+    def list_inbound(self) -> list[dict]:
+        """Every live file in the GM's inbound queue, whatever its type:
+        workspace path, and whether read_inbound can return it. Sorted,
+        so two calls agree."""
+        inbound = self._inbound()
+        if not inbound.is_dir():
+            return []
+        out = []
+        for p in sorted(inbound.rglob("*")):
+            if not p.is_file():
+                continue
+            if self._machinery(p.relative_to(inbound).parts):
+                continue
+            out.append({
+                "path": p.relative_to(self.ws.root).as_posix(),
+                "readable": p.suffix.lower() in INBOUND_SUFFIXES})
+        return out
+
+    def read_inbound(self, path: str) -> str:
+        """Full text of one inbound file — the GM's unreviewed source
+        material, not canon. Decoding is forgiving (errors="replace"):
+        this material was generated outside the workspace."""
+        p = self._inbound_path(path)
+        if p.suffix.lower() not in INBOUND_SUFFIXES:
+            raise StoreError(
+                f"{path} is not a text format serve-mcp can return "
+                f"({', '.join(sorted(INBOUND_SUFFIXES))}) — ask the GM to "
+                "convert or summarize it")
+        if not p.is_file():
+            raise StoreError(
+                f"no such inbound file: {path} — list_inbound shows the "
+                "queue")
+        return p.read_text(encoding="utf-8", errors="replace")
+```
+
+- [ ] **Step 4: Run store tests**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Expected: PASS.
+
+- [ ] **Step 5: Register the tools** — in `serve_mcp.py`, after `read_draft`:
+
+```python
+    @server.tool()
+    def list_inbound() -> list[dict]:
+        """The GM's inbound queue: material the GM authored elsewhere,
+        awaiting extraction into proper entity files. Call this only when
+        the GM asks you to extract — do not act on the queue unbidden.
+        (campaign_overview's inbound_pending count is how you may notice
+        it is non-empty and offer.) Lists every file with whether
+        read_inbound can return it. Nothing here is canon."""
+        return store.list_inbound()
+
+    @server.tool()
+    def read_inbound(path: str) -> str:
+        """Read one file from the GM's inbound queue, only when the GM
+        asks you to extract. Paths come from list_inbound. The material
+        is unreviewed source, not canon — extract it into drafts, show
+        the GM, and confirm before anything else happens with it."""
+        return store.read_inbound(path)
+```
+
+- [ ] **Step 6: Tool-layer tests** — in `tests/test_serve_mcp.py`, add to the SDK-gated `TestBuildServer`:
+
+```python
+    async def test_inbound_tools_always_registered(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual({"list_inbound", "read_inbound"}, names)
+
+    async def test_inbound_descriptions_carry_the_contract(self):
+        # Regression: the old list_staged description said the opposite
+        # ("use it to pick up drafts"), actively nudging the agent to read
+        # the GM's queue unbidden. The contract phrase is load-bearing.
+        server = serve_mcp.build_server(scaffold(self))
+        descs = {t.name: (t.description or "")
+                 for t in await server.list_tools()}
+        for name in ("list_inbound", "read_inbound"):
+            self.assertIn("only when the GM asks", descs[name])
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK (new SDK tests skip locally).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/bunnyforge/_store.py src/bunnyforge/serve_mcp.py tests/test_store.py tests/test_serve_mcp.py
+git commit -m "feat: inbound queue tools — list_inbound/read_inbound under the only-when-asked contract"
+```
+
+---
+
+### Task 5: `campaign_overview` counts
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (`overview()`, ~line 86)
+- Modify: `src/bunnyforge/serve_mcp.py` (`campaign_overview` docstring)
+- Modify: `tests/test_store.py` (`TestOverview`)
+
+**Interfaces:**
+- Consumes: `list_inbound()`, `list_drafts()` (Tasks 2, 4).
+- Produces: `overview()` result gains `"inbound_pending": int` and `"drafts_pending": int`.
+
+- [ ] **Step 1: Write the failing test** — add to `TestOverview` in `tests/test_store.py`:
+
+```python
+    def test_counts_pending_inbound_and_drafts(self):
+        # Defined as exactly len(list_inbound()) / len(list_drafts()), so
+        # a count and the listing it advertises cannot disagree. 0 when
+        # the directory is absent: a count is always present, and
+        # "nothing pending" is the true answer either way.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(store.overview()["inbound_pending"], 0)
+        self.assertEqual(store.overview()["drafts_pending"], 0)
+        store.save_draft("NPCs", "Cho", "x")
+        q = ws.root / "_ExtractInbound"
+        (q / "_Done").mkdir(parents=True)
+        (q / "idea.txt").write_text("x", encoding="utf-8")
+        (q / "scan.pdf").write_bytes(b"%PDF")
+        (q / "_Done" / "spent.txt").write_text("x", encoding="utf-8")
+        ov = store.overview()
+        self.assertEqual(ov["inbound_pending"], 2)  # pdf counted, _Done not
+        self.assertEqual(ov["drafts_pending"], 1)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestOverview -v`
+Expected: FAIL, KeyError `'inbound_pending'`.
+
+- [ ] **Step 3: Implement** — in `overview()`, immediately before the `return out` line, add:
+
+```python
+        # Counts, not contents: the agent may notice the GM's queue is
+        # non-empty and offer to extract, without reading it unbidden.
+        out["inbound_pending"] = len(self.list_inbound())
+        out["drafts_pending"] = len(self.list_drafts())
+```
+
+In `serve_mcp.py`, extend the `campaign_overview` docstring to:
+
+```python
+    @server.tool()
+    def campaign_overview() -> dict:
+        """Get your bearings in one call: the campaign's name, each section
+        with how many entities it holds, the current front-burner and
+        open-questions documents, and two counts — drafts_pending (your
+        own unpromoted drafts; list_drafts to resume them) and
+        inbound_pending (files in the GM's inbound queue). If
+        inbound_pending is non-zero you may mention it and offer to
+        extract; do not list or read the queue unless the GM asks. Call
+        this before anything else."""
+        return store.overview()
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py src/bunnyforge/serve_mcp.py tests/test_store.py
+git commit -m "feat: overview reports drafts_pending and inbound_pending"
+```
+
+---
+
+### Task 6: `promote_draft` behind `--allow-direct-edits`
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (one method after `read_draft`)
+- Modify: `src/bunnyforge/serve_mcp.py` (inside the `if allow_direct_edits:` block, ~line 155)
+- Modify: `tests/test_store.py`, `tests/test_serve_mcp.py`
+
+**Interfaces:**
+- Consumes: `_draft_path`, `_drafts`, `_load_bases`, `_save_bases`, `_bases_file` (Task 2); the git-guard pattern from `write_entity`.
+- Produces: `WorkspaceStore.promote_draft(path: str) -> str` (returns the canonical path it created/updated).
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_store.py` (the git scaffold copies `TestWriteEntity.make_git_ws`'s pattern):
+
+```python
+class TestPromoteDraft(StoreCase):
+    """The GM's in-chat approval is the gate; the flag gates the
+    capability per-run. The destination is derived — slugs made the
+    drafts tree mirror canon — so there is no dest parameter to get
+    wrong."""
+
+    def make_git_ws(self):
+        ws = self.make_ws()
+        for cmd in (["init", "-q"], ["config", "user.email", "t@t"],
+                    ["config", "user.name", "t"], ["add", "-A"],
+                    ["commit", "-qm", "seed"]):
+            subprocess.run(["git", "-C", str(ws.root)] + cmd, check=True)
+        return ws
+
+    def _git(self, ws, *args) -> str:
+        return subprocess.run(["git", "-C", str(ws.root), *args],
+                              capture_output=True, text=True,
+                              check=True).stdout
+
+    def test_promotes_a_new_draft_and_commits(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("Ideas", "Harbor Heist",
+                               "---\ntitle: Harbor Heist\n---\nplot\n")
+        out = store.promote_draft(rel)
+        self.assertEqual(out, "Ideas/harbor-heist.md")
+        self.assertIn("plot", (ws.root / out).read_text(encoding="utf-8"))
+        self.assertFalse((ws.root / rel).exists())
+        self.assertIn("serve-mcp: promote Ideas/harbor-heist.md",
+                      self._git(ws, "log", "-1", "--format=%s"))
+        self.assertEqual(self._git(ws, "status", "--porcelain").strip(), "")
+
+    def test_promotes_a_fresh_revision_and_clears_its_base(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.propose_revision("NPCs/kim-ha-eun.md", "improved text")
+        out = store.promote_draft(rel)
+        self.assertEqual(out, "NPCs/kim-ha-eun.md")
+        self.assertEqual((ws.root / out).read_text(encoding="utf-8"),
+                         "improved text")
+        self.assertFalse((ws.root / rel).exists())
+        bases = json.loads(
+            (ws.root / "_AgentDrafts" / ".proposal-bases.json")
+            .read_text(encoding="utf-8"))
+        self.assertEqual(bases, {})
+        self.assertEqual(self._git(ws, "status", "--porcelain").strip(), "")
+
+    def test_stale_revision_is_refused_not_applied(self):
+        # Promoting a stale shadow would revert the GM's interim edits,
+        # disguised inside an intended diff.
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.propose_revision("NPCs/kim-ha-eun.md", "proposal")
+        (ws.root / "NPCs/kim-ha-eun.md").write_text("GM edit",
+                                                    encoding="utf-8")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.promote_draft(rel)
+        self.assertIn("update_draft", str(ctx.exception))
+        self.assertEqual(
+            (ws.root / "NPCs/kim-ha-eun.md").read_text(encoding="utf-8"),
+            "GM edit")  # canon untouched
+
+    def test_unrecorded_base_is_refused(self):
+        # Covers a hand-authored shadow AND a draft whose canonical
+        # counterpart appeared after it was saved: target exists, no base
+        # on record, so promotion cannot verify and refuses.
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        shadow = ws.root / "_AgentDrafts" / "NPCs"
+        shadow.mkdir(parents=True)
+        (shadow / "kim-ha-eun.md").write_text("hand-made", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            store.promote_draft("_AgentDrafts/NPCs/kim-ha-eun.md")
+
+    def test_refuses_outside_a_git_repo_before_touching_anything(self):
+        ws = self.make_ws()  # no git init
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("Ideas", "Heist", "plot")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.promote_draft(rel)
+        self.assertIn("git", str(ctx.exception))
+        self.assertTrue((ws.root / rel).is_file())   # draft still there
+        self.assertFalse((ws.root / "Ideas/heist.md").exists())
+
+    def test_missing_draft_is_refused(self):
+        store = _store.WorkspaceStore(self.make_git_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.promote_draft("_AgentDrafts/Ideas/nothing.md")
+        self.assertIn("list_drafts", str(ctx.exception))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestPromoteDraft -v`
+Expected: ERROR, `no attribute 'promote_draft'`.
+
+- [ ] **Step 3: Implement** — in `_store.py`, after `read_draft`:
+
+```python
+    def promote_draft(self, path: str) -> str:
+        """Move one approved draft to its canonical location and commit.
+
+        The destination is derived by stripping the drafts prefix — slugs
+        made the two trees mirror. Order matters: every refusal fires
+        before the filesystem changes, so a refused promotion leaves the
+        draft exactly where it was."""
+        p = self._draft_path(path)
+        if not p.is_file():
+            raise StoreError(
+                f"no such draft: {path} — list_drafts shows what is "
+                "pending")
+        rel = p.relative_to(self.ws.root).as_posix()
+        inner = p.relative_to(self._drafts())
+        target = self.ws.root / inner
+        target_rel = inner.as_posix()
+        if target.is_file():
+            # A revision: its recorded base must still match canon. None
+            # (unrecorded) never equals a hash, so unverifiable shadows
+            # are refused too rather than silently applied.
+            base = self._load_bases().get(rel)
+            if base != hashlib.sha256(target.read_bytes()).hexdigest():
+                raise StoreError(
+                    f"{target_rel} changed since this revision was "
+                    "proposed (or its base is unrecorded) — read_entity "
+                    "the current file, merge with update_draft, then "
+                    "promote again")
+        probe = subprocess.run(
+            ["git", "-C", str(self.ws.root), "rev-parse",
+             "--is-inside-work-tree"], capture_output=True, text=True)
+        if probe.returncode != 0:
+            raise StoreError(
+                "promotion requires the workspace to be a git repository "
+                "— refusing to change canon without history")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(p.read_text(encoding="utf-8"), encoding="utf-8")
+        p.unlink()
+        bases = self._load_bases()
+        bases.pop(rel, None)
+        self._save_bases(bases)
+        # Stage exactly what promotion touched: the target, plus the
+        # removed draft and the manifest when git can see them (a
+        # never-tracked deleted path would fail `git add` as an unmatched
+        # pathspec).
+        bases_rel = self._bases_file().relative_to(self.ws.root).as_posix()
+        spec = [target_rel]
+        for cand in (rel, bases_rel):
+            tracked = subprocess.run(
+                ["git", "-C", str(self.ws.root), "ls-files", "--", cand],
+                capture_output=True, text=True).stdout.strip()
+            if tracked or (self.ws.root / cand).exists():
+                spec.append(cand)
+        for sub in (["add", "-A", "--"] + spec,
+                    ["commit", "-m", f"serve-mcp: promote {target_rel}"]):
+            done = subprocess.run(["git", "-C", str(self.ws.root)] + sub,
+                                  capture_output=True, text=True)
+            if done.returncode != 0:
+                raise StoreError(
+                    f"git {sub[0]} failed: "
+                    f"{done.stderr.strip() or done.stdout.strip()}")
+        return target_rel
+```
+
+- [ ] **Step 4: Run store tests**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Expected: PASS.
+
+- [ ] **Step 5: Register the tool** — in `serve_mcp.py`, inside the existing `if allow_direct_edits:` block, after `write_entity`:
+
+```python
+        @server.tool()
+        def promote_draft(path: str) -> str:
+            """Move one draft the GM has just approved in this chat to its
+            canonical location (derived from the draft path) and commit
+            it. Only call this after the GM's explicit approval of that
+            specific draft. A stale revision is refused — merge with
+            update_draft first. Available only because this server was
+            started with --allow-direct-edits."""
+            return store.promote_draft(path)
+```
+
+In `tests/test_serve_mcp.py`, find the existing SDK-gated test asserting `write_entity` is registered only with the flag (~line 151) and extend it — or mirror it — so it also asserts: `"promote_draft"` absent from the default server's tool names, present with `allow_direct_edits=True`.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/bunnyforge/_store.py src/bunnyforge/serve_mcp.py tests/test_store.py tests/test_serve_mcp.py
+git commit -m "feat: promote_draft — gated in-chat promotion with stale-base refusal"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `docs/serve-mcp.md` ("What the agent can do", lines ~92–139; nothing else in the file changes)
+- Modify: `src/bunnyforge/data/doctrine/AGENTS.md` (directory rules ~line 179; `_ExtractInbound` section lines 78–102)
+
+**Interfaces:** none — prose only. Source of truth: spec §6 and the spec appendix.
+
+- [ ] **Step 1: Rewrite `docs/serve-mcp.md` "What the agent can do"** — replace everything from `**Write back, into staging:**` (line ~99) through the `--allow-direct-edits` paragraph's end (line ~135) with:
+
+```markdown
+**Write drafts:**
+
+| tool | writes to |
+|---|---|
+| `save_draft(section, name, content, subdir=None)` | `<drafts_dir>/<section>/[<subdir>/]<slug>.md` — new content; names are slugged to kebab-case; never overwrites |
+| `propose_revision(path, content)` | `<drafts_dir>/<path>`, mirroring the canonical path, so you review it as a diff; one pending proposal per file |
+| `update_draft(path, content)` | an existing draft — the one deliberate overwrite door, for iterating across sessions |
+
+All of it lands in the agents' drafts directory (`drafts_dir`, default
+`_AgentDrafts`) and goes no further. That directory is always excluded
+from the canon read tools — whatever `exclude_dirs` says — so drafts stay
+invisible to every other bunnyforge command until you promote them.
+**In the default configuration the agent cannot alter canon at all.**
+
+**Read drafts back:** `list_drafts()` gives every pending draft with its
+kind (`new` or `revision`), title, summary, and — for revisions — whether
+canon changed underneath the proposal (`stale`). `read_draft(path)`
+returns one in full. They exist so the agent picks up its own earlier
+work and merges rather than re-writing; a `_`-prefixed subdirectory
+(say, `_AgentDrafts/_Rejected/`, if you use rejection-by-moving) is
+never listed or read, so rejected material stays rejected.
+
+**The inbound queue — read only when you ask:** `_ExtractInbound/`
+(`inbound_dir`) is yours: material you authored elsewhere, awaiting
+extraction. `list_inbound()` lists every live file — all formats, each
+marked `readable` or not — and `read_inbound(path)` returns text formats
+(`.md`, `.txt`, `.html`, `.htm`; anything else is listed but refused
+with a convert-it hint, and undecodable bytes are replaced rather than
+crashing). Both tools' descriptions carry your AGENTS.md contract: the
+agent calls them **only when you ask it to extract**. It learns the
+queue is non-empty from `campaign_overview`'s `inbound_pending` count —
+which permits noticing and offering, never unbidden reading.
+`_ExtractInbound/_Done/` and any other `_`-prefixed area are invisible
+to both tools, exactly like `_Ignore/`.
+
+**Write back, into canon — only if you ask for it:**
+
+    bunnyforge serve-mcp --allow-direct-edits ...
+
+registers two more tools. `write_entity(path, content)` edits a
+canonical file in place and commits each edit with a
+`serve-mcp: edit <path>` message. `promote_draft(path)` moves a draft
+you have just approved in chat to its canonical location (derived from
+the draft path — slugged drafts mirror canon) and commits it as
+`serve-mcp: promote <path>`; a revision whose base no longer matches
+canon is refused, never silently applied over your interim edits.
+Promotion deliberately does not touch `compendium.md` or
+`front-burner.md` — index updates flow through `propose_revision` as
+ever. Both tools refuse outside a git repository: without history there
+is no review and no undo, and that is the only thing that makes
+changing canon defensible. It is a per-run flag rather than a config
+key on purpose — trading the review boundary for git history should be
+a decision you make when starting the server, not a setting that
+quietly persists.
+```
+
+Then sweep the rest of `docs/serve-mcp.md` for the words "staging"/"staged" (the intro table reference at ~line 106 and the "Read back its own staging" paragraph are covered by the replacement above; check nothing else remains): `grep -n "stag" docs/serve-mcp.md` must return nothing.
+
+- [ ] **Step 2: Edit the scaffolded doctrine** — in `src/bunnyforge/data/doctrine/AGENTS.md`:
+
+(a) In the directory rules (the list containing "Do not read `_ExtractInbound/` unless…", ~line 179), add after that bullet:
+
+```markdown
+- `_AgentDrafts/` is the agents' outbox: drafts and proposed revisions
+  awaiting my review, written by the MCP tools (or by you, if I ask you to
+  draft something). Read it freely; nothing in it is canon. If I reject a
+  draft I delete it or move it to `_AgentDrafts/_Rejected/`, which is
+  never read, like `_Ignore/`.
+```
+
+(b) In "Extracting from _ExtractInbound/" (lines 78–102): add a bullet after "**Read it only when I ask you to extract.**…":
+
+```markdown
+- **The MCP agent reaches this queue through `list_inbound` and
+  `read_inbound`, under exactly these rules.**
+```
+
+and change the move bullet ("Once I confirm an extraction, move the spent source into `_ExtractInbound/_Done/`. Do not delete it; …") to begin:
+
+```markdown
+- **Extract, show me, confirm, then move — never delete.** Once I confirm
+  an extraction, move the spent source into `_ExtractInbound/_Done/` — or,
+  if you cannot move files, say so and I will. Do not delete it; I clear
+  `_Done/` myself. And never move anything before I have confirmed. The
+  active directory emptying is how we track what remains to process.
+```
+
+- [ ] **Step 3: Full-suite run and staging-vocabulary sweep**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests`
+Expected: OK.
+
+Run: `grep -rn "staging\|staged" src/bunnyforge/_store.py src/bunnyforge/_config.py src/bunnyforge/serve_mcp.py docs/serve-mcp.md src/bunnyforge/data/doctrine/AGENTS.md src/bunnyforge/data/campaign.toml.in`
+Expected: no output. (The doctrine's old "staging area" phrasings at lines 80 and 180 must be reworded to "inbound queue" as part of Step 2 if the grep still catches them.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/serve-mcp.md src/bunnyforge/data/doctrine/AGENTS.md
+git commit -m "docs: drafts/inbound vocabulary for serve-mcp and the scaffolded doctrine"
+```
+
+---
+
+## After the last task
+
+1. Full suite once more from a clean state: `git status` (clean), then `PYTHONPATH=src python3 -m unittest discover -s tests`.
+2. The PR body should carry the release note verbatim: *"Agent-written drafts still in `_ExtractInbound/` from the old scheme should be moved to `_AgentDrafts/` or deleted. A `staging_dir` key in `campaign.toml` must be renamed to `inbound_dir`."* Plus the suggested live-workspace AGENTS.md edit (spec appendix) for the GM to apply by hand.
+3. Open the PR with the `dcltdw:opening-a-pr` skill; do not merge — the GM reviews first.

--- a/docs/superpowers/specs/2026-08-17-inbound-drafts-split-design.md
+++ b/docs/superpowers/specs/2026-08-17-inbound-drafts-split-design.md
@@ -1,0 +1,362 @@
+# Inbound/drafts split for serve-mcp — design
+
+Date: 2026-08-17
+Status: approved (brainstormed with the GM; adversarially reviewed; findings
+triaged and folded in)
+Builds on: docs/superpowers/specs/2026-08-16-serve-mcp-design.md, PR #60
+(issue #59, "feat: serve-mcp read-only staging access")
+
+## Problem
+
+PR #60 gave the MCP agent read-back over the staging directory, but the
+directory it read was doing two jobs under one name. `staging_dir`
+(default `_ExtractInbound`) holds both:
+
+1. **Agent output** — `save_draft` and `propose_revision` write there, and
+   `list_staged`/`read_staged` read it back as "your own inbox".
+2. **The GM's inbound queue** — material the GM generated elsewhere
+   (`.txt`, `.html`, `.md`), awaiting an agent's help extracting it into
+   proper entity files.
+
+The conflation produces real defects in the live workspace: the
+`rglob("*.md")` filter hides 17 of 18 inbound files; the one it surfaces
+(`_ExtractInbound/README.md`) is mislabelled `"revision"` because a root
+`README.md` happens to exist; and the tool descriptions ("use it to pick
+up drafts from an earlier session") actively contradict the workspace
+AGENTS.md contract for the queue ("Read it only when I ask you to
+extract"). The GM's verdict: "staged" is the wrong name for any of this.
+
+The GM's system model, which this design is measured against:
+
+- **Inputs:** player perceptions from the wiki (existing flow, untouched);
+  GM ideas landing in `_ExtractInbound/`; agent-generated content not yet
+  approved.
+- **Output:** approved material flows into the canonical sections.
+- **Division of labor:** the claude.ai web agent over MCP is the *primary
+  writing instrument*, across many sessions. The VSCode agent works on
+  bunnyforge code, rarely on campaign writing. The GM reviews and
+  promotes. The MCP tool surface is the main highway for the whole
+  writing process, not a side door.
+
+## Settled inputs
+
+Decided by the GM before design; not revisited here:
+
+1. Agent output moves to its own directory; `_ExtractInbound` becomes
+   purely the GM's inbound queue.
+2. Both agents (VSCode and MCP) may extract from the queue, under the
+   existing AGENTS.md contract.
+3. The queue is read **only when the GM asks**. The agent may notice it
+   is non-empty and offer; it may not process it unbidden. Tool
+   descriptions must encode this.
+4. No move capability over the inbound queue in this release (the
+   extract → show → confirm → move-to-`_Done/` step stays with whoever
+   can move files). Design so adding it later is not a rewrite.
+5. `search` stays canon-only.
+
+Decided during design review (GM chose the maximal options):
+
+6. `promote_draft` ships now, behind `--allow-direct-edits`.
+7. Revision shadows carry base-hash tracking (not mtime, not deferred).
+8. `save_draft` grows a `subdir` parameter for nested briefs.
+
+## 1. Naming and vocabulary
+
+Two directories, two word-families. "Staged"/"staging" survives nowhere —
+not in tools, config keys, method names, docs, or error messages.
+
+| concept | directory | config key | tools | vocabulary |
+|---|---|---|---|---|
+| Agent output awaiting GM review | `_AgentDrafts/` (new) | `drafts_dir` | `save_draft`, `propose_revision`, `update_draft`, `list_drafts`, `read_draft`, `promote_draft` | "drafts" |
+| GM material awaiting extraction | `_ExtractInbound/` (unchanged on disk) | `inbound_dir` (replaces `staging_dir`) | `list_inbound`, `read_inbound` | "the inbound queue" |
+
+- `_AgentDrafts` over `_Proposals`: the GM browsing the workspace sees
+  *whose* material it is, and `save_draft` already speaks the word.
+- Within `list_drafts`, `kind` is `"new" | "revision"` (was
+  `"draft" | "revision"`): everything in the directory is a draft, so
+  what discriminates is whether it proposes new content or revises an
+  existing file.
+- Store methods match their tools: `stage_draft`/`stage_revision` rename
+  to `save_draft`/`propose_revision`; `list_staging`/`read_staged` are
+  replaced by the four read methods above.
+
+## 2. Config and migration
+
+- `Config` gains `drafts_dir` (default `"_AgentDrafts"`) and renames
+  `staging_dir` → `inbound_dir` (default `"_ExtractInbound"`).
+- **Both are auto-excluded at load time**, alongside `MANDATORY_EXCLUDES`:
+  `exclude_dirs = user's list | MANDATORY_EXCLUDES | {inbound_dir,
+  drafts_dir}`. No configuration can un-exclude either special directory.
+  `_ExtractInbound` drops out of the default `exclude_dirs` list and out
+  of the `campaign.toml.in` comment block — keeping it there would be the
+  second copy of a default that the template itself warns against.
+- **Validation:** `ConfigError` when `drafts_dir` or `inbound_dir` names
+  any entry of `entity_dirs`/`inherit_dirs`, or when the two name the
+  same directory — either collision would silently exclude a canon
+  section from every walker, or silently recreate the conflation this
+  design exists to kill. Same pattern as the existing
+  entity/inherit overlap check.
+- **`staging_dir` in campaign.toml → hard `ConfigError`** naming the
+  rename (`workspace.staging_dir was renamed — use inbound_dir`).
+  `load()` ignores unknown keys, so without this the old key would be
+  silently dropped and the workspace would quietly fall back to the
+  default. The scaffold never shipped the key, so this trips
+  approximately nobody, but the failure it prevents is silent.
+- **No migration script.** Workspaces created by `init` have the whole
+  `[workspace]` block commented out, so new defaults apply on upgrade
+  with zero edits. `init` needs no new scaffolding: `save_draft`
+  `mkdir -p`s its destination, so `_AgentDrafts/` appears on first use.
+- **Release note, one line:** agent-written drafts still sitting in
+  `_ExtractInbound/` from the old scheme should be moved to
+  `_AgentDrafts/` or deleted; a `staging_dir` key in `campaign.toml`
+  must be renamed to `inbound_dir`. (The live workspace's queue is all
+  GM material, so no server-start detection is warranted.)
+
+## 3. Store surface and guards
+
+All behaviour on `WorkspaceStore` (stdlib only — it remains the swap seam
+for a hosted git-backed backend, issue #43), in the existing
+instructive-`StoreError` style: every refusal names the valid next move.
+
+Shared rule for **both** directories: any path component beginning with
+`_` below the family root is never listed, read, or written. This is the
+workspace's own underscore-means-machinery convention; it makes
+`_ExtractInbound/_Done/` unreadable without being named in code, and
+makes `_AgentDrafts/_Rejected/` a workable GM rejection signal for free.
+Each family gets one private resolver enforcing: no workspace escape,
+inside the family root, no `_` component. The inbound resolver is the
+deferred-move provision — a future `mark_extracted(path)` is one new
+method reusing it (its `_Done/` *destination* is constructed internally,
+not through the reader's resolver).
+
+`_canonical()` is unchanged: both directories arrive in `exclude_dirs`
+via config, so canon tools refuse them exactly as they refuse `_Ignore/`.
+
+### Drafts family (agent output; read and write)
+
+Names are slugified on write: lowercase; spaces and underscores become
+hyphens; apostrophes drop; runs of hyphens collapse; leading/trailing
+hyphens strip; empty result is refused. Input is still validated by
+`_DRAFT_NAME_RE` first. The display title lives in front matter, where
+the workspace convention already puts it. Slugs make the drafts tree
+mirror canon (`_AgentDrafts/<section>/[<subdir>/]<slug>.md` ↔
+`<section>/[<subdir>/]<slug>.md`), which is what lets `promote_draft`
+derive its destination.
+
+- `save_draft(section, name, content, subdir=None)` — writes
+  `drafts_dir/<section>/[<subdir>/]<slug>.md`. `subdir` is validated by
+  the same regex, slugified the same way, one level deep (nested briefs:
+  `Briefs/session-015/<name>.md`). `perceptions_dir` is not draftable —
+  the perception record is by contract never agent-authored. Refuses if
+  the draft already exists (naming `update_draft`), and refuses if the
+  **mirrored canonical file exists** (naming `propose_revision`) — a new
+  draft colliding with a canonical name would otherwise be misreported
+  as a revision and reviewed as a diff against the wrong entity.
+- `propose_revision(path, content)` — target must be an existing
+  canonical `.md` (as today); writes the shadow copy and records its
+  **base** (below). Refuses if a shadow for `path` already exists,
+  naming `read_draft` + `update_draft` — the previous latest-wins rule
+  silently destroyed pending proposals, which the end-of-session ritual
+  ("draft the updates" to front-burner, compendium, open-questions)
+  makes routine, not rare.
+- `update_draft(path, content)` — **the single overwrite door.** `path`
+  must be an existing `.md` under `drafts_dir` (so the agent necessarily
+  listed or read first). For a revision shadow, refreshes the recorded
+  base to current canon — the refusal flow that led here already forced
+  a read-and-merge.
+- `list_drafts()` — sorted rows over `rglob("*.md")` (everything here is
+  agent-written `.md` by construction), skipping `_` components:
+  `{path, kind, title, summary}` with `stale` added on revision rows.
+  `title`/`summary` come from front matter via the same extraction
+  `list_entities` uses — thirty accumulated drafts must not cost thirty
+  reads to find one. `kind` is `"revision"` iff the mirrored canonical
+  file exists; sound now that only agent output lives here.
+  `stale: true|false|null` — whether canon changed since the proposal's
+  base was recorded; `null` when no base is on record.
+- `read_draft(path)` — resolver guards, `.md`, exists; refusals name
+  `list_drafts` and `read_entity`.
+- `promote_draft(path)` — see §5.
+
+### Base tracking
+
+One manifest: `drafts_dir/.proposal-bases.json` (stdlib `json`; dot-file,
+invisible to every walker and to `list_drafts`), mapping
+workspace-relative shadow path → SHA-256 of the canonical file's bytes at
+proposal time. `propose_revision` records; `update_draft` refreshes;
+`promote_draft` verifies and removes; every write prunes entries whose
+shadow no longer exists. A missing or unparseable manifest is treated as
+empty (all bases unknown → `stale: null`), never an error: it is a cache
+of provenance, not a lock file.
+
+Rejected alternatives: sidecar-per-file (clutters the GM's view of the
+drafts tree), front-matter injection (mutates agent-authored content),
+mtime comparison (git checkouts refresh mtimes; a hint that lies invites
+misplaced trust).
+
+### Inbound family (GM queue; read only)
+
+- `list_inbound()` — sorted `{path, readable}` over **all files** under
+  `inbound_dir`, skipping `_` components. Every extension is listed: a
+  listing that hides files is precisely the defect being fixed. `readable`
+  is `suffix in {".md", ".txt", ".html", ".htm"}` — a PDF or image
+  appears in the list, honestly marked unreadable.
+- `read_inbound(path)` — resolver guards, then the suffix allowlist
+  ("not a text format serve-mcp can return — ask the GM to convert or
+  summarize it"), then exists. Reads with `errors="replace"`: this is
+  foreign material generated elsewhere, and one stray non-UTF-8 byte in
+  a GM's `.txt` must not crash the tool. Canon and drafts stay strict —
+  they are workspace-authored.
+
+## 4. Tool registrations, descriptions, campaign_overview
+
+Descriptions are the contract's enforcement surface; each family states
+its own.
+
+- `save_draft` / `propose_revision` / `update_draft` — destination is
+  "your drafts directory", for GM review and promotion.
+- `list_drafts` / `read_draft` — keep the resume nudge, correct for this
+  material: "your own unpromoted drafts from this and earlier sessions …
+  pick one up and merge rather than writing it again. Nothing here is
+  canon."
+- `list_inbound` / `read_inbound` — encode the AGENTS.md contract:
+  "The GM's inbound queue: material the GM authored elsewhere, awaiting
+  extraction into proper entity files. Call this only when the GM asks
+  you to extract. Do not act on its contents unbidden. Nothing in it is
+  canon — it is unreviewed source material." **Both** tools sit under
+  only-when-asked: the offer the agent is permitted to make comes from
+  the overview count alone, not from unbidden filename enumeration.
+- `campaign_overview` — `overview()` gains `inbound_pending` (defined as
+  exactly `len(list_inbound())`, all files counted, readable or not) and
+  `drafts_pending` (`len(list_drafts())`). Both are `0` when the
+  directory is absent — a count field is always present, and "nothing
+  pending" is the true answer either way (deliberately simpler than the
+  sections' absent-vs-empty rule). The docstring states the permission
+  boundary: if `inbound_pending` is non-zero you may mention it and
+  offer to extract; do not list or read the queue unless asked.
+
+## 5. Promotion
+
+`promote_draft(path)` — registered only under `--allow-direct-edits`,
+the same philosophy as `write_entity`: the capability is gated per-run at
+server start; the GM's in-chat approval is the actual gate per call.
+
+- Destination is **derived**: strip the `drafts_dir` prefix. No `dest`
+  parameter to get wrong; slugs and `subdir` made the trees mirror.
+- `kind: "new"` — the canonical target must **not** exist; parent
+  directories are created as needed.
+- `kind: "revision"` — the target must exist, and the recorded base must
+  still match canon. Stale or unknown base → refusal naming the re-merge
+  flow (`read_entity` current canon → `update_draft`, which re-baselines
+  → retry). A stale shadow is *refused at promotion, not silently
+  applied* — promoting it would revert the GM's interim canon edits,
+  disguised inside an intended diff.
+- Refuses outside a git repository, exactly as `write_entity` does:
+  writes the target, removes the draft (and its manifest entry), stages
+  both paths, commits once as `serve-mcp: promote <path>`.
+- Deliberately **not** included: compendium or front-burner updates.
+  Promotion moves one file; the end-of-session ritual already covers
+  index updates via `propose_revision`, and the docs say so — promotion
+  must not grow a hidden second job.
+
+## 6. Documentation
+
+- **`docs/serve-mcp.md`** — "What the agent can do" restructures around
+  three vocabularies: **canon** (read tools, unchanged), **drafts** (the
+  write tools land in `_AgentDrafts/`; `list_drafts`/`read_draft` read
+  them back; `update_draft` iterates; `promote_draft` under
+  `--allow-direct-edits`; promotion otherwise manual and the GM's),
+  **inbound queue** (`_ExtractInbound/` is the GM's; `list_inbound`/
+  `read_inbound` under the only-when-asked contract; `_`-prefixed
+  subdirectories invisible; non-text files listed but refused on read).
+  "Staging" leaves the document. The config paragraph documents
+  `drafts_dir`/`inbound_dir` and notes both are always excluded from
+  canon regardless of `exclude_dirs`.
+- **`src/bunnyforge/data/doctrine/AGENTS.md`** (the scaffold) —
+  - The directory taxonomy gains `_AgentDrafts/`: the agent's outbox;
+    speculative by definition, never canon; agents may read it freely;
+    a draft the GM rejects is deleted or moved to
+    `_AgentDrafts/_Rejected/` (never read, like `_Done/`).
+  - The `_ExtractInbound` section notes the MCP agent reaches the queue
+    through `list_inbound`/`read_inbound` under the same contract, and
+    rephrases the `_Done/` move per-surface: "move the spent source into
+    `_ExtractInbound/_Done/` — or, if you cannot move files, say so and
+    I will" — the current absolute phrasing orders the MCP agent to do
+    something it cannot, inviting apology loops or false claims.
+- **The live workspace's AGENTS.md** — the GM applies the same two
+  edits; suggested text in the appendix. Code and this repo's docs do
+  not depend on it.
+
+## 7. Testing
+
+TDD throughout; stdlib `unittest` against temp workspaces, matching the
+existing suite.
+
+- **Config:** defaults for both keys; auto-exclusion survives a custom
+  `exclude_dirs` that omits them; `staging_dir` key raises the rename
+  error; section/each-other collision validation.
+- **Drafts:** slugify (spacing, apostrophes, case, empty); `subdir`
+  validation and one-level depth; canonical-collision refusal;
+  existing-draft refusal names `update_draft`; `propose_revision`
+  refuses on existing shadow; `update_draft` overwrite + re-baseline;
+  `list_drafts` kinds, titles/summaries, stale tri-state, `_` skip;
+  `read_draft` refusals; canon tools refuse drafts paths;
+  `perceptions_dir` not draftable.
+- **Base manifest:** record/refresh/verify/prune lifecycle; missing and
+  corrupt manifest read as empty.
+- **Inbound:** `list_inbound` surfaces `.txt`/`.html`/`.md`, marks
+  `.pdf` unreadable, skips `_Done/` and any `_` component (tested before
+  `_Done/` ever exists in the wild — the trap named in the constraints);
+  `read_inbound` refusals (canonical path, `_Done/`, non-text, missing);
+  non-UTF-8 bytes return replaced characters.
+- **Overview:** both counts agree with their listings; `0` when the
+  directory is absent.
+- **Promotion:** new/revision happy paths (file moved, manifest entry
+  gone, one commit); stale and unknown-base refusals; target-exists
+  refusal for `"new"`; non-git refusal; absent without
+  `--allow-direct-edits`.
+- **Tool layer:** registered names updated; one regression test pins the
+  contract phrase ("only when the GM asks") in `list_inbound`'s
+  description — deliberately, since a description saying the opposite is
+  the live bug this redesign fixes.
+
+## Adversarial review disposition
+
+An adversarial subagent review traced the GM's three input flows through
+the design. Its verdict shaped §§3–5: the directories and reads were
+sound, but the write side of `_AgentDrafts/` had single-session
+semantics (never-overwrite, latest-wins, no state, no metadata) under a
+multi-session convergent workflow. Accepted findings: draft iteration
+dead-end (→ `update_draft`); latest-wins clobbering (→ shadow-exists
+refusal); no promotion path (→ `promote_draft` + slugs); rejection
+unrepresentable (→ `_` skip + `_Rejected/` convention); AGENTS.md
+contradictions (→ §6 edits); new-draft/canon collision (→ `save_draft`
+refusal); flat briefs (→ `subdir`); discovery gap (→ `drafts_pending`,
+richer `list_drafts` rows); stale shadows (→ base tracking); count
+semantics (→ defined as the listing's length); config collisions (→
+validation). Rejected: a server-start warning for legacy drafts in the
+queue (the live queue is all GM material; the release note suffices).
+The review could not break: the path-guard model, `_Done/` protection,
+notice-and-offer, the perceptions flow, and publishing isolation.
+
+## Appendix: suggested edit to the live workspace's AGENTS.md
+
+Under the directory rules (alongside `_Ignore/`, `_Archive/`,
+`_ExtractInbound/`):
+
+> - `_AgentDrafts/` is the agents' outbox: drafts and proposed revisions
+>   awaiting my review, written there by the MCP tools (or by you, if I
+>   ask you to draft something). Read it freely; nothing in it is canon.
+>   If I reject a draft I delete it or move it to `_AgentDrafts/_Rejected/`,
+>   which is never read, like `_Ignore/`.
+
+In the "Extracting from _ExtractInbound/" section, after the existing
+bullets:
+
+> - The MCP agent reaches this queue through `list_inbound` and
+>   `read_inbound`, under exactly these rules.
+
+And rephrase the move step:
+
+> - Once I confirm an extraction, move the spent source into
+>   `_ExtractInbound/_Done/` — or, if you cannot move files, say so and
+>   I will.

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -35,8 +35,8 @@ Config = namedtuple(
     "Config",
     "name namespace entity_dirs inherit_dirs compendium_dirs root_docs "
     "exclude_dirs names_cultures names_official_culture names_spelling "
-    "briefs_dir sheets_dir perceptions_dir type_dirs staging_dir wiki_url "
-    "wiki_install_root accepted snapshot_max_age_days fetch_command",
+    "briefs_dir sheets_dir perceptions_dir type_dirs inbound_dir drafts_dir "
+    "wiki_url wiki_install_root accepted snapshot_max_age_days fetch_command",
     # wiki_url and wiki_install_root: [wiki] is entirely optional, so a
     # workspace using neither RPC nor the `wiki` review suite leaves both
     # None. accepted: [[review.accepted]] is likewise optional, so a
@@ -116,12 +116,15 @@ _DEFAULTS = {
     "root_docs": ["AGENTS.md", "compendium.md", "front-burner.md",
                   "open-questions.md", "out-of-game.md", "situation-design.md",
                   "style-guide.md", "tickets.md"],
-    "exclude_dirs": ["_Ignore", "_Archive", "_ExtractInbound", "_Templates",
+    "exclude_dirs": ["_Ignore", "_Archive", "_Templates",
                      "Sheets", "Reviews", "docs", "scripts", "tests"],
-    # Where material authored outside the workspace lands to await
-    # extraction. Deliberately one of exclude_dirs above: a staged draft is
-    # not content until a human promotes it, so nothing walks it.
-    "staging_dir": "_ExtractInbound",
+    # The GM's inbound queue (material authored elsewhere, awaiting
+    # extraction) and the agents' drafts directory (output awaiting GM
+    # review). Both are appended to exclude_dirs at load time, so neither
+    # appears in the default list above — a second copy would be a second
+    # thing to drift, and no configuration may un-exclude them.
+    "inbound_dir": "_ExtractInbound",
+    "drafts_dir": "_AgentDrafts",
     "briefs_dir": "Briefs",
     "sheets_dir": "Sheets",
     "perceptions_dir": "Perceptions",
@@ -316,6 +319,26 @@ def load(workspace: Path) -> Config:
             "not overlap — each would be walked twice; offending "
             f"director{'ies' if len(both) > 1 else 'y'}: {', '.join(both)}")
 
+    if "staging_dir" in ws:
+        raise ConfigError(
+            f"{path}: workspace.staging_dir was renamed — use inbound_dir "
+            "for the GM's inbound queue. Agent drafts now live separately "
+            "under drafts_dir (default _AgentDrafts).")
+
+    inbound_dir = _str(ws, "inbound_dir")
+    drafts_dir = _str(ws, "drafts_dir")
+    if inbound_dir == drafts_dir:
+        raise ConfigError(
+            f"{path}: workspace.inbound_dir and workspace.drafts_dir are "
+            f"both {inbound_dir!r} — they must name different directories; "
+            "one is the GM's inbound queue, the other the agents' drafts")
+    for key, val in (("inbound_dir", inbound_dir), ("drafts_dir", drafts_dir)):
+        if val in entity_dirs or val in inherit_dirs:
+            raise ConfigError(
+                f"{path}: workspace.{key} = {val!r} names a content section "
+                "— it would be excluded from every walk; pick a directory "
+                "of its own (convention: a _-prefixed name)")
+
     return Config(
         name=campaign.get("name", namespace),
         namespace=namespace,
@@ -323,7 +346,8 @@ def load(workspace: Path) -> Config:
         inherit_dirs=inherit_dirs,
         compendium_dirs=_str_tuple(ws, "compendium_dirs"),
         root_docs=_str_tuple(ws, "root_docs"),
-        exclude_dirs=frozenset(_str_tuple(ws, "exclude_dirs")) | MANDATORY_EXCLUDES,
+        exclude_dirs=(frozenset(_str_tuple(ws, "exclude_dirs"))
+                      | MANDATORY_EXCLUDES | {inbound_dir, drafts_dir}),
         names_cultures=names.get("cultures"),
         names_official_culture=names.get("official_culture"),
         names_spelling=spelling,
@@ -331,7 +355,8 @@ def load(workspace: Path) -> Config:
         sheets_dir=_str(ws, "sheets_dir"),
         perceptions_dir=_str(ws, "perceptions_dir"),
         type_dirs=_type_dirs(ws),
-        staging_dir=_str(ws, "staging_dir"),
+        inbound_dir=inbound_dir,
+        drafts_dir=drafts_dir,
         wiki_url=wiki_url,
         wiki_install_root=wiki_install_root,
         accepted=accepted,

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -242,7 +242,12 @@ class WorkspaceStore:
             raise StoreError(
                 f"bad {label} name {raw!r} — letters, digits, spaces, "
                 "- _ ' only, starting with a letter or digit")
-        return _slug(raw)
+        slug = _slug(raw)
+        if not slug:
+            raise StoreError(
+                f"{label} name {raw!r} slugs to empty — use a name with "
+                "at least one letter or digit that survives lowercasing")
+        return slug
 
     def _draft_path(self, path: str) -> Path:
         root = self.ws.root
@@ -328,7 +333,24 @@ class WorkspaceStore:
                 f"no such content file: {path} — propose_revision proposes "
                 "changes to an existing file; use save_draft for new "
                 "content")
-        dest = self._drafts() / target.relative_to(self.ws.root)
+        inner = target.relative_to(self.ws.root)
+        if any(part.startswith("_") for part in inner.parts):
+            # _canonical only refuses configured exclude_dirs, so a
+            # _-prefixed component that isn't one of those (NPCs/_notes.md,
+            # anything under Briefs/_scratch/) still resolves here. Mirroring
+            # it would land the shadow in the drafts directory's own
+            # machinery area, which list_drafts/read_draft/update_draft/
+            # promote_draft all refuse to touch — an invisible, permanent
+            # lockout, since the existence check below would then refuse
+            # every future proposal for this file too. Refuse up front
+            # instead, before anything is written.
+            raise StoreError(
+                f"{path} is under a _-prefixed directory — its draft would "
+                f"land in {self.ws.config.drafts_dir}/'s machinery area, "
+                "which is never listed or read, so the proposal could "
+                "never be reviewed or promoted; move or rename the file "
+                "out of the _-prefixed directory if you want it revisable")
+        dest = self._drafts() / inner
         rel = dest.relative_to(self.ws.root).as_posix()
         if dest.exists():
             raise StoreError(
@@ -432,9 +454,19 @@ class WorkspaceStore:
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(p.read_text(encoding="utf-8"), encoding="utf-8")
         p.unlink()
+        # Only rewrite the manifest when there is something to write: a
+        # genuine prune (removing this entry, or dropping other stale
+        # entries) when the file already exists, or removing this entry
+        # when it was actually present. A NEW draft in a workspace with no
+        # prior proposals has no manifest and no entry — rewriting then
+        # would *create* .proposal-bases.json containing "{}", a file that
+        # never existed, and the pathspec logic below would add it to a
+        # commit whose own contract is "exactly what promotion touched".
         bases = self._load_bases()
+        had_entry = rel in bases
         bases.pop(rel, None)
-        self._save_bases(bases)
+        if had_entry or self._bases_file().is_file():
+            self._save_bases(bases)
         # Add exactly what promotion touched to the index: the target,
         # plus the removed draft and the manifest when git can see them
         # (a never-tracked deleted path would fail `git add` as an

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -333,6 +333,22 @@ class WorkspaceStore:
         self._set_base(rel, target)
         return rel
 
+    def update_draft(self, path: str, content: str) -> str:
+        """Overwrite one existing draft — the only overwrite door, so
+        clobbering is always deliberate: the path must already exist,
+        which means it came from list_drafts or read_draft."""
+        p = self._draft_path(path)
+        if not p.is_file():
+            raise StoreError(
+                f"no such draft: {path} — save_draft creates new drafts; "
+                "list_drafts shows what exists")
+        p.write_text(content, encoding="utf-8")
+        rel = p.relative_to(self.ws.root).as_posix()
+        mirrored = self.ws.root / p.relative_to(self._drafts())
+        if mirrored.is_file():
+            self._set_base(rel, mirrored)
+        return rel
+
     def list_drafts(self) -> list[dict]:
         """Every pending draft: path, kind ("new" content or a "revision"
         of an existing file), title and summary from front matter, and —

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -121,6 +121,10 @@ class WorkspaceStore:
                            ("open_questions", "open-questions.md")):
             p = self.ws.root / fname
             out[key] = p.read_text(encoding="utf-8") if p.is_file() else None
+        # Counts, not contents: the agent may notice the GM's queue is
+        # non-empty and offer to extract, without reading it unbidden.
+        out["inbound_pending"] = len(self.list_inbound())
+        out["drafts_pending"] = len(self.list_drafts())
         return out
 
     def list_entities(self, section: str) -> list[dict]:

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -3,10 +3,10 @@
 _store.py — the workspace-access layer behind `bunnyforge serve-mcp`.
 
 Every MCP tool call touches the workspace through WorkspaceStore, so the
-path guards and the staging/canonical boundary have exactly one home. A
-remote agent's request is untrusted input: it names a path, and refusing
-the ones that escape the workspace or reach into excluded directories is
-this module's job, not the tool layer's.
+path guards and the drafts/inbound/canonical boundaries have exactly one
+home. A remote agent's request is untrusted input: it names a path, and
+refusing the ones that escape the workspace or reach into excluded
+directories is this module's job, not the tool layer's.
 
 Stdlib only, deliberately: the MCP SDK belongs to serve_mcp.py, and even
 there only inside function bodies — this module must import cleanly on a
@@ -19,6 +19,8 @@ belongs on the class, never in free functions serve_mcp.py calls directly.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import random
 import re
 import subprocess
@@ -36,6 +38,18 @@ NAME_COUNT_CAP = 50   # names per request; a brainstorm needs a handful, not a p
 # underscore (dot-files hide; the _-prefix is the workspace's own marker
 # for machinery directories).
 _DRAFT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9 _'-]*")
+
+BASES_NAME = ".proposal-bases.json"
+
+
+def _slug(name: str) -> str:
+    """A _DRAFT_NAME_RE-validated name, as a canon-style filename stem:
+    lowercase, separators to single hyphens, apostrophes dropped. Canon
+    files are kebab-case, and slugs are what let the drafts tree mirror
+    canon — which is what lets promotion derive its destination."""
+    s = name.lower().replace("'", "")
+    s = re.sub(r"[\s_]+", "-", s)
+    return re.sub(r"-+", "-", s).strip("-")
 
 
 class StoreError(Exception):
@@ -64,11 +78,10 @@ class WorkspaceStore:
         """Resolve a workspace-relative path, refusing escapes and excluded
         directories.
 
-        The staging directory is one of the excluded ones, so a draft written
-        there is not readable back through this method: the canon read tools
-        serve canon, and staged material is not canon until a human promotes
-        it. Staging has its own labelled door — read_staged, below — which
-        guards the inverse condition and reaches nothing else.
+        The drafts and inbound directories are among the excluded ones, so
+        neither is readable through this method: the canon read tools serve
+        canon. Each has its own labelled door — read_draft and read_inbound
+        — guarding the inverse condition.
         """
         root = self.ws.root
         p = (root / path).resolve()
@@ -201,90 +214,166 @@ class WorkspaceStore:
                 "places": [_names.place_name(rng, inv, key)
                            for _ in range(count)]}
 
-    # -- staging ------------------------------------------------------------
+    # -- agent drafts -------------------------------------------------------
+    # The agents' outbox: drafts and proposed revisions awaiting GM review.
+    # Excluded from the canon reads BY DESIGN (config auto-excludes it), so
+    # it has its own labelled doors. _draft_path guards the inverse of
+    # _canonical() — inside the drafts directory rather than outside it —
+    # so these methods cannot be talked into serving canon. Underscore
+    # components are machinery (the workspace's own convention): a draft
+    # the GM moves to _Rejected/ is never listed or read again.
 
-    def _staging(self) -> Path:
-        return self.ws.root / self.ws.config.inbound_dir
+    def _drafts(self) -> Path:
+        return self.ws.root / self.ws.config.drafts_dir
 
-    # Reading staging back is the agent's own inbox, not a second door into
-    # canon: these two are the only way in, they reach nothing else, and the
-    # tool docstrings say the material is unreviewed. read_staged's guard is
-    # the exact inverse of _canonical() -- inside the staging directory
-    # rather than outside it -- so it cannot be talked into serving canon.
-    # Its messages name the TOOL the agent can call next, which is what it
-    # can act on; list_staging is what the tool layer registers as that.
+    def _draftable_sections(self) -> tuple[str, ...]:
+        # The perception record is by contract never agent-authored.
+        return tuple(s for s in self._sections()
+                     if s != self.ws.config.perceptions_dir)
 
-    def list_staging(self) -> list[dict]:
-        """Every staged markdown file: its workspace path and what it is.
+    def _slugged(self, raw: str, label: str) -> str:
+        if not _DRAFT_NAME_RE.fullmatch(raw):
+            raise StoreError(
+                f"bad {label} name {raw!r} — letters, digits, spaces, "
+                "- _ ' only, starting with a letter or digit")
+        return _slug(raw)
 
-        "revision" means the mirrored canonical file exists, so the GM reads
-        it as a diff; "draft" means new content with nothing to compare
-        against. Sorted, so two calls agree.
-        """
-        staging = self._staging()
-        out = []
-        for p in sorted(staging.rglob("*.md")):
-            if not p.is_file():
-                continue
-            mirrored = self.ws.root / p.relative_to(staging)
-            out.append({"path": p.relative_to(self.ws.root).as_posix(),
-                        "kind": "revision" if mirrored.is_file() else "draft"})
-        return out
-
-    def read_staged(self, path: str) -> str:
-        """Full text of one staged file — unreviewed material, not canon."""
+    def _draft_path(self, path: str) -> Path:
         root = self.ws.root
-        staging = self._staging()
+        drafts = self._drafts()
         p = (root / path).resolve()
         if not p.is_relative_to(root):
             raise StoreError(f"path escapes the workspace: {path}")
-        if not p.is_relative_to(staging):
+        if not p.is_relative_to(drafts):
             raise StoreError(
-                f"not a staged path: {path} — read_staged serves "
-                f"{self.ws.config.inbound_dir}/ only; canonical files are "
+                f"not a draft path: {path} — this tool serves "
+                f"{self.ws.config.drafts_dir}/ only; canonical files are "
                 "read with read_entity")
+        if any(part.startswith("_")
+               for part in p.relative_to(drafts).parts):
+            raise StoreError(
+                f"{path} is in a _-prefixed area of the drafts directory "
+                "(the GM's machinery, e.g. _Rejected/) and is never served")
         if p.suffix != ".md":
             raise StoreError(
-                f"not a staged markdown file: {path} — staging holds .md "
-                "drafts and revisions")
-        if not p.is_file():
-            raise StoreError(
-                f"no such staged file: {path} — list_staged shows what is "
-                "currently staged")
-        return p.read_text(encoding="utf-8")
+                f"not a draft markdown file: {path} — drafts are .md only")
+        return p
 
-    # -- write side ---------------------------------------------------------
-    # Staging paths are built directly rather than through _canonical: the
-    # staging directory is excluded from the canon reads BY DESIGN, and these
-    # two methods are the only writers. Traversal is impossible by
-    # construction -- section is validated against config, and _DRAFT_NAME_RE
-    # admits no separator.
+    # The base manifest: workspace-relative shadow path -> SHA-256 of the
+    # canonical file at proposal time. A provenance cache, not a lock file:
+    # missing or unparseable reads as empty, and every save prunes entries
+    # whose shadow is gone.
 
-    def stage_draft(self, section: str, name: str, content: str) -> str:
-        self._check_section(section)
-        if not _DRAFT_NAME_RE.fullmatch(name):
+    def _bases_file(self) -> Path:
+        return self._drafts() / BASES_NAME
+
+    def _load_bases(self) -> dict[str, str]:
+        try:
+            raw = json.loads(self._bases_file().read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        return {k: v for k, v in raw.items()
+                if isinstance(k, str) and isinstance(v, str)}
+
+    def _save_bases(self, bases: dict[str, str]) -> None:
+        live = {k: v for k, v in bases.items()
+                if (self.ws.root / k).is_file()}
+        f = self._bases_file()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps(live, indent=2, sort_keys=True) + "\n",
+                     encoding="utf-8")
+
+    def _set_base(self, shadow_rel: str, canon: Path) -> None:
+        bases = self._load_bases()
+        bases[shadow_rel] = hashlib.sha256(canon.read_bytes()).hexdigest()
+        self._save_bases(bases)
+
+    def save_draft(self, section: str, name: str, content: str,
+                   subdir: str | None = None) -> str:
+        if section not in self._draftable_sections():
             raise StoreError(
-                f"bad draft name {name!r} — letters, digits, spaces, "
-                "- _ ' only, starting with a letter or digit")
-        dest = self._staging() / section / f"{name}.md"
+                f"unknown or undraftable section {section!r} — one of: "
+                + ", ".join(self._draftable_sections()))
+        rel = Path(section)
+        if subdir is not None:
+            rel = rel / self._slugged(subdir, "subdir")
+        rel = rel / f"{self._slugged(name, 'draft')}.md"
+        if (self.ws.root / rel).is_file():
+            raise StoreError(
+                f"{rel.as_posix()} already exists in canon — use "
+                "propose_revision to suggest changes to it, or pick "
+                "another name")
+        dest = self._drafts() / rel
         if dest.exists():
-            rel = dest.relative_to(self.ws.root).as_posix()
-            raise StoreError(f"{rel} already exists — pick another name")
+            drel = dest.relative_to(self.ws.root).as_posix()
+            raise StoreError(
+                f"{drel} already exists — read_draft it and revise with "
+                "update_draft, or pick another name")
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content, encoding="utf-8")
         return dest.relative_to(self.ws.root).as_posix()
 
-    def stage_revision(self, path: str, content: str) -> str:
+    def propose_revision(self, path: str, content: str) -> str:
         target = self._canonical(path)
         if not target.is_file() or target.suffix != ".md":
             raise StoreError(
-                f"no such content file: {path} — stage_revision proposes "
-                "changes to an existing file; use stage_draft for new "
+                f"no such content file: {path} — propose_revision proposes "
+                "changes to an existing file; use save_draft for new "
                 "content")
-        dest = self._staging() / target.relative_to(self.ws.root)
+        dest = self._drafts() / target.relative_to(self.ws.root)
+        rel = dest.relative_to(self.ws.root).as_posix()
+        if dest.exists():
+            raise StoreError(
+                f"a pending proposal already exists at {rel} — read_draft "
+                "it, merge your changes into it, then update_draft")
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(content, encoding="utf-8")  # latest proposal wins
-        return dest.relative_to(self.ws.root).as_posix()
+        dest.write_text(content, encoding="utf-8")
+        self._set_base(rel, target)
+        return rel
+
+    def list_drafts(self) -> list[dict]:
+        """Every pending draft: path, kind ("new" content or a "revision"
+        of an existing file), title and summary from front matter, and —
+        for revisions — whether canon changed since it was proposed.
+        Sorted, so two calls agree."""
+        drafts = self._drafts()
+        bases = self._load_bases()
+        out = []
+        for p in sorted(drafts.rglob("*.md")):
+            if not p.is_file():
+                continue
+            inner = p.relative_to(drafts)
+            if any(part.startswith("_") for part in inner.parts):
+                continue
+            rel = p.relative_to(self.ws.root).as_posix()
+            fm, _body = _common.split_front_matter(
+                p.read_text(encoding="utf-8"))
+            mirrored = self.ws.root / inner
+            row = {"path": rel,
+                   "kind": "revision" if mirrored.is_file() else "new",
+                   "title": fm.get("title") or p.stem,
+                   "summary": fm.get("summary", "")}
+            if row["kind"] == "revision":
+                base = bases.get(rel)
+                row["stale"] = (None if base is None else
+                                hashlib.sha256(mirrored.read_bytes())
+                                .hexdigest() != base)
+            out.append(row)
+        return out
+
+    def read_draft(self, path: str) -> str:
+        """Full text of one pending draft — unreviewed material, not
+        canon."""
+        p = self._draft_path(path)
+        if not p.is_file():
+            raise StoreError(
+                f"no such draft: {path} — list_drafts shows what is "
+                "pending")
+        return p.read_text(encoding="utf-8")
+
+    # -- write side ---------------------------------------------------------
 
     def write_entity(self, path: str, content: str) -> str:
         target = self._canonical(path)

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -395,6 +395,68 @@ class WorkspaceStore:
                 "pending")
         return p.read_text(encoding="utf-8")
 
+    def promote_draft(self, path: str) -> str:
+        """Move one approved draft to its canonical location and commit.
+
+        The destination is derived by stripping the drafts prefix — slugs
+        made the two trees mirror. Order matters: every refusal fires
+        before the filesystem changes, so a refused promotion leaves the
+        draft exactly where it was."""
+        p = self._draft_path(path)
+        if not p.is_file():
+            raise StoreError(
+                f"no such draft: {path} — list_drafts shows what is "
+                "pending")
+        rel = p.relative_to(self.ws.root).as_posix()
+        inner = p.relative_to(self._drafts())
+        target = self.ws.root / inner
+        target_rel = inner.as_posix()
+        if target.is_file():
+            # A revision: its recorded base must still match canon. None
+            # (unrecorded) never equals a hash, so unverifiable shadows
+            # are refused too rather than silently applied.
+            base = self._load_bases().get(rel)
+            if base != hashlib.sha256(target.read_bytes()).hexdigest():
+                raise StoreError(
+                    f"{target_rel} changed since this revision was "
+                    "proposed (or its base is unrecorded) — read_entity "
+                    "the current file, merge with update_draft, then "
+                    "promote again")
+        probe = subprocess.run(
+            ["git", "-C", str(self.ws.root), "rev-parse",
+             "--is-inside-work-tree"], capture_output=True, text=True)
+        if probe.returncode != 0:
+            raise StoreError(
+                "promotion requires the workspace to be a git repository "
+                "— refusing to change canon without history")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(p.read_text(encoding="utf-8"), encoding="utf-8")
+        p.unlink()
+        bases = self._load_bases()
+        bases.pop(rel, None)
+        self._save_bases(bases)
+        # Add exactly what promotion touched to the index: the target,
+        # plus the removed draft and the manifest when git can see them
+        # (a never-tracked deleted path would fail `git add` as an
+        # unmatched pathspec).
+        bases_rel = self._bases_file().relative_to(self.ws.root).as_posix()
+        spec = [target_rel]
+        for cand in (rel, bases_rel):
+            tracked = subprocess.run(
+                ["git", "-C", str(self.ws.root), "ls-files", "--", cand],
+                capture_output=True, text=True).stdout.strip()
+            if tracked or (self.ws.root / cand).exists():
+                spec.append(cand)
+        for sub in (["add", "-A", "--"] + spec,
+                    ["commit", "-m", f"serve-mcp: promote {target_rel}"]):
+            done = subprocess.run(["git", "-C", str(self.ws.root)] + sub,
+                                  capture_output=True, text=True)
+            if done.returncode != 0:
+                raise StoreError(
+                    f"git {sub[0]} failed: "
+                    f"{done.stderr.strip() or done.stdout.strip()}")
+        return target_rel
+
     # -- inbound queue ------------------------------------------------------
     # The GM's inbound queue: material authored elsewhere, awaiting
     # extraction into proper entity files. Read-only here, and the tool

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -454,7 +454,11 @@ class WorkspaceStore:
             if done.returncode != 0:
                 raise StoreError(
                     f"git {sub[0]} failed: "
-                    f"{done.stderr.strip() or done.stdout.strip()}")
+                    f"{done.stderr.strip() or done.stdout.strip()} — "
+                    f"{target_rel} holds the promoted content, written but "
+                    "NOT committed, and the draft was removed; commit or "
+                    "inspect it by hand (do not discard it) before "
+                    "retrying")
         return target_rel
 
     # -- inbound queue ------------------------------------------------------

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -204,7 +204,7 @@ class WorkspaceStore:
     # -- staging ------------------------------------------------------------
 
     def _staging(self) -> Path:
-        return self.ws.root / self.ws.config.staging_dir
+        return self.ws.root / self.ws.config.inbound_dir
 
     # Reading staging back is the agent's own inbox, not a second door into
     # canon: these two are the only way in, they reach nothing else, and the
@@ -241,7 +241,7 @@ class WorkspaceStore:
         if not p.is_relative_to(staging):
             raise StoreError(
                 f"not a staged path: {path} — read_staged serves "
-                f"{self.ws.config.staging_dir}/ only; canonical files are "
+                f"{self.ws.config.inbound_dir}/ only; canonical files are "
                 "read with read_entity")
         if p.suffix != ".md":
             raise StoreError(

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -41,6 +41,8 @@ _DRAFT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9 _'-]*")
 
 BASES_NAME = ".proposal-bases.json"
 
+INBOUND_SUFFIXES = frozenset({".md", ".txt", ".html", ".htm"})
+
 
 def _slug(name: str) -> str:
     """A _DRAFT_NAME_RE-validated name, as a canon-style filename stem:
@@ -388,6 +390,77 @@ class WorkspaceStore:
                 f"no such draft: {path} — list_drafts shows what is "
                 "pending")
         return p.read_text(encoding="utf-8")
+
+    # -- inbound queue ------------------------------------------------------
+    # The GM's inbound queue: material authored elsewhere, awaiting
+    # extraction into proper entity files. Read-only here, and the tool
+    # descriptions add "only when the GM asks". _inbound_path is the shared
+    # resolver a future mark_extracted() reuses — a move tool is one new
+    # method, not a rewrite (its _Done/ destination would be constructed
+    # internally, not through this reader's resolver, which refuses
+    # _-prefixed components).
+
+    def _inbound(self) -> Path:
+        return self.ws.root / self.ws.config.inbound_dir
+
+    @staticmethod
+    def _machinery(parts: tuple[str, ...]) -> bool:
+        # _-prefixed: the workspace's machinery convention (_Done/,
+        # _Rejected/). .-prefixed: hidden files (.DS_Store) — never GM
+        # material, and listing them would inflate inbound_pending.
+        return any(part.startswith(("_", ".")) for part in parts)
+
+    def _inbound_path(self, path: str) -> Path:
+        root = self.ws.root
+        inbound = self._inbound()
+        p = (root / path).resolve()
+        if not p.is_relative_to(root):
+            raise StoreError(f"path escapes the workspace: {path}")
+        if not p.is_relative_to(inbound):
+            raise StoreError(
+                f"not an inbound path: {path} — read_inbound serves "
+                f"{self.ws.config.inbound_dir}/ only; canonical files are "
+                "read with read_entity")
+        if self._machinery(p.relative_to(inbound).parts):
+            raise StoreError(
+                f"{path} is in a processed or private area of the inbound "
+                "queue (_- or .-prefixed) and is never read — _Done/ holds "
+                "spent source awaiting the GM's cleanup")
+        return p
+
+    def list_inbound(self) -> list[dict]:
+        """Every live file in the GM's inbound queue, whatever its type:
+        workspace path, and whether read_inbound can return it. Sorted,
+        so two calls agree."""
+        inbound = self._inbound()
+        if not inbound.is_dir():
+            return []
+        out = []
+        for p in sorted(inbound.rglob("*")):
+            if not p.is_file():
+                continue
+            if self._machinery(p.relative_to(inbound).parts):
+                continue
+            out.append({
+                "path": p.relative_to(self.ws.root).as_posix(),
+                "readable": p.suffix.lower() in INBOUND_SUFFIXES})
+        return out
+
+    def read_inbound(self, path: str) -> str:
+        """Full text of one inbound file — the GM's unreviewed source
+        material, not canon. Decoding is forgiving (errors="replace"):
+        this material was generated outside the workspace."""
+        p = self._inbound_path(path)
+        if p.suffix.lower() not in INBOUND_SUFFIXES:
+            raise StoreError(
+                f"{path} is not a text format serve-mcp can return "
+                f"({', '.join(sorted(INBOUND_SUFFIXES))}) — ask the GM to "
+                "convert or summarize it")
+        if not p.is_file():
+            raise StoreError(
+                f"no such inbound file: {path} — list_inbound shows the "
+                "queue")
+        return p.read_text(encoding="utf-8", errors="replace")
 
     # -- write side ---------------------------------------------------------
 

--- a/src/bunnyforge/data/campaign.toml.in
+++ b/src/bunnyforge/data/campaign.toml.in
@@ -31,9 +31,13 @@ cultures = "names/cultures"        # a DIRECTORY of one-file-per-culture
 # root_docs       = ["AGENTS.md", "compendium.md", "front-burner.md",
 #                    "open-questions.md", "out-of-game.md", "situation-design.md",
 #                    "style-guide.md", "tickets.md"]
-# exclude_dirs    = ["_Ignore", "_Archive", "_ExtractInbound", "_Templates",
+# exclude_dirs    = ["_Ignore", "_Archive", "_Templates",
 #                    "Sheets", "Reviews", "docs", "scripts", "tests"]
 # briefs_dir      = "Briefs"
 # sheets_dir      = "Sheets"
 # perceptions_dir = "Perceptions"
+# inbound_dir     = "_ExtractInbound"  # the GM's inbound queue; always
+#                                      # excluded from canon, listed or not
+# drafts_dir      = "_AgentDrafts"     # agent output awaiting review; always
+#                                      # excluded from canon, listed or not
 # type_dirs       = { npc = "NPCs", faction = "Factions", place = "Setting" }

--- a/src/bunnyforge/data/doctrine/AGENTS.md
+++ b/src/bunnyforge/data/doctrine/AGENTS.md
@@ -77,13 +77,15 @@ propose changes to canon — not to the perception record.
 
 ## Extracting from _ExtractInbound/
 
-`_ExtractInbound/` is a staging area for material brought into the workspace —
-typically wiki pages unpacked from a tarball. It is distinct from `_Ignore/`,
+`_ExtractInbound/` is an inbound queue for material brought into the workspace
+— typically wiki pages unpacked from a tarball. It is distinct from `_Ignore/`,
 which is never read.
 
 - **Read it only when I ask you to extract.** Do not act on its contents
   proactively. You may notice it is non-empty and offer; you may not process it
   unbidden.
+- **The MCP agent reaches this queue through `list_inbound` and
+  `read_inbound`, under exactly these rules.**
 - **Nothing in it is canon.** It is unreviewed source, and a copy — the wiki is
   the source of truth until the material is extracted into proper entity files.
 - **On any conflict, ask — this is "Clarify before proceeding" applied here.**
@@ -94,10 +96,11 @@ which is never read.
   guard captain who retires and a guard captain who is killed are describing two
   people, not one fact to reconcile.) When in doubt, surface it and let me
   answer.
-- **Extract, show me, confirm, then move — never delete.** Once I confirm an
-  extraction, move the spent source into `_ExtractInbound/_Done/`. Do not delete
-  it; I clear `_Done/` myself. And never move anything before I have confirmed.
-  The active directory emptying is how we track what remains to process.
+- **Extract, show me, confirm, then move — never delete.** Once I confirm
+  an extraction, move the spent source into `_ExtractInbound/_Done/` — or,
+  if you cannot move files, say so and I will. Do not delete it; I clear
+  `_Done/` myself. And never move anything before I have confirmed. The
+  active directory emptying is how we track what remains to process.
 - **`_ExtractInbound/_Done/` is never read**, exactly like `_Ignore/`. It holds
   processed source awaiting my manual cleanup.
 
@@ -176,9 +179,14 @@ include the separator, even if the GM notes section is empty. A handout is a
   no precedent (see the deletion rule below). It is not canon, and it is not a
   fallback when an answer cannot be found elsewhere. The only exception is
   a file in it that I name explicitly and ask you to work on.
-- Do not read `_ExtractInbound/` unless I ask you to extract from it. It is a
-  staging area for imported material, none of it canon. See its own section
+- Do not read `_ExtractInbound/` unless I ask you to extract from it. It is an
+  inbound queue for imported material, none of it canon. See its own section
   below.
+- `_AgentDrafts/` is the agents' outbox: drafts and proposed revisions
+  awaiting my review, written by the MCP tools (or by you, if I ask you to
+  draft something). Read it freely; nothing in it is canon. If I reject a
+  draft I delete it or move it to `_AgentDrafts/_Rejected/`, which is
+  never read, like `_Ignore/`.
 
 ## Speculative material stays speculative
 

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -120,37 +120,41 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         return store.generate_names(culture, count)
 
     @server.tool()
-    def save_draft(section: str, name: str, content: str) -> str:
-        """Stage NEW content (a full markdown file, front matter included)
-        into the workspace's staging area for the GM to review and promote.
-        Never overwrites; returns the staged path."""
-        return store.stage_draft(section, name, content)
+    def save_draft(section: str, name: str, content: str,
+                   subdir: str | None = None) -> str:
+        """Draft NEW content (a full markdown file, front matter included)
+        into your drafts directory for the GM to review and promote. The
+        name is slugged to kebab-case (put the display title in front
+        matter); subdir nests one level, e.g. section="Briefs",
+        subdir="session-015". Never overwrites — revise existing drafts
+        with update_draft. Returns the draft's path."""
+        return store.save_draft(section, name, content, subdir)
 
     @server.tool()
     def propose_revision(path: str, content: str) -> str:
-        """Stage a full-file revision of an EXISTING workspace file as a
-        shadow copy in the staging area. The GM reviews it as a diff.
-        Re-proposing replaces the earlier proposal; returns the staged
-        path."""
-        return store.stage_revision(path, content)
+        """Propose a full-file revision of an EXISTING canonical file, as
+        a shadow copy in your drafts directory; the GM reviews it as a
+        diff. One pending proposal per file: if one exists, read_draft it,
+        merge, and update_draft instead. Returns the draft's path."""
+        return store.propose_revision(path, content)
 
     @server.tool()
-    def list_staged() -> list[dict]:
-        """List everything you have staged and not yet had promoted: each
-        path, and whether it is a "draft" (new content) or a "revision" (a
-        proposed rewrite of an existing file). This is your own inbox, NOT
-        canon — nothing here has been reviewed, and it may never be. Use it
-        to pick up drafts from an earlier session instead of starting them
-        again."""
-        return store.list_staging()
+    def list_drafts() -> list[dict]:
+        """List your own unpromoted drafts from this and earlier sessions:
+        path, kind ("new" content or a "revision" of an existing file),
+        title and summary, and for revisions whether canon has changed
+        underneath them (stale). Nothing here is canon — it is your
+        unreviewed work awaiting the GM. Pick a draft up and merge rather
+        than writing it again."""
+        return store.list_drafts()
 
     @server.tool()
-    def read_staged(path: str) -> str:
-        """Read one staged file in full. Paths come from list_staged.
-        Staged material is UNREVIEWED and is not canon — do not treat it as
-        established fact about the campaign; read it to revisit or merge
-        your own earlier drafts. For canonical files, use read_entity."""
-        return store.read_staged(path)
+    def read_draft(path: str) -> str:
+        """Read one of your pending drafts in full. Paths come from
+        list_drafts. Draft material is UNREVIEWED and not canon — do not
+        treat it as established fact. For canonical files, use
+        read_entity."""
+        return store.read_draft(path)
 
     if allow_direct_edits:
         @server.tool()

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -165,6 +165,24 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         read_entity."""
         return store.read_draft(path)
 
+    @server.tool()
+    def list_inbound() -> list[dict]:
+        """The GM's inbound queue: material the GM authored elsewhere,
+        awaiting extraction into proper entity files. Call this only when
+        the GM asks you to extract — do not act on the queue unbidden.
+        (campaign_overview's inbound_pending count is how you may notice
+        it is non-empty and offer.) Lists every file with whether
+        read_inbound can return it. Nothing here is canon."""
+        return store.list_inbound()
+
+    @server.tool()
+    def read_inbound(path: str) -> str:
+        """Read one file from the GM's inbound queue, only when the GM
+        asks you to extract. Paths come from list_inbound. The material
+        is unreviewed source, not canon — extract it into drafts, show
+        the GM, and confirm before anything else happens with it."""
+        return store.read_inbound(path)
+
     if allow_direct_edits:
         @server.tool()
         def write_entity(path: str, content: str) -> str:

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -139,6 +139,15 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         return store.propose_revision(path, content)
 
     @server.tool()
+    def update_draft(path: str, content: str) -> str:
+        """Overwrite one of your existing drafts with revised content —
+        the deliberate way to iterate on a draft across sessions.
+        read_draft it first and merge; updating a revision shadow also
+        re-baselines it against current canon. Paths come from
+        list_drafts."""
+        return store.update_draft(path, content)
+
+    @server.tool()
     def list_drafts() -> list[dict]:
         """List your own unpromoted drafts from this and earlier sessions:
         path, kind ("new" content or a "revision" of an existing file),

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -196,6 +196,16 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
             started with --allow-direct-edits."""
             return store.write_entity(path, content)
 
+        @server.tool()
+        def promote_draft(path: str) -> str:
+            """Move one draft the GM has just approved in this chat to its
+            canonical location (derived from the draft path) and commit
+            it. Only call this after the GM's explicit approval of that
+            specific draft. A stale revision is refused — merge with
+            update_draft first. Available only because this server was
+            started with --allow-direct-edits."""
+            return store.promote_draft(path)
+
     def _reader(path):
         def read() -> str:
             return path.read_text(encoding="utf-8")

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -88,8 +88,13 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
     @server.tool()
     def campaign_overview() -> dict:
         """Get your bearings in one call: the campaign's name, each section
-        with how many entities it holds, and the current front-burner and
-        open-questions documents. Call this before anything else."""
+        with how many entities it holds, the current front-burner and
+        open-questions documents, and two counts — drafts_pending (your
+        own unpromoted drafts; list_drafts to resume them) and
+        inbound_pending (files in the GM's inbound queue). If
+        inbound_pending is non-zero you may mention it and offer to
+        extract; do not list or read the queue unless the GM asks. Call
+        this before anything else."""
         return store.overview()
 
     @server.tool()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -246,25 +246,68 @@ class TestConfigLoad(unittest.TestCase):
             _config.load(cfg)
         self.assertIn("must be a table of strings", str(ctx.exception))
 
-    def test_staging_dir_defaults_to_extract_inbound(self):
-        # Where material written from outside the workspace lands to await
-        # extraction. The default matches the existing convention, and is
-        # already in the default exclude_dirs -- staged drafts are meant to
-        # be invisible to every walk until a human promotes them.
+    def test_inbound_dir_defaults_to_extract_inbound(self):
+        # The GM's inbound queue: material authored elsewhere, awaiting
+        # extraction. Excluded from every walk unconditionally (below).
         cfg = _config.load(self._ws(MINIMAL))
-        self.assertEqual(cfg.staging_dir, "_ExtractInbound")
-        self.assertIn(cfg.staging_dir, cfg.exclude_dirs)
+        self.assertEqual(cfg.inbound_dir, "_ExtractInbound")
+        self.assertIn(cfg.inbound_dir, cfg.exclude_dirs)
 
-    def test_staging_dir_honours_explicit_override(self):
+    def test_drafts_dir_defaults_to_agent_drafts(self):
+        cfg = _config.load(self._ws(MINIMAL))
+        self.assertEqual(cfg.drafts_dir, "_AgentDrafts")
+        self.assertIn(cfg.drafts_dir, cfg.exclude_dirs)
+
+    def test_special_dirs_are_excluded_even_when_exclude_dirs_omits_them(self):
+        # No configuration may un-exclude either special directory: a
+        # workspace that customised exclude_dirs without them would silently
+        # serve agent drafts as canon.
         cfg = _config.load(self._ws(
-            MINIMAL + '\n[workspace]\nstaging_dir = "_Inbox"\n'))
-        self.assertEqual(cfg.staging_dir, "_Inbox")
+            MINIMAL + '\n[workspace]\nexclude_dirs = ["docs"]\n'))
+        self.assertIn("_ExtractInbound", cfg.exclude_dirs)
+        self.assertIn("_AgentDrafts", cfg.exclude_dirs)
 
-    def test_staging_dir_wrong_type_raises(self):
+    def test_overridden_special_dirs_are_auto_excluded_too(self):
+        cfg = _config.load(self._ws(
+            MINIMAL +
+            '\n[workspace]\ninbound_dir = "_Inbox"\ndrafts_dir = "_Outbox"\n'))
+        self.assertEqual(cfg.inbound_dir, "_Inbox")
+        self.assertEqual(cfg.drafts_dir, "_Outbox")
+        self.assertIn("_Inbox", cfg.exclude_dirs)
+        self.assertIn("_Outbox", cfg.exclude_dirs)
+
+    def test_staging_dir_key_is_refused_naming_the_rename(self):
+        # load() ignores unknown keys, so without this check an old
+        # staging_dir key would be silently dropped — a behaviour change
+        # with no error.
         with self.assertRaises(_config.ConfigError) as ctx:
             _config.load(self._ws(
-                MINIMAL + '\n[workspace]\nstaging_dir = ["x"]\n'))
-        self.assertIn("staging_dir", str(ctx.exception))
+                MINIMAL + '\n[workspace]\nstaging_dir = "_Inbox"\n'))
+        self.assertIn("inbound_dir", str(ctx.exception))
+
+    def test_inbound_and_drafts_dir_wrong_type_raises(self):
+        for key in ("inbound_dir", "drafts_dir"):
+            with self.assertRaises(_config.ConfigError) as ctx:
+                _config.load(self._ws(
+                    MINIMAL + f'\n[workspace]\n{key} = ["x"]\n'))
+            self.assertIn(key, str(ctx.exception))
+
+    def test_special_dir_naming_a_section_raises(self):
+        # drafts_dir = "Ideas" would auto-exclude a canon section from
+        # every walker — silently, since auto-exclusion happens at load.
+        for key, section in (("drafts_dir", "Ideas"), ("inbound_dir", "Briefs")):
+            with self.assertRaises(_config.ConfigError) as ctx:
+                _config.load(self._ws(
+                    MINIMAL + f'\n[workspace]\n{key} = "{section}"\n'))
+            self.assertIn(section, str(ctx.exception))
+
+    def test_inbound_and_drafts_dir_must_differ(self):
+        # Identical values would recreate the conflation this split kills.
+        with self.assertRaises(_config.ConfigError) as ctx:
+            _config.load(self._ws(
+                MINIMAL +
+                '\n[workspace]\ninbound_dir = "_X"\ndrafts_dir = "_X"\n'))
+        self.assertIn("_X", str(ctx.exception))
 
 
 class TestWorkspace(unittest.TestCase):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -483,7 +483,7 @@ class TestGeneratedConfig(unittest.TestCase):
             cfg.exclude_dirs,
             frozenset(_config._DEFAULTS["exclude_dirs"])
             | _config.MANDATORY_EXCLUDES
-            | {cfg.inbound_dir, cfg.drafts_dir})
+            | {_config._DEFAULTS["inbound_dir"], _config._DEFAULTS["drafts_dir"]})
 
     def test_name_and_namespace_carry_the_substituted_values(self):
         cfg = self._config_of()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -482,7 +482,8 @@ class TestGeneratedConfig(unittest.TestCase):
         self.assertEqual(
             cfg.exclude_dirs,
             frozenset(_config._DEFAULTS["exclude_dirs"])
-            | _config.MANDATORY_EXCLUDES)
+            | _config.MANDATORY_EXCLUDES
+            | {cfg.inbound_dir, cfg.drafts_dir})
 
     def test_name_and_namespace_carry_the_substituted_values(self):
         cfg = self._config_of()

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -227,7 +227,11 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         # ("use it to pick up drafts"), actively nudging the agent to read
         # the GM's queue unbidden. The contract phrase is load-bearing.
         server = serve_mcp.build_server(scaffold(self))
-        descs = {t.name: (t.description or "")
+        # The MCP SDK derives tool descriptions from docstrings and preserves
+        # their line breaks, so the contract sentence may span lines in the
+        # source. Normalize whitespace so we can pin the phrase itself
+        # rather than its typography.
+        descs = {t.name: " ".join((t.description or "").split())
                  for t in await server.list_tools()}
         for name in ("list_inbound", "read_inbound"):
             self.assertIn("only when the GM asks", descs[name])

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -152,6 +152,8 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
             store, allow_direct_edits=True).list_tools()}
         self.assertNotIn("write_entity", off)
         self.assertIn("write_entity", on)
+        self.assertNotIn("promote_draft", off)
+        self.assertIn("promote_draft", on)
 
     async def test_save_draft_lands_in_the_drafts_dir(self):
         store = scaffold(self)

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -215,6 +215,21 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         uris = {str(r.uri) for r in await server.list_resources()}
         self.assertNotIn("bunnyforge://doctrine/situation-design.md", uris)
 
+    async def test_inbound_tools_always_registered(self):
+        server = serve_mcp.build_server(scaffold(self))
+        names = {t.name for t in await server.list_tools()}
+        self.assertLessEqual({"list_inbound", "read_inbound"}, names)
+
+    async def test_inbound_descriptions_carry_the_contract(self):
+        # Regression: the old list_staged description said the opposite
+        # ("use it to pick up drafts"), actively nudging the agent to read
+        # the GM's queue unbidden. The contract phrase is load-bearing.
+        server = serve_mcp.build_server(scaffold(self))
+        descs = {t.name: (t.description or "")
+                 for t in await server.list_tools()}
+        for name in ("list_inbound", "read_inbound"):
+            self.assertIn("only when the GM asks", descs[name])
+
     async def test_streamable_app_is_asgi(self):
         server = serve_mcp.build_server(scaffold(self))
         self.assertTrue(callable(serve_mcp.build_app(server)))

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -113,7 +113,7 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         server = serve_mcp.build_server(scaffold(self))
         names = {t.name for t in await server.list_tools()}
         self.assertLessEqual(
-            {"save_draft", "propose_revision", "list_drafts", "read_draft"},
+            {"save_draft", "propose_revision", "update_draft", "list_drafts", "read_draft"},
             names)
 
     async def test_list_drafts_reports_what_was_drafted(self):

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -107,49 +107,44 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
             {"campaign_overview", "list_entities", "read_entity", "search",
              "generate_names"}, names)
 
-    async def test_staging_tools_always_registered(self):
+    async def test_draft_tools_always_registered(self):
+        # The drafts directory is the agent's own outbox: writing to it and
+        # reading it back need no flag; nothing here can reach canon.
         server = serve_mcp.build_server(scaffold(self))
         names = {t.name for t in await server.list_tools()}
-        self.assertLessEqual({"save_draft", "propose_revision"}, names)
+        self.assertLessEqual(
+            {"save_draft", "propose_revision", "list_drafts", "read_draft"},
+            names)
 
-    async def test_staging_read_tools_always_registered(self):
-        # Staging is the agent's own inbox, so reading it back needs no flag:
-        # nothing here can reach canon.
-        server = serve_mcp.build_server(scaffold(self))
-        names = {t.name for t in await server.list_tools()}
-        self.assertLessEqual({"list_staged", "read_staged"}, names)
-
-    async def test_list_staged_reports_what_was_staged(self):
+    async def test_list_drafts_reports_what_was_drafted(self):
         store = scaffold(self)
         server = serve_mcp.build_server(store)
-        await server.call_tool(
-            "save_draft", {"section": "NPCs", "name": "Cho", "content": "x"})
-        payload = await self._text(await server.call_tool("list_staged", {}))
-        self.assertIn("_ExtractInbound/NPCs/Cho.md", payload)
-        self.assertIn("draft", payload)
+        await server.call_tool("save_draft", {
+            "section": "NPCs", "name": "Cho", "content": "x"})
+        payload = await self._text(await server.call_tool("list_drafts", {}))
+        self.assertIn("_AgentDrafts/NPCs/cho.md", payload)
 
-    async def test_read_staged_round_trips_a_draft(self):
+    async def test_read_draft_round_trips(self):
         store = scaffold(self)
         server = serve_mcp.build_server(store)
-        await server.call_tool(
-            "save_draft", {"section": "NPCs", "name": "Cho",
-                           "content": "---\ntitle: Cho\n---\nthe smuggler\n"})
+        await server.call_tool("save_draft", {
+            "section": "NPCs", "name": "Cho", "content": "draft body"})
         payload = await self._text(await server.call_tool(
-            "read_staged", {"path": "_ExtractInbound/NPCs/Cho.md"}))
-        self.assertIn("the smuggler", payload)
+            "read_draft", {"path": "_AgentDrafts/NPCs/cho.md"}))
+        self.assertIn("draft body", payload)
 
-    async def test_read_staged_refuses_a_canonical_path(self):
-        # The two read doors stay separate: read_staged must not become a
+    async def test_read_draft_refuses_a_canonical_path(self):
+        # The two read doors stay separate: read_draft must not become a
         # second way into canon.
         server = serve_mcp.build_server(scaffold(self))
         with self.assertRaises(Exception) as ctx:
             await server.call_tool(
-                "read_staged", {"path": "NPCs/kim-ha-eun.md"})
+                "read_draft", {"path": "NPCs/kim-ha-eun.md"})
         self.assertIn("read_entity", str(ctx.exception))
 
     async def test_write_entity_only_with_the_flag(self):
-        # The gate is the whole safety story: staging is always available
-        # because it cannot reach canon, and canon is reachable only
+        # The gate is the whole safety story: drafts are always available
+        # because they cannot reach canon, and canon is reachable only
         # because someone passed a per-run flag.
         store = scaffold(self)
         off = {t.name for t in await serve_mcp.build_server(store).list_tools()}
@@ -158,13 +153,13 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("write_entity", off)
         self.assertIn("write_entity", on)
 
-    async def test_save_draft_lands_in_staging(self):
+    async def test_save_draft_lands_in_the_drafts_dir(self):
         store = scaffold(self)
-        await serve_mcp.build_server(store).call_tool(
-            "save_draft", {"section": "NPCs", "name": "Cho",
-                           "content": "---\ntitle: Cho\n---\n"})
+        server = serve_mcp.build_server(store)
+        await server.call_tool("save_draft", {
+            "section": "NPCs", "name": "Cho", "content": "x"})
         self.assertTrue(
-            (store.ws.root / "_ExtractInbound/NPCs/Cho.md").is_file())
+            (store.ws.root / "_AgentDrafts/NPCs/cho.md").is_file())
 
     async def test_every_tool_carries_a_description(self):
         # The description is how the remote agent decides to call a tool at

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -539,3 +539,120 @@ class TestUpdateDraft(StoreCase):
         with self.assertRaises(_store.StoreError):
             _store.WorkspaceStore(ws).update_draft(
                 "_AgentDrafts/_Rejected/dead.md", "resurrect")
+
+
+class TestInbound(StoreCase):
+    """The GM's inbound queue. Read-only, and only when the GM asks: the
+    tool descriptions carry that contract; the store's job is that _Done/
+    (and any _-prefixed area) is unreachable and every live file is
+    honestly listed."""
+
+    def seed_queue(self, ws) -> Path:
+        q = ws.root / "_ExtractInbound"
+        (q / "notes").mkdir(parents=True)
+        (q / "notes" / "idea.txt").write_text(
+            "a harbor heist", encoding="utf-8")
+        (q / "page.html").write_text("<p>hi</p>", encoding="utf-8")
+        (q / "README.md").write_text("readme", encoding="utf-8")
+        (q / "scan.pdf").write_bytes(b"%PDF-1.4 not text")
+        done = q / "_Done"
+        done.mkdir()
+        (done / "spent.txt").write_text("processed", encoding="utf-8")
+        return q
+
+    def test_lists_every_live_file_marking_readability(self):
+        # ALL extensions are listed — a listing that hides files is the
+        # defect this redesign fixes (17 of 18 files were invisible). A
+        # PDF appears, honestly marked unreadable.
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        self.assertEqual(_store.WorkspaceStore(ws).list_inbound(), [
+            {"path": "_ExtractInbound/README.md", "readable": True},
+            {"path": "_ExtractInbound/notes/idea.txt", "readable": True},
+            {"path": "_ExtractInbound/page.html", "readable": True},
+            {"path": "_ExtractInbound/scan.pdf", "readable": False},
+        ])
+
+    def test_done_is_never_listed(self):
+        # _Done/ holds processed source awaiting the GM's manual cleanup —
+        # never read, exactly like _Ignore/. Tested before _Done/ exists
+        # anywhere in the wild: this was the trap in the old rglob.
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        paths = [r["path"] for r in _store.WorkspaceStore(ws).list_inbound()]
+        self.assertFalse(any("_Done" in p for p in paths))
+
+    def test_hidden_dot_files_are_skipped(self):
+        # .DS_Store and friends are machinery, not GM material; listing
+        # them would inflate inbound_pending and clutter every offer.
+        ws = self.make_ws()
+        q = self.seed_queue(ws)
+        (q / ".DS_Store").write_bytes(b"\x00")
+        paths = [r["path"] for r in _store.WorkspaceStore(ws).list_inbound()]
+        self.assertFalse(any(".DS_Store" in p for p in paths))
+
+    def test_no_queue_is_an_empty_list_not_an_error(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.list_inbound(), [])
+
+    def test_read_round_trips_text(self):
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(
+            store.read_inbound("_ExtractInbound/notes/idea.txt"),
+            "a harbor heist")
+
+    def test_undecodable_bytes_are_replaced_not_a_crash(self):
+        # Inbound material is generated elsewhere; one stray latin-1 byte
+        # in a GM's .txt must not crash the tool.
+        ws = self.make_ws()
+        q = ws.root / "_ExtractInbound"
+        q.mkdir()
+        (q / "weird.txt").write_bytes(b"caf\xe9")
+        out = _store.WorkspaceStore(ws).read_inbound(
+            "_ExtractInbound/weird.txt")
+        self.assertEqual(out, "caf�")
+
+    def test_non_text_read_is_refused_with_the_convert_hint(self):
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        with self.assertRaises(_store.StoreError) as ctx:
+            _store.WorkspaceStore(ws).read_inbound(
+                "_ExtractInbound/scan.pdf")
+        self.assertIn("convert", str(ctx.exception))
+
+    def test_done_read_is_refused(self):
+        ws = self.make_ws()
+        self.seed_queue(ws)
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).read_inbound(
+                "_ExtractInbound/_Done/spent.txt")
+
+    def test_canonical_path_is_refused_naming_read_entity(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.read_inbound("NPCs/kim-ha-eun.md")
+        self.assertIn("read_entity", str(ctx.exception))
+
+    def test_escape_is_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.read_inbound("_ExtractInbound/../../outside.md")
+
+    def test_missing_file_is_refused_naming_the_listing(self):
+        ws = self.make_ws()
+        (ws.root / "_ExtractInbound").mkdir()
+        with self.assertRaises(_store.StoreError) as ctx:
+            _store.WorkspaceStore(ws).read_inbound(
+                "_ExtractInbound/nothing.txt")
+        self.assertIn("list_inbound", str(ctx.exception))
+
+    def test_honours_configured_inbound_dir(self):
+        ws = self.make_ws('\n[workspace]\ninbound_dir = "_Inbox"\n')
+        q = ws.root / "_Inbox"
+        q.mkdir()
+        (q / "idea.txt").write_text("x", encoding="utf-8")
+        rows = _store.WorkspaceStore(ws).list_inbound()
+        self.assertEqual(rows, [{"path": "_Inbox/idea.txt",
+                                 "readable": True}])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,9 +1,11 @@
 import hashlib
 import json
+import re
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from bunnyforge import _config, _store
 
@@ -315,6 +317,26 @@ class TestSaveDraft(StoreCase):
         rel = _store.WorkspaceStore(ws).save_draft("NPCs", "Cho", "x")
         self.assertEqual(rel, "_Outbox/NPCs/cho.md")
 
+    def test_slugged_refuses_an_empty_slug(self):
+        # _DRAFT_NAME_RE's required leading alphanumeric is the only thing
+        # that currently makes an empty slug impossible — nothing in _slug
+        # or _slugged itself states or guards that invariant. Relax the
+        # regex later (say, to admit non-ASCII names) and this would
+        # silently start writing files named plain ".md". _slugged must
+        # guard the invariant itself, not rely on the regex accidentally
+        # holding it up.
+        #
+        # No input can both pass today's _DRAFT_NAME_RE and slug to empty
+        # (the leading alnum char always survives _slug's substitutions),
+        # so this test relaxes the regex the way a future change might, to
+        # reach the guard through the real _slugged code path rather than
+        # reimplementing its logic.
+        store = _store.WorkspaceStore(self.make_ws())
+        with mock.patch.object(_store, "_DRAFT_NAME_RE", re.compile(r".*")):
+            with self.assertRaises(_store.StoreError) as ctx:
+                store._slugged("___", "draft")
+        self.assertIn("draft", str(ctx.exception))
+
 
 class TestProposeRevision(StoreCase):
     def test_shadow_mirrors_the_canonical_path_and_records_a_base(self):
@@ -355,6 +377,21 @@ class TestProposeRevision(StoreCase):
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError):
             store.propose_revision("../outside.md", "x")
+
+    def test_refuses_a_target_with_an_underscore_component(self):
+        # A canonical file like NPCs/_notes.md (or anything under a
+        # _-prefixed directory that isn't a configured exclude_dir) would
+        # otherwise mirror into the drafts machinery area — invisible to
+        # list_drafts/read_draft/update_draft/promote_draft forever, yet
+        # still occupying the "pending proposal already exists" slot for
+        # every future attempt. Must be refused up front instead.
+        ws = self.make_ws()
+        (ws.root / "NPCs" / "_notes.md").write_text("secret", encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.propose_revision("NPCs/_notes.md", "x")
+        self.assertIn("NPCs/_notes.md", str(ctx.exception))
+        self.assertFalse((ws.root / "_AgentDrafts").exists())
 
 
 class TestDraftReads(StoreCase):
@@ -766,3 +803,18 @@ class TestPromoteDraft(StoreCase):
         with self.assertRaises(_store.StoreError) as ctx:
             store.promote_draft("_AgentDrafts/Ideas/nothing.md")
         self.assertIn("list_drafts", str(ctx.exception))
+
+    def test_promoting_a_new_draft_never_creates_a_manifest(self):
+        # In a workspace where no revision was ever proposed, _load_bases()
+        # returns {}, the pop is a no-op, and an unconditional _save_bases
+        # would still *create* .proposal-bases.json containing "{}" — a
+        # file that never existed before, committed into a promotion whose
+        # own comment says it adds "exactly what promotion touched".
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("Ideas", "Harbor Heist",
+                               "---\ntitle: Harbor Heist\n---\nplot\n")
+        store.promote_draft(rel)
+        self.assertFalse(
+            (ws.root / "_AgentDrafts" / ".proposal-bases.json").exists())
+        self.assertEqual(self._git(ws, "status", "--porcelain").strip(), "")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -256,7 +256,7 @@ class TestStageDraft(StoreCase):
                 store.stage_draft("NPCs", bad, "x")
 
     def test_honors_configured_staging_dir(self):
-        ws = self.make_ws('\n[workspace]\nstaging_dir = "_Inbox"\n')
+        ws = self.make_ws('\n[workspace]\ninbound_dir = "_Inbox"\n')
         rel = _store.WorkspaceStore(ws).stage_draft("NPCs", "Cho", "x")
         self.assertEqual(rel, "_Inbox/NPCs/Cho.md")
 
@@ -321,7 +321,7 @@ class TestStagingReads(StoreCase):
                          ["_ExtractInbound/NPCs/Cho.md"])
 
     def test_listing_honors_a_configured_staging_dir(self):
-        ws = self.make_ws('\n[workspace]\nstaging_dir = "_Inbox"\n')
+        ws = self.make_ws('\n[workspace]\ninbound_dir = "_Inbox"\n')
         store = _store.WorkspaceStore(ws)
         store.stage_draft("NPCs", "Cho", "x")
         self.assertEqual([e["path"] for e in store.list_staging()],

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -675,3 +675,94 @@ class TestInbound(StoreCase):
         rows = _store.WorkspaceStore(ws).list_inbound()
         self.assertEqual(rows, [{"path": "_Inbox/idea.txt",
                                  "readable": True}])
+
+
+class TestPromoteDraft(StoreCase):
+    """The GM's in-chat approval is the gate; the flag gates the
+    capability per-run. The destination is derived — slugs made the
+    drafts tree mirror canon — so there is no dest parameter to get
+    wrong."""
+
+    def make_git_ws(self):
+        ws = self.make_ws()
+        for cmd in (["init", "-q"], ["config", "user.email", "t@t"],
+                    ["config", "user.name", "t"], ["add", "-A"],
+                    ["commit", "-qm", "seed"]):
+            subprocess.run(["git", "-C", str(ws.root)] + cmd, check=True)
+        return ws
+
+    def _git(self, ws, *args) -> str:
+        return subprocess.run(["git", "-C", str(ws.root), *args],
+                              capture_output=True, text=True,
+                              check=True).stdout
+
+    def test_promotes_a_new_draft_and_commits(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("Ideas", "Harbor Heist",
+                               "---\ntitle: Harbor Heist\n---\nplot\n")
+        out = store.promote_draft(rel)
+        self.assertEqual(out, "Ideas/harbor-heist.md")
+        self.assertIn("plot", (ws.root / out).read_text(encoding="utf-8"))
+        self.assertFalse((ws.root / rel).exists())
+        self.assertIn("serve-mcp: promote Ideas/harbor-heist.md",
+                      self._git(ws, "log", "-1", "--format=%s"))
+        self.assertEqual(self._git(ws, "status", "--porcelain").strip(), "")
+
+    def test_promotes_a_fresh_revision_and_clears_its_base(self):
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.propose_revision("NPCs/kim-ha-eun.md", "improved text")
+        out = store.promote_draft(rel)
+        self.assertEqual(out, "NPCs/kim-ha-eun.md")
+        self.assertEqual((ws.root / out).read_text(encoding="utf-8"),
+                         "improved text")
+        self.assertFalse((ws.root / rel).exists())
+        bases = json.loads(
+            (ws.root / "_AgentDrafts" / ".proposal-bases.json")
+            .read_text(encoding="utf-8"))
+        self.assertEqual(bases, {})
+        self.assertEqual(self._git(ws, "status", "--porcelain").strip(), "")
+
+    def test_stale_revision_is_refused_not_applied(self):
+        # Promoting a stale shadow would revert the GM's interim edits,
+        # disguised inside an intended diff.
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.propose_revision("NPCs/kim-ha-eun.md", "proposal")
+        (ws.root / "NPCs/kim-ha-eun.md").write_text("GM edit",
+                                                    encoding="utf-8")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.promote_draft(rel)
+        self.assertIn("update_draft", str(ctx.exception))
+        self.assertEqual(
+            (ws.root / "NPCs/kim-ha-eun.md").read_text(encoding="utf-8"),
+            "GM edit")  # canon untouched
+
+    def test_unrecorded_base_is_refused(self):
+        # Covers a hand-authored shadow AND a draft whose canonical
+        # counterpart appeared after it was saved: target exists, no base
+        # on record, so promotion cannot verify and refuses.
+        ws = self.make_git_ws()
+        store = _store.WorkspaceStore(ws)
+        shadow = ws.root / "_AgentDrafts" / "NPCs"
+        shadow.mkdir(parents=True)
+        (shadow / "kim-ha-eun.md").write_text("hand-made", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            store.promote_draft("_AgentDrafts/NPCs/kim-ha-eun.md")
+
+    def test_refuses_outside_a_git_repo_before_touching_anything(self):
+        ws = self.make_ws()  # no git init
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("Ideas", "Heist", "plot")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.promote_draft(rel)
+        self.assertIn("git", str(ctx.exception))
+        self.assertTrue((ws.root / rel).is_file())   # draft still there
+        self.assertFalse((ws.root / "Ideas/heist.md").exists())
+
+    def test_missing_draft_is_refused(self):
+        store = _store.WorkspaceStore(self.make_git_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.promote_draft("_AgentDrafts/Ideas/nothing.md")
+        self.assertIn("list_drafts", str(ctx.exception))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -68,6 +68,25 @@ class TestOverview(StoreCase):
         store = _store.WorkspaceStore(self.make_ws())
         self.assertNotIn("Factions", store.overview()["sections"])
 
+    def test_counts_pending_inbound_and_drafts(self):
+        # Defined as exactly len(list_inbound()) / len(list_drafts()), so
+        # a count and the listing it advertises cannot disagree. 0 when
+        # the directory is absent: a count is always present, and
+        # "nothing pending" is the true answer either way.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(store.overview()["inbound_pending"], 0)
+        self.assertEqual(store.overview()["drafts_pending"], 0)
+        store.save_draft("NPCs", "Cho", "x")
+        q = ws.root / "_ExtractInbound"
+        (q / "_Done").mkdir(parents=True)
+        (q / "idea.txt").write_text("x", encoding="utf-8")
+        (q / "scan.pdf").write_bytes(b"%PDF")
+        (q / "_Done" / "spent.txt").write_text("x", encoding="utf-8")
+        ov = store.overview()
+        self.assertEqual(ov["inbound_pending"], 2)  # pdf counted, _Done not
+        self.assertEqual(ov["drafts_pending"], 1)
+
 
 class TestListEntities(StoreCase):
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -495,3 +495,47 @@ class TestWriteEntity(StoreCase):
             store.write_entity("NPCs/nobody.md", "x")
         with self.assertRaises(_store.StoreError):
             store.write_entity("../outside.md", "x")
+
+
+class TestUpdateDraft(StoreCase):
+    def test_overwrites_an_existing_draft(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.save_draft("NPCs", "Cho", "old")
+        self.assertEqual(store.update_draft(rel, "new"), rel)
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"), "new")
+
+    def test_missing_draft_is_refused_naming_save_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.update_draft("_AgentDrafts/NPCs/nobody.md", "x")
+        self.assertIn("save_draft", str(ctx.exception))
+
+    def test_canonical_and_escape_paths_are_refused(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError):
+            store.update_draft("NPCs/kim-ha-eun.md", "x")
+        with self.assertRaises(_store.StoreError):
+            store.update_draft("../outside.md", "x")
+
+    def test_rebaselines_a_revision_shadow(self):
+        # The refusal flow that leads here forced a read-and-merge, so the
+        # agent has seen current canon: updating a shadow re-records its
+        # base, and the revision stops being stale.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "first")
+        (ws.root / "NPCs/kim-ha-eun.md").write_text("GM edit",
+                                                    encoding="utf-8")
+        self.assertIs(store.list_drafts()[0]["stale"], True)
+        store.update_draft("_AgentDrafts/NPCs/kim-ha-eun.md", "merged")
+        self.assertIs(store.list_drafts()[0]["stale"], False)
+
+    def test_underscore_component_is_refused(self):
+        ws = self.make_ws()
+        rejected = ws.root / "_AgentDrafts" / "_Rejected"
+        rejected.mkdir(parents=True)
+        (rejected / "dead.md").write_text("x", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).update_draft(
+                "_AgentDrafts/_Rejected/dead.md", "resurrect")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import subprocess
 import tempfile
 import unittest
@@ -113,13 +115,13 @@ class TestReadEntity(StoreCase):
             store.read_entity("/etc/hosts")
 
     def test_excluded_dir_is_refused(self):
-        # The staging directory is excluded by default, so drafts written
-        # there are not readable back through read_entity: it serves canon.
-        # Staging is reached through read_staged instead (TestStagingReads).
+        # The inbound directory is excluded by default, so material dropped
+        # there is not readable back through read_entity: it serves canon.
+        # (The drafts directory has the same boundary; see TestDraftReads.)
         ws = self.make_ws()
-        staged = ws.root / "_ExtractInbound"
-        staged.mkdir()
-        (staged / "secret.md").write_text("staged", encoding="utf-8")
+        dropped = ws.root / "_ExtractInbound"
+        dropped.mkdir()
+        (dropped / "secret.md").write_text("dropped", encoding="utf-8")
         store = _store.WorkspaceStore(ws)
         with self.assertRaises(_store.StoreError):
             store.read_entity("_ExtractInbound/secret.md")
@@ -232,138 +234,223 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class TestStageDraft(StoreCase):
-    def test_writes_into_staging_and_creates_dirs(self):
+class TestSaveDraft(StoreCase):
+    def test_writes_into_drafts_and_slugs_the_name(self):
         ws = self.make_ws()
         store = _store.WorkspaceStore(ws)
-        rel = store.stage_draft("NPCs", "Old Man Cho", "---\ntitle: Cho\n---\n")
-        self.assertEqual(rel, "_ExtractInbound/NPCs/Old Man Cho.md")
+        rel = store.save_draft("NPCs", "Old Man Cho", "---\ntitle: Cho\n---\n")
+        self.assertEqual(rel, "_AgentDrafts/NPCs/old-man-cho.md")
         self.assertTrue((ws.root / rel).is_file())
 
-    def test_refuses_overwrite(self):
+    def test_slug_drops_apostrophes_and_collapses_separators(self):
         store = _store.WorkspaceStore(self.make_ws())
-        store.stage_draft("NPCs", "Cho", "x")
+        rel = store.save_draft("NPCs", "Mara's  Old_Friend", "x")
+        self.assertEqual(rel, "_AgentDrafts/NPCs/maras-old-friend.md")
+
+    def test_subdir_nests_one_level_and_is_slugged(self):
+        # Briefs live at Briefs/session-NNN/<name>.md; a draft brief must be
+        # able to take its canonical shape, or every promotion re-nests by
+        # hand.
+        ws = self.make_ws()
+        rel = _store.WorkspaceStore(ws).save_draft(
+            "Briefs", "Kim Ha-eun", "x", subdir="Session 15")
+        self.assertEqual(rel, "_AgentDrafts/Briefs/session-15/kim-ha-eun.md")
+
+    def test_existing_draft_refusal_names_update_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.save_draft("NPCs", "Cho", "x")
         with self.assertRaises(_store.StoreError) as ctx:
-            store.stage_draft("NPCs", "Cho", "y")
-        self.assertIn("another name", str(ctx.exception))
+            store.save_draft("NPCs", "Cho", "y")
+        self.assertIn("update_draft", str(ctx.exception))
+
+    def test_canonical_collision_refusal_names_propose_revision(self):
+        # A new draft shadowing an existing canonical file would be
+        # misreported as a revision and reviewed as a diff against the
+        # wrong entity.
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.save_draft("NPCs", "Kim Ha-eun", "x")  # slug: kim-ha-eun
+        self.assertIn("propose_revision", str(ctx.exception))
 
     def test_refuses_unknown_section_and_bad_names(self):
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError):
-            store.stage_draft("Nope", "Cho", "x")
+            store.save_draft("Nope", "Cho", "x")
         for bad in ("../escape", "a/b", ".hidden", "_underscore"):
             with self.assertRaises(_store.StoreError):
-                store.stage_draft("NPCs", bad, "x")
+                store.save_draft("NPCs", bad, "x")
+            with self.assertRaises(_store.StoreError):
+                store.save_draft("NPCs", "Cho", "x", subdir=bad)
 
-    def test_honors_configured_staging_dir(self):
-        ws = self.make_ws('\n[workspace]\ninbound_dir = "_Inbox"\n')
-        rel = _store.WorkspaceStore(ws).stage_draft("NPCs", "Cho", "x")
-        self.assertEqual(rel, "_Inbox/NPCs/Cho.md")
-
-
-class TestStageRevision(StoreCase):
-    def test_shadow_mirrors_the_canonical_path(self):
-        ws = self.make_ws()
-        store = _store.WorkspaceStore(ws)
-        rel = store.stage_revision("NPCs/kim-ha-eun.md", "new text")
-        self.assertEqual(rel, "_ExtractInbound/NPCs/kim-ha-eun.md")
-        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
-                         "new text")
-
-    def test_latest_proposal_wins(self):
-        ws = self.make_ws()
-        store = _store.WorkspaceStore(ws)
-        store.stage_revision("NPCs/kim-ha-eun.md", "first")
-        rel = store.stage_revision("NPCs/kim-ha-eun.md", "second")
-        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
-                         "second")
-
-    def test_requires_an_existing_target(self):
+    def test_perceptions_are_not_draftable(self):
+        # The perception record is by contract never agent-authored.
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError) as ctx:
-            store.stage_revision("NPCs/nobody.md", "x")
-        self.assertIn("stage_draft", str(ctx.exception))  # points at the fix
+            store.save_draft("Perceptions", "Cho", "x")
+        listed = str(ctx.exception).split("one of:")[1]
+        self.assertNotIn("Perceptions", listed)
+        self.assertIn("Briefs", listed)
+
+    def test_honours_configured_drafts_dir(self):
+        ws = self.make_ws('\n[workspace]\ndrafts_dir = "_Outbox"\n')
+        rel = _store.WorkspaceStore(ws).save_draft("NPCs", "Cho", "x")
+        self.assertEqual(rel, "_Outbox/NPCs/cho.md")
+
+
+class TestProposeRevision(StoreCase):
+    def test_shadow_mirrors_the_canonical_path_and_records_a_base(self):
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        rel = store.propose_revision("NPCs/kim-ha-eun.md", "new text")
+        self.assertEqual(rel, "_AgentDrafts/NPCs/kim-ha-eun.md")
+        self.assertEqual((ws.root / rel).read_text(encoding="utf-8"),
+                         "new text")
+        bases = json.loads(
+            (ws.root / "_AgentDrafts" / ".proposal-bases.json")
+            .read_text(encoding="utf-8"))
+        canon_hash = hashlib.sha256(
+            (ws.root / "NPCs/kim-ha-eun.md").read_bytes()).hexdigest()
+        self.assertEqual(bases[rel], canon_hash)
+
+    def test_second_proposal_is_refused_and_the_first_survives(self):
+        # The old latest-wins rule silently destroyed pending proposals —
+        # routine, not rare: the end-of-session ritual proposes front-burner
+        # updates every session.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "first")
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.propose_revision("NPCs/kim-ha-eun.md", "second")
+        self.assertIn("update_draft", str(ctx.exception))
+        self.assertEqual(
+            (ws.root / "_AgentDrafts/NPCs/kim-ha-eun.md")
+            .read_text(encoding="utf-8"), "first")
+
+    def test_requires_an_existing_target_naming_save_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.propose_revision("NPCs/nobody.md", "x")
+        self.assertIn("save_draft", str(ctx.exception))
 
     def test_refuses_escapes(self):
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError):
-            store.stage_revision("../outside.md", "x")
+            store.propose_revision("../outside.md", "x")
 
 
-class TestStagingReads(StoreCase):
-    """The agent's own inbox. Staging stays invisible to the canon read
-    tools; these two methods are the one labelled way back in, so that a
-    draft written last session can be revisited rather than re-invented.
-    """
+class TestDraftReads(StoreCase):
+    """The agents' own outbox: freely readable, so a draft written last
+    session is revisited rather than re-invented."""
 
-    def test_listing_distinguishes_a_draft_from_a_revision(self):
-        store = _store.WorkspaceStore(self.make_ws())
-        store.stage_draft("NPCs", "Cho", "x")
-        store.stage_revision("NPCs/kim-ha-eun.md", "y")
-        found = {e["path"]: e["kind"] for e in store.list_staging()}
-        self.assertEqual(found, {
-            "_ExtractInbound/NPCs/Cho.md": "draft",
-            "_ExtractInbound/NPCs/kim-ha-eun.md": "revision",
-        })
-
-    def test_nothing_staged_is_an_empty_list_not_an_error(self):
-        # The staging directory does not exist until something is staged.
-        store = _store.WorkspaceStore(self.make_ws())
-        self.assertEqual(store.list_staging(), [])
-
-    def test_listing_ignores_non_markdown(self):
+    def test_listing_reports_kind_title_and_summary(self):
         ws = self.make_ws()
         store = _store.WorkspaceStore(ws)
-        store.stage_draft("NPCs", "Cho", "x")
-        (ws.root / "_ExtractInbound" / "notes.txt").write_text(
-            "scratch", encoding="utf-8")
-        self.assertEqual([e["path"] for e in store.list_staging()],
-                         ["_ExtractInbound/NPCs/Cho.md"])
+        store.save_draft("NPCs", "Cho",
+                         "---\ntitle: Old Man Cho\n"
+                         "summary: A dockside fixer.\n---\nbody\n")
+        store.propose_revision("NPCs/kim-ha-eun.md", "y")
+        rows = {r["path"]: r for r in store.list_drafts()}
+        cho = rows["_AgentDrafts/NPCs/cho.md"]
+        self.assertEqual(cho["kind"], "new")
+        self.assertEqual(cho["title"], "Old Man Cho")
+        self.assertEqual(cho["summary"], "A dockside fixer.")
+        self.assertNotIn("stale", cho)          # stale is revision-only
+        rev = rows["_AgentDrafts/NPCs/kim-ha-eun.md"]
+        self.assertEqual(rev["kind"], "revision")
+        self.assertIs(rev["stale"], False)
 
-    def test_listing_honors_a_configured_staging_dir(self):
-        ws = self.make_ws('\n[workspace]\ninbound_dir = "_Inbox"\n')
+    def test_title_falls_back_to_the_stem(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        store.save_draft("NPCs", "Cho", "no front matter\n")
+        [row] = store.list_drafts()
+        self.assertEqual(row["title"], "cho")
+        self.assertEqual(row["summary"], "")
+
+    def test_revision_goes_stale_when_canon_moves(self):
+        # A pending shadow must not silently revert the GM's interim edits;
+        # stale is how the listing warns, and promote_draft later refuses.
+        ws = self.make_ws()
         store = _store.WorkspaceStore(ws)
-        store.stage_draft("NPCs", "Cho", "x")
-        self.assertEqual([e["path"] for e in store.list_staging()],
-                         ["_Inbox/NPCs/Cho.md"])
+        store.propose_revision("NPCs/kim-ha-eun.md", "proposal")
+        (ws.root / "NPCs/kim-ha-eun.md").write_text("GM edit",
+                                                    encoding="utf-8")
+        [row] = store.list_drafts()
+        self.assertIs(row["stale"], True)
 
-    def test_read_round_trips_a_staged_file(self):
+    def test_unrecorded_base_reports_stale_none(self):
+        ws = self.make_ws()
+        shadow = ws.root / "_AgentDrafts" / "NPCs"
+        shadow.mkdir(parents=True)
+        (shadow / "kim-ha-eun.md").write_text("hand-made", encoding="utf-8")
+        [row] = _store.WorkspaceStore(ws).list_drafts()
+        self.assertIsNone(row["stale"])
+
+    def test_corrupt_manifest_reads_as_empty_not_an_error(self):
+        # The manifest is a provenance cache, not a lock file.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.propose_revision("NPCs/kim-ha-eun.md", "proposal")
+        (ws.root / "_AgentDrafts" / ".proposal-bases.json").write_text(
+            "not json", encoding="utf-8")
+        [row] = store.list_drafts()
+        self.assertIsNone(row["stale"])
+
+    def test_listing_skips_underscore_components(self):
+        # _AgentDrafts/_Rejected/ is the GM's rejection signal — never
+        # listed, so rejected material cannot be resurrected by resume.
+        ws = self.make_ws()
+        store = _store.WorkspaceStore(ws)
+        store.save_draft("NPCs", "Cho", "x")
+        rejected = ws.root / "_AgentDrafts" / "_Rejected"
+        rejected.mkdir(parents=True)
+        (rejected / "dead.md").write_text("x", encoding="utf-8")
+        self.assertEqual([r["path"] for r in store.list_drafts()],
+                         ["_AgentDrafts/NPCs/cho.md"])
+
+    def test_nothing_drafted_is_an_empty_list_not_an_error(self):
         store = _store.WorkspaceStore(self.make_ws())
-        rel = store.stage_draft("NPCs", "Cho", "---\ntitle: Cho\n---\nbody\n")
-        self.assertEqual(store.read_staged(rel),
-                         "---\ntitle: Cho\n---\nbody\n")
+        self.assertEqual(store.list_drafts(), [])
 
-    def test_escape_is_refused(self):
+    def test_read_round_trips_a_draft(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        rel = store.save_draft("NPCs", "Cho", "---\ntitle: Cho\n---\nbody\n")
+        self.assertEqual(store.read_draft(rel), "---\ntitle: Cho\n---\nbody\n")
+
+    def test_escape_and_absolute_paths_are_refused(self):
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError):
-            store.read_staged("_ExtractInbound/../../outside.md")
-
-    def test_absolute_path_outside_the_workspace_is_refused(self):
-        store = _store.WorkspaceStore(self.make_ws())
+            store.read_draft("_AgentDrafts/../../outside.md")
         with self.assertRaises(_store.StoreError):
-            store.read_staged("/etc/hosts")
+            store.read_draft("/etc/hosts")
 
     def test_a_canonical_path_is_refused_and_points_at_read_entity(self):
-        # The inverse guard: read_staged serves staging and nothing else, so
-        # canon reaches the agent through one method only.
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError) as ctx:
-            store.read_staged("NPCs/kim-ha-eun.md")
+            store.read_draft("NPCs/kim-ha-eun.md")
         self.assertIn("read_entity", str(ctx.exception))
 
-    def test_missing_file_is_refused_pointing_at_the_listing(self):
+    def test_an_underscore_component_is_refused(self):
+        ws = self.make_ws()
+        rejected = ws.root / "_AgentDrafts" / "_Rejected"
+        rejected.mkdir(parents=True)
+        (rejected / "dead.md").write_text("x", encoding="utf-8")
+        with self.assertRaises(_store.StoreError):
+            _store.WorkspaceStore(ws).read_draft(
+                "_AgentDrafts/_Rejected/dead.md")
+
+    def test_missing_draft_is_refused_pointing_at_the_listing(self):
         store = _store.WorkspaceStore(self.make_ws())
         with self.assertRaises(_store.StoreError) as ctx:
-            store.read_staged("_ExtractInbound/NPCs/nobody.md")
-        self.assertIn("list_staged", str(ctx.exception))
+            store.read_draft("_AgentDrafts/NPCs/nobody.md")
+        self.assertIn("list_drafts", str(ctx.exception))
 
-    def test_a_non_markdown_staged_file_is_refused(self):
-        ws = self.make_ws()
-        (ws.root / "_ExtractInbound").mkdir()
-        (ws.root / "_ExtractInbound" / "notes.txt").write_text(
-            "scratch", encoding="utf-8")
+    def test_canon_tools_refuse_draft_paths(self):
+        # The inverse boundary: _AgentDrafts is auto-excluded, so the
+        # canon read door must refuse it exactly as it refuses _Ignore/.
+        store = _store.WorkspaceStore(self.make_ws())
+        rel = store.save_draft("NPCs", "Cho", "x")
         with self.assertRaises(_store.StoreError):
-            _store.WorkspaceStore(ws).read_staged("_ExtractInbound/notes.txt")
+            store.read_entity(rel)
 
 
 class TestWriteEntity(StoreCase):


### PR DESCRIPTION
Splits `serve-mcp`'s conflated staging directory into two, with two vocabularies and two sets of guards: `_AgentDrafts/` (agent output, with a full draft lifecycle) and `_ExtractInbound/` (the GM's inbound queue, read-only, only when asked).

Implements `docs/superpowers/specs/2026-08-17-inbound-drafts-split-design.md` via `docs/superpowers/plans/2026-08-17-inbound-drafts-split.md` (both added here as the first two commits). **Please don't merge without reviewing — see "Decisions taken on your behalf" below.**

## The problem this fixes

`_ExtractInbound/` was doing two jobs under one name, which produced live defects: the `rglob("*.md")` filter hid 17 of 18 inbound files; the one it surfaced was mislabelled `"revision"` because a root `README.md` happened to exist; and the tool descriptions ("use it to pick up drafts from an earlier session") told the agent to do the opposite of what the workspace AGENTS.md contract says about the queue.

## Files changed

| file | | what |
|---|---|---|
| `docs/superpowers/specs/2026-08-17-inbound-drafts-split-design.md` | (new) | the design this implements |
| `docs/superpowers/plans/2026-08-17-inbound-drafts-split.md` | (new) | the seven-task implementation plan |
| `src/bunnyforge/_config.py` | (modified) | `staging_dir` → `inbound_dir`; adds `drafts_dir`; auto-exclusion and collision validation |
| `src/bunnyforge/_store.py` | (modified) | both families, their resolvers, the base manifest, and promotion |
| `src/bunnyforge/serve_mcp.py` | (modified) | tool registrations and descriptions |
| `src/bunnyforge/data/campaign.toml.in` | (modified) | documents both keys; drops `_ExtractInbound` from the `exclude_dirs` example |
| `src/bunnyforge/data/doctrine/AGENTS.md` | (modified) | scaffolded doctrine: `_AgentDrafts/` taxonomy entry, per-surface `_Done/` phrasing |
| `docs/serve-mcp.md` | (modified) | restructured around canon / drafts / inbound queue |
| `tests/test_store.py` | (modified) | the bulk of the new coverage |
| `tests/test_config.py` | (modified) | defaults, auto-exclusion, rename refusal, collision validation |
| `tests/test_serve_mcp.py` | (modified) | tool registration and description contracts |
| `tests/test_init.py` | (modified) | one assertion widened for auto-exclusion |

## Work breakdown

**Config (`a078bce`, `416bd48`).** `staging_dir` becomes `inbound_dir`; `drafts_dir` is new. Both are unioned into `exclude_dirs` at load time, so no configuration can un-exclude either — the hole is closed structurally rather than by documentation. A leftover `staging_dir` key raises a `ConfigError` naming the rename, because `load()` ignores unknown keys and would otherwise drop it silently. Collisions (either key naming a content section, or the two naming each other) are refused.

**Drafts family (`d07b500`, `a0a28ff`).** `save_draft` / `propose_revision` / `update_draft` / `list_drafts` / `read_draft`. Names are slugified so the drafts tree mirrors canon, which is what lets promotion derive its destination with no `dest` parameter to get wrong. `update_draft` is the single overwrite door — `save_draft` and `propose_revision` both refuse rather than clobber, so the old latest-wins rule can no longer destroy a pending proposal. Revision provenance lives in one manifest (`_AgentDrafts/.proposal-bases.json`) recording the SHA-256 of canon at proposal time; it is a cache, not a lock file, so a missing or corrupt manifest reads as empty and reports `stale: null` rather than erroring.

**Inbound family (`8d5a1ea`).** `list_inbound` lists *every* file whatever its extension, marking each `readable` or not — a listing that hides files is precisely the defect being fixed. `read_inbound` serves the text formats and refuses the rest with a convert-it hint, decoding with `errors="replace"` because this material was authored outside the workspace. Both descriptions carry the contract phrase "only when the GM asks", pinned by a regression test.

**Overview counts (`c64d883`).** `drafts_pending` and `inbound_pending`, defined as exactly the lengths of their listings so a count and the listing it advertises cannot disagree. These exist to enable the permission boundary: the agent may notice the queue is non-empty and offer, without reading it unbidden.

**Promotion (`ebe8bdc`, `e0b7488`).** `promote_draft`, registered only under `--allow-direct-edits`. Destination is derived; every refusal fires before any filesystem mutation; a stale or unverifiable revision base is refused rather than silently applied over your interim edits.

**Docs (`6590bb5`, `7569d31`).** `docs/serve-mcp.md` restructured around the three vocabularies; the scaffolded doctrine gains `_AgentDrafts/` and rephrases the `_Done/` move per-surface, since the absolute phrasing ordered the MCP agent to move files it cannot move.

**Review fixes (`4e046bc`, `72a2b66`).** See below.

## Release note

> Agent-written drafts still in `_ExtractInbound/` from the old scheme should be moved to `_AgentDrafts/` or deleted. A `staging_dir` key in `campaign.toml` must be renamed to `inbound_dir`.

## Operational impact

No migration script, and none needed: workspaces created by `init` have the whole `[workspace]` block commented out, so the new defaults apply on upgrade with no edits. `save_draft` creates `_AgentDrafts/` on first use, so `init` needed no new scaffolding.

The one breaking change is deliberate and loud: a `staging_dir` key in an existing `campaign.toml` now raises a `ConfigError` naming the rename rather than being silently ignored. The scaffold never shipped that key, so this should affect approximately nobody.

**Manual step for you:** the live workspace's own `AGENTS.md` needs the two edits below applied by hand. Nothing in this repo depends on them.

Under the directory rules (alongside `_Ignore/`, `_Archive/`, `_ExtractInbound/`):

> - `_AgentDrafts/` is the agents' outbox: drafts and proposed revisions
>   awaiting my review, written there by the MCP tools (or by you, if I
>   ask you to draft something). Read it freely; nothing in it is canon.
>   If I reject a draft I delete it or move it to `_AgentDrafts/_Rejected/`,
>   which is never read, like `_Ignore/`.

In the "Extracting from _ExtractInbound/" section, after the existing bullets:

> - The MCP agent reaches this queue through `list_inbound` and
>   `read_inbound`, under exactly these rules.

And rephrase the move step:

> - Once I confirm an extraction, move the spent source into
>   `_ExtractInbound/_Done/` — or, if you cannot move files, say so and
>   I will.

## Verification

- `PYTHONPATH=src python3 -m unittest discover -s tests` → **873 tests, OK (skipped=53)**. Baseline before this work was 833, OK, 52 skipped.
- The `mcp` extra is not installed locally, so 53 SDK-gated tests normally skip here and only run in CI. I installed `mcp 2.0.0` into a throwaway virtualenv and ran the full suite against the real SDK: **873 tests, OK, zero skips**. Every test on this branch has actually executed and passed.

That SDK run earned its keep. It caught `test_inbound_descriptions_carry_the_contract` failing against the real SDK: the MCP SDK builds tool descriptions from docstrings and preserves their line breaks, so the pinned phrase appeared as `only when\nthe GM asks` and never matched. The plan authored both the docstrings and the test, and they could not both hold as written. `4e046bc` fixes it by normalizing whitespace in the test rather than reflowing the shipped docstrings — the phrase is still required in full, but the guard now survives any future re-wrap of the prose. **Without that run this branch would have gone red in CI.**

## Decisions taken on your behalf

Each of these is a judgement call I made rather than stopping; please overrule anything you disagree with.

1. **Task 1's file list was incomplete.** `tests/test_init.py` asserts every defaultable key equals its default, which breaks once the two new directories are auto-excluded. I allowed the out-of-plan edit, since "full suite green after every task" outranks a file list that was descriptive rather than exhaustive.
2. **The plan's test fixture named the campaign.** It used a subdirectory named `anjeonggm`, which trips this repo's own `tests/test_portability.py` guard banning that token from shipped test files. Renamed to `notes`; the sort ordering the assertion depends on is preserved.
3. **A test comment still says `list_staged`.** The vocabulary ban is scoped to tool names, config keys, store methods, docstrings, error messages, and `docs/serve-mcp.md`. A comment naming the removed historical tool is none of those, and it is what makes the regression test legible. The final reviewer independently agreed.
4. **The vocabulary sweep cannot return zero output.** Two hits survive in `_config.py`: the guard that detects the old `staging_dir` key and its error text. Spec §2 mandates that guard with that literal text — an error cannot tell you which key to rename without naming it. The plan's expectation is what was wrong, not the code. (The plan's grep was also case-sensitive, so it could not verify a case-insensitive ban; I ran both forms.)
5. **The contract-phrase fix went in the test, not the docstrings.** Reflowing the prose would work but re-arms the same trap for whoever edits it next, and lets a test dictate formatting. The shipped descriptions are unchanged.

## Known nits, deliberately not fixed

The final whole-branch review triaged fifteen deferred minor findings: four were fixed in `72a2b66` (a `propose_revision` lockout, the empty-slug guard, a phantom manifest commit, and the missing `drafts_pending` doc line); the rest are follow-up material that does not touch the design. Two nits were introduced by that fix wave and left standing, since the process allows no second fix wave:

- The new refusal message says "under a `_`-prefixed directory", but the guard tests every path component, so it also catches a `_`-prefixed *filename* — which is the shape it was actually written for. The next move it names is still correct.
- `had_entry` in `promote_draft` is logically redundant with the `is_file()` check beside it.

## One observation, now filed as #62

`_common.iter_content_files` filters on `exclude_dirs` membership and has no `_`-prefix rule, so a canonical file containing a `_`-prefixed component **were one to exist** would stay readable as canon while this branch makes it un-revisable.

To be explicit, since an earlier draft of this section read as though it were reporting a real file: **no such file exists.** `NPCs/_notes.md` appears in `_store.py`'s comment and in one test fixture purely as a hypothetical naming the *shape* of path involved — there are no `_`-prefixed `.md` files and no `_`-prefixed directories anywhere in the repo, the scaffold, or `samples/`. The documented `_` directories are already refused earlier by `_canonical`'s `exclude_dirs` check, so the new guard only ever fires on path shapes the convention does not sanction.

The asymmetry predates this branch, and the guard is cheap and fails closed, so it stays. But it prompted a larger question now tracked in **#62**: a leading `_` has no single meaning today. It spans *never read* (`_Ignore/`), *read freely* (`_Archive/`), and *read only when asked* (`_ExtractInbound/`) — and it is enforced two different ways, by enumeration for canon walkers and by a general prefix rule for the two new families here. #62 proposes picking one and applying it uniformly; if that lands on "the enumeration is the rule", this guard is the first thing that should go.

## Test expectations

None — no failures are expected. Both suites are fully green.

## Provenance

- **Agent:** Claude Code (CLI), executing the plan with `superpowers:subagent-driven-development` — a fresh implementer subagent per task, a spec-and-quality review after each, and a whole-branch review at the end.
- **Model / version:** the session was set to **Opus 5** via `/model`; I cannot observe which model I actually ran as. Subagents were dispatched explicitly: implementers on Sonnet 5 and Haiku 4.5, task reviewers on Haiku 4.5, Sonnet 5 and Opus 5, and the final whole-branch review on Fable 5. Each commit's `Co-Authored-By:` trailer names the model dispatched for that task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

