### PR TITLE
Split AGENTS.md: package-owned doctrine, plus a GM-owned campaign-doctrine.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ offline path via `deploy-export --render-only`.
 
 - **Python ≥ 3.11, zero runtime dependencies.**
 - **Agent-first doctrine.** `init` writes an `AGENTS.md` contract that
-  tells an AI agent how to behave in the workspace, and doctrine
-  *skeletons* — a style guide and a situation-design guide that interview
-  you: each section explains what belongs in it, so filling them in is
-  answering questions, not staring at a blank file.
+  tells an AI agent how to behave in the workspace — package-owned, so a
+  new release replaces it wholesale — plus `campaign-doctrine.md` beside
+  it for the rules that are yours alone. And doctrine *skeletons*: a style
+  guide and a situation-design guide that interview you, each section
+  explaining what belongs in it, so filling them in is answering
+  questions rather than staring at a blank file. See
+  [`docs/adopting-doctrine.md`](docs/adopting-doctrine.md) for how to
+  adopt a new version.
 - **Player-visibility model.** Every file carries a `visibility` field;
   the exporter enforces it, so GM-only material cannot leak to the wiki.
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ offline path via `deploy-export --render-only`.
 
 - **Python ≥ 3.11, zero runtime dependencies.**
 - **Agent-first doctrine.** `init` writes an `AGENTS.md` contract that
-  tells an AI agent how to behave in the workspace — package-owned, so a
-  new release replaces it wholesale — plus `campaign-doctrine.md` beside
-  it for the rules that are yours alone. And doctrine *skeletons*: a style
-  guide and a situation-design guide that interview you, each section
-  explaining what belongs in it, so filling them in is answering
-  questions rather than staring at a blank file. See
-  [`docs/adopting-doctrine.md`](docs/adopting-doctrine.md) for how to
-  adopt a new version.
+  tells an AI agent how to behave in the workspace — package-owned, so
+  adopting a new release replaces it wholesale — plus
+  `campaign-doctrine.md` beside it for the rules that are yours alone.
+  And doctrine *skeletons*: a style guide and a situation-design guide
+  that interview you, each section explaining what belongs in it, so
+  filling them in is answering questions rather than staring at a blank
+  file. See [`docs/adopting-doctrine.md`](docs/adopting-doctrine.md) for
+  how to adopt a new version.
 - **Player-visibility model.** Every file carries a `visibility` field;
   the exporter enforces it, so GM-only material cannot leak to the wiki.
 

--- a/docs/adopting-doctrine.md
+++ b/docs/adopting-doctrine.md
@@ -18,10 +18,10 @@ From your workspace root, with the new bunnyforge installed:
     git diff AGENTS.md
 
 Read the diff — that is the whole review, and it is the reason this stays a
-manual step. Then bump the `bunnyforge==` pin in `requirements.txt` in the
-same commit, and run your campaign tests. `tests/test_campaign_drift.py`
-compares your copy to the installed package byte for byte; it goes green when
-the copy and the pin agree.
+manual step. If your workspace pins `bunnyforge==` in `requirements.txt`,
+bump it in the same commit. If you also have a `tests/test_campaign_drift.py`
+that compares your copy to the installed package byte for byte, run it — it
+goes green when the copy and the pin agree.
 
 If the diff contains something you do not want, the answer is not to keep the
 old bytes. Put the exception in `campaign-doctrine.md`, naming the generic
@@ -41,23 +41,24 @@ campaign-specific rules written into `AGENTS.md` itself. Five steps, once:
 
    What remains is your campaign's own material.
 
-2. **Move it.** Create `campaign-doctrine.md` (copy the packaged stub from
-   `python3 -c "from bunnyforge import init; print(init.packaged_bytes('root/campaign-doctrine.md').decode())"`)
+2. **Move it.** Create `campaign-doctrine.md` (copy the packaged stub with
+   `python3 -c "import pathlib; from bunnyforge import init; pathlib.Path('campaign-doctrine.md').write_bytes(init.packaged_bytes('root/campaign-doctrine.md'))"`)
    and cut those sections into it. Where a section overrides a rule in
    `AGENTS.md`, say which rule, in the section itself.
 
-3. **Take the packaged `AGENTS.md` whole**, using the adopt command above.
-   This performs any pending upstream adoption at the same time.
-
-4. **Register the new file.** If your `campaign.toml` lists `root_docs`
+3. **Register the new file.** If your `campaign.toml` lists `root_docs`
    explicitly, add `"campaign-doctrine.md"` to it — an explicit list
    overrides the packaged default, so the new entry will not reach you
    otherwise. If the key is commented out, there is nothing to do.
 
+4. **Take the packaged `AGENTS.md` whole**, using the adopt command above.
+   This performs any pending upstream adoption (and the pin bump, if you
+   have one) at the same time.
+
 5. **Turn the guard on.** If your `tests/test_campaign_drift.py` allowlists
    `AGENTS.md`, delete that entry. It exists because the file was a fork;
-   after the split it is a copy again, and it can be compared exactly. Bump
-   the pin and run the suite.
+   after the split it is a copy again, and it can be compared exactly. Run
+   the suite.
 
 Step 5 is the point of the whole exercise. An allowlisted file is an
 unguarded file, and `AGENTS.md` is the one you least want unguarded.

--- a/docs/adopting-doctrine.md
+++ b/docs/adopting-doctrine.md
@@ -1,0 +1,63 @@
+# Adopting packaged doctrine
+
+`AGENTS.md` in your workspace is a copy of the one bunnyforge ships. The
+package owns it: it is generic, identical in every workspace, and changes
+when bunnyforge changes. `campaign-doctrine.md` beside it is yours, and no
+release will ever touch it.
+
+That split is what makes adoption cheap. Because nothing campaign-specific
+lives in `AGENTS.md`, a new version is a file copy rather than a merge.
+
+## Adopting a new version
+
+From your workspace root, with the new bunnyforge installed:
+
+    python3 -c "import pathlib; from bunnyforge import init; \
+      pathlib.Path('AGENTS.md').write_bytes( \
+        init.packaged_bytes('doctrine/AGENTS.md'))"
+    git diff AGENTS.md
+
+Read the diff — that is the whole review, and it is the reason this stays a
+manual step. Then bump the `bunnyforge==` pin in `requirements.txt` in the
+same commit, and run your campaign tests. `tests/test_campaign_drift.py`
+compares your copy to the installed package byte for byte; it goes green when
+the copy and the pin agree.
+
+If the diff contains something you do not want, the answer is not to keep the
+old bytes. Put the exception in `campaign-doctrine.md`, naming the generic
+rule it displaces, and take the upstream copy whole.
+
+## Migrating a workspace scaffolded before the split
+
+Workspaces created before `campaign-doctrine.md` existed have their
+campaign-specific rules written into `AGENTS.md` itself. Five steps, once:
+
+1. **Find what is yours.** Diff your `AGENTS.md` against the version you
+   currently pin, not against the newest one — otherwise upstream changes you
+   have not adopted yet look like local edits:
+
+       git -C /path/to/bunnyforge show vX.Y.Z:src/bunnyforge/data/doctrine/AGENTS.md > /tmp/pinned.md
+       diff -u /tmp/pinned.md AGENTS.md
+
+   What remains is your campaign's own material.
+
+2. **Move it.** Create `campaign-doctrine.md` (copy the packaged stub from
+   `python3 -c "from bunnyforge import init; print(init.packaged_bytes('root/campaign-doctrine.md').decode())"`)
+   and cut those sections into it. Where a section overrides a rule in
+   `AGENTS.md`, say which rule, in the section itself.
+
+3. **Take the packaged `AGENTS.md` whole**, using the adopt command above.
+   This performs any pending upstream adoption at the same time.
+
+4. **Register the new file.** If your `campaign.toml` lists `root_docs`
+   explicitly, add `"campaign-doctrine.md"` to it — an explicit list
+   overrides the packaged default, so the new entry will not reach you
+   otherwise. If the key is commented out, there is nothing to do.
+
+5. **Turn the guard on.** If your `tests/test_campaign_drift.py` allowlists
+   `AGENTS.md`, delete that entry. It exists because the file was a fork;
+   after the split it is a copy again, and it can be compared exactly. Bump
+   the pin and run the suite.
+
+Step 5 is the point of the whole exercise. An allowlisted file is an
+unguarded file, and `AGENTS.md` is the one you least want unguarded.

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -93,8 +93,11 @@ are missing.
 
 **Read canon:** `campaign_overview`, `list_entities`, `read_entity`,
 `search`, `generate_names`. Workspace doctrine (`style-guide.md`,
-`situation-design.md`, `AGENTS.md`) is served as MCP *resources* — tell
-the agent to load them before it writes anything for this campaign.
+`situation-design.md`, `AGENTS.md`, `campaign-doctrine.md`) is served as
+MCP *resources* — tell the agent to load them before it writes anything
+for this campaign. `campaign-doctrine.md` carries the rules specific to
+this campaign, and overrides `AGENTS.md` where the two disagree; a
+workspace that predates it simply serves the other three.
 
 **Write drafts:**
 

--- a/docs/superpowers/plans/2026-08-18-campaign-doctrine-split.md
+++ b/docs/superpowers/plans/2026-08-18-campaign-doctrine-split.md
@@ -1,0 +1,559 @@
+# Campaign Doctrine Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the workspace's `AGENTS.md` into a package-owned half that can be replaced wholesale and a new GM-owned `campaign-doctrine.md`, so adopting new doctrine becomes a file copy instead of a merge.
+
+**Architecture:** `AGENTS.md` stays exactly what it is — generic, packaged, byte-identical in every workspace. A new authored stub, `campaign-doctrine.md`, lands beside it at the workspace root in the same MANIFEST class as the existing root stubs (`canonical=None`, so no drift guard ever tracks it). The packaged `AGENTS.md` points at it from its **Read order** and states the precedence rule. Three consumers reach it three ways: Claude Code through the existing `@AGENTS.md` import chain and the Read order, the MCP agent through a fourth entry in `DOCTRINE_FILES`, and any other agent through the same prose Read order the other five root docs already rely on. Nothing in bunnyforge parses `AGENTS.md`; the pointer is prose, and what the tests enforce is that the pointer exists and its target resolves.
+
+**Tech Stack:** Python ≥ 3.11, stdlib only. `unittest` (run via `python3 -m unittest discover -s tests -t . -v`). The MCP half needs the `mcp` extra (`pip install -e '.[mcp]'`).
+
+**Spec:** https://github.com/dcltdw/bunnyforge/issues/32#issuecomment-5329315062 — the analysis comment on issue #32. Read it before Task 1; it carries the measurements every decision below rests on.
+
+## Global Constraints
+
+- **Package is stdlib-only at runtime.** No new dependency may be added by this work.
+- **Python ≥ 3.11.**
+- **The file is named `campaign-doctrine.md`** and is referenced as `[[campaign-doctrine]]`. Decided; do not rename it mid-implementation — it becomes a wikilink target inside packaged doctrine the moment it ships.
+- **The fresh-workspace gate must stay green:** `bunnyforge init` followed by `bunnyforge review checkup` reports `Summary: 0 error(s), 0 warning(s).` (`tests/test_init.py::TestFreshWorkspacePassesTheGate`, and a separate CI step).
+- **No test may write into the repo.** CI has an explicit "No test wrote into the repo" step. Every test scaffolds into `tempfile.TemporaryDirectory()`.
+- **Work on a branch; never commit to `main`.** `main` is ruleset-protected and needs a PR plus four green checks.
+- **Every commit carries a `Co-Authored-By:` trailer naming the AI model.**
+- **`campaign-doctrine.md` has `canonical=None`.** It is an authored stub like `ROOT_STUBS`, not a copy of anything. Giving it a canonical would put it back under the drift guard, which is the exact thing this work exists to get it out from under.
+- **Do not build `bunnyforge doctrine adopt`, `--check`, or any migration subcommand.** The analysis concluded both are unnecessary after the split. The migration is a written recipe run once.
+
+---
+
+### Task 1: Package the `campaign-doctrine.md` stub and land it at the workspace root
+
+**Files:**
+- Create: `src/bunnyforge/data/root/campaign-doctrine.md`
+- Modify: `src/bunnyforge/init.py:75-76` (the `ROOT_STUBS` tuple)
+- Test: `tests/test_init.py` (add to the class containing `test_does_not_write_reanchor_txt`, around line 455)
+
+**Interfaces:**
+- Consumes: `init.packaged_bytes(resource: str) -> bytes`, `init.MANIFEST`, the module-level `ROOT_STUBS` tuple.
+- Produces: the packaged resource path `"root/campaign-doctrine.md"` and the workspace-root destination `"campaign-doctrine.md"`. Tasks 2, 3, 4 and 5 all refer to those two exact strings.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_init.py`, immediately after `test_does_not_write_reanchor_txt`:
+
+```python
+    def test_writes_the_campaign_doctrine_stub(self):
+        # The GM-owned half of the doctrine split (#32). It lands like the
+        # other root stubs -- authored, canonical=None -- because no packaged
+        # version of it may ever overwrite what a campaign writes there. That
+        # is the whole point: AGENTS.md becomes replaceable only once there is
+        # somewhere else for campaign-specific rules to live.
+        stub = _scaffold(self) / "campaign-doctrine.md"
+        self.assertTrue(stub.is_file())
+        self.assertEqual(stub.read_bytes(),
+                         init.packaged_bytes("root/campaign-doctrine.md"))
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python3 -m unittest tests.test_init -k campaign_doctrine_stub -v`
+
+Expected: FAIL. The assertion on `stub.is_file()` fails, or `packaged_bytes` raises `FileNotFoundError` — either is the right red, because neither the packaged file nor the manifest entry exists yet.
+
+- [ ] **Step 3: Create the packaged stub**
+
+Create `src/bunnyforge/data/root/campaign-doctrine.md` with exactly this content. It follows the house style of the other root stubs (`data/root/out-of-game.md`): prose that says what the file is for, then headings whose HTML-comment prompts interview the GM.
+
+```markdown
+# Campaign Doctrine
+
+Rules that apply to *this* campaign and no other. `[[AGENTS]]` is the generic
+agent contract: the bunnyforge package owns it, ships it identically to every
+workspace, and replaces it wholesale when you adopt a new version — so
+anything campaign-specific written into it is lost on the next adoption. This
+file is the other half, and it is yours. No packaged version of it will ever
+overwrite what you write here.
+
+Where a rule below contradicts `[[AGENTS]]`, this file wins — but say so in
+the rule itself, naming the generic rule it displaces, so an exception is
+visible from both sides rather than inferred.
+
+An agent that finds this file empty should carry on with `[[AGENTS]]`
+unchanged. Nothing here is required.
+
+## Subtrees with their own rules
+
+<!-- Directories that do not follow the workspace's normal conventions: a
+     conlang enclave, an imported ruleset, anything with its own file format
+     or its own checker. Say what stops applying, and what applies instead. -->
+
+## Exemptions from the generic contract
+
+<!-- Places where a rule in AGENTS.md does not hold here. Name the rule, say
+     how it changes, and say why. An exemption nobody wrote a reason for gets
+     re-litigated every few months. -->
+
+## Extra tools and checks
+
+<!-- Commands this campaign runs that bunnyforge does not ship: campaign
+     tests, custom checkers, scripts an agent should run before saying
+     something is done. -->
+```
+
+- [ ] **Step 4: Add the manifest entry**
+
+In `src/bunnyforge/init.py`, extend `ROOT_STUBS` (currently lines 75-76) and its comment:
+
+```python
+# The root docs with no canonical in-repo source: the in-repo copies are live
+# campaign state rather than doctrine, so these are authored generically for
+# data/root/ instead. campaign-doctrine.md is here for the opposite reason --
+# it is the GM-owned half of the doctrine split, and a canonical would put it
+# back under the drift guard the split exists to get it out from under.
+ROOT_STUBS = ("campaign-doctrine.md", "compendium.md", "front-burner.md",
+              "open-questions.md", "out-of-game.md", "tickets.md")
+```
+
+No change to `MANIFEST` itself is needed — line 89 already expands `ROOT_STUBS` into `Packaged(f"root/{name}", name, None, False)` entries.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_init -v`
+
+Expected: PASS, including `test_writes_the_campaign_doctrine_stub` and both directions of `TestPackagedDataMatchesItsCanonical` (the second direction — "every packaged file must be named by the manifest" — is what would have caught a `data/root/` file added without the `ROOT_STUBS` entry).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/data/root/campaign-doctrine.md src/bunnyforge/init.py tests/test_init.py
+git commit -m "feat: scaffold campaign-doctrine.md, the GM-owned half of the doctrine split"
+```
+
+---
+
+### Task 2: Make it a configured root doc
+
+Root docs are what `_common.iter_content_files` walks and what `review.check_wikilinks` accepts as link targets (`src/bunnyforge/_common.py:111`). Until `campaign-doctrine.md` is in that list, Task 3's `[[campaign-doctrine]]` link is a broken wikilink and the 0/0 gate fails. This task must land before Task 3.
+
+**Files:**
+- Modify: `src/bunnyforge/_config.py:116-118` (`_DEFAULTS["root_docs"]`)
+- Modify: `src/bunnyforge/data/campaign.toml.in:31-33` (the commented example)
+- Test: `tests/test_init.py`, class `TestGeneratedConfig` (around line 462)
+
+**Interfaces:**
+- Consumes: `init.packaged_bytes("campaign.toml.in")`, `_config._DEFAULTS`.
+- Produces: `"campaign-doctrine.md"` present in `_config._DEFAULTS["root_docs"]`. Task 3's wikilink test depends on this, because `tests/test_init.py::_root_doc_only_workspace` builds its probe workspace from exactly that list.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_init.py`, inside `class TestGeneratedConfig`:
+
+```python
+    def test_the_commented_root_docs_example_names_every_default(self):
+        # campaign.toml.in teaches what is overridable by showing each default
+        # commented out. That is a second copy of _DEFAULTS, and the class's
+        # docstring is right that a second copy is a second thing to drift --
+        # so guard the one list this change touches rather than trusting it.
+        template = init.packaged_bytes("campaign.toml.in").decode("utf-8")
+        for doc in _config._DEFAULTS["root_docs"]:
+            with self.subTest(doc=doc):
+                self.assertIn(f'"{doc}"', template)
+```
+
+- [ ] **Step 2: Run the test to verify it passes, then break it deliberately**
+
+Run: `python3 -m unittest tests.test_init -k commented_root_docs -v`
+
+Expected: PASS. This test is green against today's code — it is a guard being installed *before* the change that needs it, which is the right order. Confirm it can fail by temporarily adding `"nope.md"` to `_config._DEFAULTS["root_docs"]`, re-running (expect FAIL naming `nope.md`), then removing it. A guard you have not watched fail is not yet evidence that it can.
+
+- [ ] **Step 3: Add the doc to the defaults**
+
+In `src/bunnyforge/_config.py`, replace lines 116-118:
+
+```python
+    "root_docs": ["AGENTS.md", "campaign-doctrine.md", "compendium.md",
+                  "front-burner.md", "open-questions.md", "out-of-game.md",
+                  "situation-design.md", "style-guide.md", "tickets.md"],
+```
+
+- [ ] **Step 4: Update the commented example to match**
+
+In `src/bunnyforge/data/campaign.toml.in`, replace lines 31-33:
+
+```
+# root_docs       = ["AGENTS.md", "campaign-doctrine.md", "compendium.md",
+#                    "front-burner.md", "open-questions.md", "out-of-game.md",
+#                    "situation-design.md", "style-guide.md", "tickets.md"]
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_init -v`
+
+Expected: PASS. `test_every_defaultable_key_equals_its_default` picks up the new default automatically; `test_the_commented_root_docs_example_names_every_default` now covers the new entry; `TestFreshWorkspacePassesTheGate` still reports 0/0 because Task 1 scaffolds the file that the new root-doc entry names.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/_config.py src/bunnyforge/data/campaign.toml.in tests/test_init.py
+git commit -m "feat: campaign-doctrine.md is a root doc, so wikilinks can reach it"
+```
+
+---
+
+### Task 3: Point the packaged doctrine at it
+
+**Files:**
+- Modify: `src/bunnyforge/data/doctrine/AGENTS.md:16-27` (the Read order list) and insert a new section immediately before it
+- Test: `tests/test_init.py`, class `TestPackagedDoctrineIsPortable` (around line 51)
+
+**Interfaces:**
+- Consumes: `init.packaged_bytes("doctrine/AGENTS.md")`; `campaign-doctrine.md` present in `_config._DEFAULTS["root_docs"]` from Task 2.
+- Produces: the literal string `[[campaign-doctrine]]` inside the `## Read order` section of the packaged `AGENTS.md`. Nothing downstream reads this programmatically — the test is the contract.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_init.py`, inside `class TestPackagedDoctrineIsPortable`:
+
+```python
+    def test_the_read_order_points_at_campaign_doctrine(self):
+        # The include is prose, not an import: nothing can force an agent to
+        # follow it, and the five root docs already in this list rest on the
+        # same footing. What IS enforceable is that the pointer exists and
+        # that its target resolves -- the second half is the wikilink test
+        # above, which is why both live in this class.
+        doctrine = init.packaged_bytes("doctrine/AGENTS.md").decode("utf-8")
+        self.assertIn("## Read order", doctrine)
+        read_order = doctrine.split("## Read order", 1)[1].split("\n## ", 1)[0]
+        self.assertIn("[[campaign-doctrine]]", read_order,
+                      "AGENTS.md no longer tells an agent to read the "
+                      "campaign-owned half; the split is inert without it")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python3 -m unittest tests.test_init -k read_order_points -v`
+
+Expected: FAIL — `'[[campaign-doctrine]]' not found in` the Read order block, with the message about the split being inert.
+
+- [ ] **Step 3: Add the ownership section and the Read order entry**
+
+In `src/bunnyforge/data/doctrine/AGENTS.md`, insert this new section between the intro block (which ends at line 14 with the `_Ignore/` sentence) and `## Read order`:
+
+```markdown
+## This file and `[[campaign-doctrine]]`
+
+This file is generic. The bunnyforge package owns it, ships it identically to
+every workspace, and replaces it wholesale when a new version is adopted — so
+anything written into it that is true of this campaign only will be lost.
+`[[campaign-doctrine]]` is the other half: campaign-specific rules, owned by
+me, never overwritten.
+
+Where the two disagree, `[[campaign-doctrine]]` wins. It is required to name
+the rule here that it displaces, so an exception is visible from both sides
+rather than inferred.
+```
+
+Then replace the numbered list at lines 18-27 with:
+
+```markdown
+At the start of any working session, read in this order:
+
+1. `[[campaign-doctrine]]` — this campaign's own rules. First, because it can
+   override anything in this file, and it says so where it does.
+2. `[[front-burner]]` — current state. Outranks every older file on any conflict.
+3. `[[compendium]]` — the index. Use it to find what else is relevant.
+4. `[[style-guide]]` — binding constraints on tone and voice.
+5. `[[situation-design]]` — how prep material is structured. Read before
+   building any scenario, NPC, or faction material.
+6. `[[open-questions]]` — what is deliberately undecided.
+
+Then read the entity files relevant to the task at hand.
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_init -v`
+
+Expected: PASS. Two tests matter here and both are pre-existing: `test_agents_md_wikilinks_resolve_with_only_root_docs` proves `[[campaign-doctrine]]` resolves in a workspace holding nothing but root docs, and `TestFreshWorkspacePassesTheGate::test_checkup_reports_no_errors_and_no_warnings` proves the real `init`→`checkup` path still reports `Summary: 0 error(s), 0 warning(s).`
+
+If the wikilink test fails here, Task 2 was skipped or its `_DEFAULTS` edit was lost — `_root_doc_only_workspace` builds its probe from that list.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `python3 -m unittest discover -s tests -t . -v`
+
+Expected: PASS, 0 failures. `tests/test_review.py` and `tests/test_export_player.py` are the two most likely to notice a doctrine edit; if either fails, read the failure before changing anything — it is telling you something real about the new section.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bunnyforge/data/doctrine/AGENTS.md tests/test_init.py
+git commit -m "feat: AGENTS.md names campaign-doctrine.md and fixes their precedence"
+```
+
+---
+
+### Task 4: Serve it to the MCP agent
+
+The MCP agent does not follow prose. Without this task the campaign-owned half simply is not visible to it. `serve_mcp` lists absent files as nothing at all (`src/bunnyforge/serve_mcp.py:40-43`, `214-222`), so this change is safe for workspaces scaffolded before the split.
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py:40-43` (`DOCTRINE_FILES` and its comment)
+- Test: `tests/test_serve_mcp.py`, in the class containing `test_doctrine_resource_lists_and_reads` (around line 207)
+
+**Interfaces:**
+- Consumes: `serve_mcp.build_server(store)`, the module-level `serve_mcp.DOCTRINE_FILES` tuple, and the test helper `scaffold(case) -> _store.WorkspaceStore` defined at `tests/test_serve_mcp.py:27`.
+- Produces: the resource URI `bunnyforge://doctrine/campaign-doctrine.md`.
+
+This task needs the MCP extra installed: `pip install -e '.[mcp]'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_serve_mcp.py`, immediately after `test_absent_doctrine_file_is_not_listed`:
+
+```python
+    async def test_campaign_doctrine_is_served_when_present(self):
+        # The MCP agent follows no include directive: a "see also" inside
+        # AGENTS.md reaches it as literal text and nothing more. The GM-owned
+        # half is visible to it only because the server lists it too.
+        store = scaffold(self)
+        (store.ws.root / "campaign-doctrine.md").write_text(
+            "# Campaign Doctrine\nThe Language/ subtree has its own rules.\n",
+            encoding="utf-8")
+        server = serve_mcp.build_server(store)
+        uris = {str(r.uri) for r in await server.list_resources()}
+        self.assertIn("bunnyforge://doctrine/campaign-doctrine.md", uris)
+        parts = list(await server.read_resource(
+            "bunnyforge://doctrine/campaign-doctrine.md"))
+        self.assertIn("own rules", "".join(p.content for p in parts))
+```
+
+Note the ordering: the file is written *before* `build_server`, because `build_server` registers resources once at assembly time (the `for filename in DOCTRINE_FILES` loop at line 214). A file created afterwards would not be listed.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python3 -m unittest tests.test_serve_mcp -k campaign_doctrine_is_served -v`
+
+Expected: FAIL — `'bunnyforge://doctrine/campaign-doctrine.md' not found in` the URI set.
+
+- [ ] **Step 3: Add the file to `DOCTRINE_FILES`**
+
+In `src/bunnyforge/serve_mcp.py`, replace lines 40-43:
+
+```python
+# Workspace doctrine, offered as MCP resources so a fresh conversation can
+# load the house rules before it writes anything. Absent files are simply
+# not listed -- which is also what makes campaign-doctrine.md safe to add
+# here: a workspace scaffolded before the doctrine split does not have it,
+# and gets exactly the three resources it got before.
+DOCTRINE_FILES = ("style-guide.md", "situation-design.md", "AGENTS.md",
+                  "campaign-doctrine.md")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_serve_mcp -v`
+
+Expected: PASS, including the pre-existing `test_absent_doctrine_file_is_not_listed`, which is now also the regression guard for un-migrated workspaces.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: serve-mcp serves campaign-doctrine.md alongside the packaged doctrine"
+```
+
+---
+
+### Task 5: Documentation and the migration recipe
+
+Five workspaces could exist; exactly one does. The migration is a written procedure run by hand, not a subcommand — see the Global Constraints. But it ships, because a workspace scaffolded before this change needs it and the plan document will not be there.
+
+**Files:**
+- Create: `docs/adopting-doctrine.md`
+- Modify: `README.md:16-20` (the "Agent-first doctrine" bullet)
+- Modify: `docs/serve-mcp.md:94-97` (the resources sentence)
+
+**Interfaces:**
+- Consumes: nothing programmatic. Every path and filename below comes from Tasks 1-4.
+- Produces: nothing programmatic.
+
+- [ ] **Step 1: Write the migration doc**
+
+Create `docs/adopting-doctrine.md`:
+
+```markdown
+# Adopting packaged doctrine
+
+`AGENTS.md` in your workspace is a copy of the one bunnyforge ships. The
+package owns it: it is generic, identical in every workspace, and changes
+when bunnyforge changes. `campaign-doctrine.md` beside it is yours, and no
+release will ever touch it.
+
+That split is what makes adoption cheap. Because nothing campaign-specific
+lives in `AGENTS.md`, a new version is a file copy rather than a merge.
+
+## Adopting a new version
+
+From your workspace root, with the new bunnyforge installed:
+
+    python3 -c "import pathlib; from bunnyforge import init; \
+      pathlib.Path('AGENTS.md').write_bytes( \
+        init.packaged_bytes('doctrine/AGENTS.md'))"
+    git diff AGENTS.md
+
+Read the diff — that is the whole review, and it is the reason this stays a
+manual step. Then bump the `bunnyforge==` pin in `requirements.txt` in the
+same commit, and run your campaign tests. `tests/test_campaign_drift.py`
+compares your copy to the installed package byte for byte; it goes green when
+the copy and the pin agree.
+
+If the diff contains something you do not want, the answer is not to keep the
+old bytes. Put the exception in `campaign-doctrine.md`, naming the generic
+rule it displaces, and take the upstream copy whole.
+
+## Migrating a workspace scaffolded before the split
+
+Workspaces created before `campaign-doctrine.md` existed have their
+campaign-specific rules written into `AGENTS.md` itself. Five steps, once:
+
+1. **Find what is yours.** Diff your `AGENTS.md` against the version you
+   currently pin, not against the newest one — otherwise upstream changes you
+   have not adopted yet look like local edits:
+
+       git -C /path/to/bunnyforge show vX.Y.Z:src/bunnyforge/data/doctrine/AGENTS.md > /tmp/pinned.md
+       diff -u /tmp/pinned.md AGENTS.md
+
+   What remains is your campaign's own material.
+
+2. **Move it.** Create `campaign-doctrine.md` (copy the packaged stub from
+   `python3 -c "from bunnyforge import init; print(init.packaged_bytes('root/campaign-doctrine.md').decode())"`)
+   and cut those sections into it. Where a section overrides a rule in
+   `AGENTS.md`, say which rule, in the section itself.
+
+3. **Take the packaged `AGENTS.md` whole**, using the adopt command above.
+   This performs any pending upstream adoption at the same time.
+
+4. **Register the new file.** If your `campaign.toml` lists `root_docs`
+   explicitly, add `"campaign-doctrine.md"` to it — an explicit list
+   overrides the packaged default, so the new entry will not reach you
+   otherwise. If the key is commented out, there is nothing to do.
+
+5. **Turn the guard on.** If your `tests/test_campaign_drift.py` allowlists
+   `AGENTS.md`, delete that entry. It exists because the file was a fork;
+   after the split it is a copy again, and it can be compared exactly. Bump
+   the pin and run the suite.
+
+Step 5 is the point of the whole exercise. An allowlisted file is an
+unguarded file, and `AGENTS.md` is the one you least want unguarded.
+```
+
+- [ ] **Step 2: Update the README bullet**
+
+In `README.md`, replace lines 16-20:
+
+```markdown
+- **Agent-first doctrine.** `init` writes an `AGENTS.md` contract that
+  tells an AI agent how to behave in the workspace — package-owned, so a
+  new release replaces it wholesale — plus `campaign-doctrine.md` beside
+  it for the rules that are yours alone. And doctrine *skeletons*: a style
+  guide and a situation-design guide that interview you, each section
+  explaining what belongs in it, so filling them in is answering
+  questions rather than staring at a blank file.
+```
+
+- [ ] **Step 3: Update the serve-mcp doc**
+
+In `docs/serve-mcp.md`, replace lines 94-97:
+
+```markdown
+**Read canon:** `campaign_overview`, `list_entities`, `read_entity`,
+`search`, `generate_names`. Workspace doctrine (`style-guide.md`,
+`situation-design.md`, `AGENTS.md`, `campaign-doctrine.md`) is served as
+MCP *resources* — tell the agent to load them before it writes anything
+for this campaign. `campaign-doctrine.md` carries the rules specific to
+this campaign, and overrides `AGENTS.md` where the two disagree; a
+workspace that predates it simply serves the other three.
+```
+
+- [ ] **Step 4: Verify the docs against the code you actually wrote**
+
+Run: `python3 -c "from bunnyforge import init; print(init.packaged_bytes('root/campaign-doctrine.md').decode())"`
+
+Expected: prints the stub from Task 1. This is the exact command `docs/adopting-doctrine.md` step 2 tells a GM to run; run it rather than assuming it works.
+
+Then run: `python3 -c "from bunnyforge import serve_mcp; print(serve_mcp.DOCTRINE_FILES)"`
+
+Expected: the four-tuple ending in `'campaign-doctrine.md'`, matching what `docs/serve-mcp.md` now claims.
+
+- [ ] **Step 5: Run the full suite and the portability check**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -t . -v
+python3 tests/check_portability.py
+```
+
+Expected: both pass. `check_portability.py` greps packaged data for campaign-specific terms; the new stub is generic, so it should be clean. If it flags something, the stub's wording is the bug, not the check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/adopting-doctrine.md README.md docs/serve-mcp.md
+git commit -m "docs: the doctrine ownership split, and how to adopt a new version"
+```
+
+---
+
+### Task 6: Verify in a clean checkout, then open the PR
+
+**Files:** none modified.
+
+- [ ] **Step 1: Verify where the artifact will live, not where you worked**
+
+A warm cache and uncommitted edits both mask failures the next person hits. Run the gate from a throwaway checkout of the branch:
+
+```bash
+git worktree add /tmp/bf-verify HEAD
+cd /tmp/bf-verify
+python3 -m venv .venv && .venv/bin/pip install -e '.[mcp]'
+.venv/bin/python -m unittest discover -s tests -t . -v
+.venv/bin/python tests/check_portability.py
+```
+
+Expected: 0 failures from both.
+
+- [ ] **Step 2: Run the init-then-checkup gate as a real user would**
+
+```bash
+cd /tmp
+/tmp/bf-verify/.venv/bin/python -m bunnyforge.init /tmp/bf-fresh --name "Verify"
+/tmp/bf-verify/.venv/bin/python -m bunnyforge.review checkup --workspace /tmp/bf-fresh
+ls /tmp/bf-fresh/campaign-doctrine.md
+```
+
+Expected: `Summary: 0 error(s), 0 warning(s).` and the file exists. Record the actual output; do not paraphrase it.
+
+- [ ] **Step 3: Clean up the verification checkout**
+
+```bash
+rm -rf /tmp/bf-fresh
+git worktree remove /tmp/bf-verify --force
+```
+
+- [ ] **Step 4: Open the PR**
+
+Use the `dcltdw:opening-a-pr` skill. The PR body should carry: the measurement that motivated it (against `v0.3.1` the live workspace's `AGENTS.md` is the packaged file plus one appended section — no interleaving), the point that `AGENTS.md` is currently allowlisted out of `test_campaign_drift` and this is what lets it come back under the guard, and the note that `bunnyforge doctrine adopt` is deliberately not built. Link issue #32 and say it closes as Won't Do once this lands, rather than `Closes #32`.
+
+Wait for four green checks and for review approval before merging. Do not merge unprompted.
+
+---
+
+## Out of scope — deliberately
+
+Recorded so an executor does not helpfully add them:
+
+- **`bunnyforge doctrine adopt` / `--check` / `doctrine split`.** The analysis concluded the split makes all three unnecessary; the drift test plus the pin test already *are* `--check`.
+- **Anything touching `style-guide.skeleton.md` or `situation-design.skeleton.md`.** Those are real skeletons — 84→705 and 73→215 lines in the live workspace, interleaved beyond extraction, and correctly outside the drift guard already. There is no seam there and this change must not pretend otherwise.
+- **The Anjeong migration itself.** Anjeong is a separate repository, pinned to `bunnyforge==0.3.1`, and nothing breaks until that pin moves. It follows `docs/adopting-doctrine.md` after this ships — and after #62 and the release, so it adopts everything in one move.
+- **The release.** Ticket #62 (the leading-`_` convention) comes next, and the release comes last so it carries both decisions.

--- a/src/bunnyforge/README.md
+++ b/src/bunnyforge/README.md
@@ -56,9 +56,9 @@ not exist, or must be an empty directory — a file, a non-empty directory, or a
 existing `campaign.toml` is one `error:` line and exit 1. There is no `--force`
 and no overwrite semantics.
 
-What it writes — 38 files, every one of them a `MANIFEST` entry: `campaign.toml`
+What it writes — 39 files, every one of them a `MANIFEST` entry: `campaign.toml`
 (live keys for name, namespace and the culture directory; every defaultable key
-present as a comment showing its default), the 8 root docs, the 10 content
+present as a comment showing its default), the 9 root docs, the 10 content
 directories each with its README, the 12 `_Templates/` files, a starter culture
 at `names/cultures/vashkand.toml`, a minimal `.gitignore`, the 3-file `tests/`
 scaffold, and 2 files under `.vscode/`. It does not run `git init`; version

--- a/src/bunnyforge/_config.py
+++ b/src/bunnyforge/_config.py
@@ -113,9 +113,9 @@ _DEFAULTS = {
                     "Sessions", "Handouts"],
     "inherit_dirs": ["Briefs", "Perceptions"],
     "compendium_dirs": ["NPCs", "Factions", "Setting", "Mechanics", "PCs", "Ideas"],
-    "root_docs": ["AGENTS.md", "compendium.md", "front-burner.md",
-                  "open-questions.md", "out-of-game.md", "situation-design.md",
-                  "style-guide.md", "tickets.md"],
+    "root_docs": ["AGENTS.md", "campaign-doctrine.md", "compendium.md",
+                  "front-burner.md", "open-questions.md", "out-of-game.md",
+                  "situation-design.md", "style-guide.md", "tickets.md"],
     "exclude_dirs": ["_Ignore", "_Archive", "_Templates",
                      "Sheets", "Reviews", "docs", "scripts", "tests"],
     # The GM's inbound queue (material authored elsewhere, awaiting

--- a/src/bunnyforge/data/campaign.toml.in
+++ b/src/bunnyforge/data/campaign.toml.in
@@ -28,9 +28,9 @@ cultures = "names/cultures"        # a DIRECTORY of one-file-per-culture
 #                    "Sessions", "Handouts"]
 # inherit_dirs    = ["Briefs", "Perceptions"]
 # compendium_dirs = ["NPCs", "Factions", "Setting", "Mechanics", "PCs", "Ideas"]
-# root_docs       = ["AGENTS.md", "compendium.md", "front-burner.md",
-#                    "open-questions.md", "out-of-game.md", "situation-design.md",
-#                    "style-guide.md", "tickets.md"]
+# root_docs       = ["AGENTS.md", "campaign-doctrine.md", "compendium.md",
+#                    "front-burner.md", "open-questions.md", "out-of-game.md",
+#                    "situation-design.md", "style-guide.md", "tickets.md"]
 # exclude_dirs    = ["_Ignore", "_Archive", "_Templates",
 #                    "Sheets", "Reviews", "docs", "scripts", "tests"]
 # briefs_dir      = "Briefs"

--- a/src/bunnyforge/data/doctrine/AGENTS.md
+++ b/src/bunnyforge/data/doctrine/AGENTS.md
@@ -13,16 +13,30 @@ from it** — decisions rest on precedent, which is the whole reason it is kept.
 `_Ignore/` holds raw material, plus retired work that set no precedent: **never
 read it** unless I name a file in it and ask.
 
+## This file and `[[campaign-doctrine]]`
+
+This file is generic. The bunnyforge package owns it, ships it identically to
+every workspace, and replaces it wholesale when a new version is adopted — so
+anything written into it that is true of this campaign only will be lost.
+`[[campaign-doctrine]]` is the other half: campaign-specific rules, owned by
+me, never overwritten.
+
+Where the two disagree, `[[campaign-doctrine]]` wins. It is required to name
+the rule here that it displaces, so an exception is visible from both sides
+rather than inferred.
+
 ## Read order
 
 At the start of any working session, read in this order:
 
-1. `[[front-burner]]` — current state. Outranks every older file on any conflict.
-2. `[[compendium]]` — the index. Use it to find what else is relevant.
-3. `[[style-guide]]` — binding constraints on tone and voice.
-4. `[[situation-design]]` — how prep material is structured. Read before
+1. `[[campaign-doctrine]]` — this campaign's own rules. First, because it can
+   override anything in this file, and it says so where it does.
+2. `[[front-burner]]` — current state. Outranks every older file on any conflict.
+3. `[[compendium]]` — the index. Use it to find what else is relevant.
+4. `[[style-guide]]` — binding constraints on tone and voice.
+5. `[[situation-design]]` — how prep material is structured. Read before
    building any scenario, NPC, or faction material.
-5. `[[open-questions]]` — what is deliberately undecided.
+6. `[[open-questions]]` — what is deliberately undecided.
 
 Then read the entity files relevant to the task at hand.
 

--- a/src/bunnyforge/data/root/campaign-doctrine.md
+++ b/src/bunnyforge/data/root/campaign-doctrine.md
@@ -1,0 +1,33 @@
+# Campaign Doctrine
+
+Rules that apply to *this* campaign and no other. `[[AGENTS]]` is the generic
+agent contract: the bunnyforge package owns it, ships it identically to every
+workspace, and replaces it wholesale when you adopt a new version — so
+anything campaign-specific written into it is lost on the next adoption. This
+file is the other half, and it is yours. No packaged version of it will ever
+overwrite what you write here.
+
+Where a rule below contradicts `[[AGENTS]]`, this file wins — but say so in
+the rule itself, naming the generic rule it displaces, so an exception is
+visible from both sides rather than inferred.
+
+An agent that finds this file empty should carry on with `[[AGENTS]]`
+unchanged. Nothing here is required.
+
+## Subtrees with their own rules
+
+<!-- Directories that do not follow the workspace's normal conventions: a
+     conlang enclave, an imported ruleset, anything with its own file format
+     or its own checker. Say what stops applying, and what applies instead. -->
+
+## Exemptions from the generic contract
+
+<!-- Places where a rule in AGENTS.md does not hold here. Name the rule, say
+     how it changes, and say why. An exemption nobody wrote a reason for gets
+     re-litigated every few months. -->
+
+## Extra tools and checks
+
+<!-- Commands this campaign runs that bunnyforge does not ship: campaign
+     tests, custom checkers, scripts an agent should run before saying
+     something is done. -->

--- a/src/bunnyforge/init.py
+++ b/src/bunnyforge/init.py
@@ -71,9 +71,11 @@ CONTENT_DIRS = (
 
 # The root docs with no canonical in-repo source: the in-repo copies are live
 # campaign state rather than doctrine, so these are authored generically for
-# data/root/ instead.
-ROOT_STUBS = ("compendium.md", "front-burner.md", "open-questions.md",
-              "out-of-game.md", "tickets.md")
+# data/root/ instead. campaign-doctrine.md is here for the opposite reason --
+# it is the GM-owned half of the doctrine split, and a canonical would put it
+# back under the drift guard the split exists to get it out from under.
+ROOT_STUBS = ("campaign-doctrine.md", "compendium.md", "front-burner.md",
+              "open-questions.md", "out-of-game.md", "tickets.md")
 
 MANIFEST = (
     Packaged("campaign.toml.in", CONFIG_NAME, None, True),

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -39,8 +39,11 @@ KEY_ENV = "BUNNYFORGE_MCP_KEY"
 
 # Workspace doctrine, offered as MCP resources so a fresh conversation can
 # load the house rules before it writes anything. Absent files are simply
-# not listed.
-DOCTRINE_FILES = ("style-guide.md", "situation-design.md", "AGENTS.md")
+# not listed -- which is also what makes campaign-doctrine.md safe to add
+# here: a workspace scaffolded before the doctrine split does not have it,
+# and gets exactly the three resources it got before.
+DOCTRINE_FILES = ("style-guide.md", "situation-design.md", "AGENTS.md",
+                  "campaign-doctrine.md")
 
 _INSTALL_HINT = ("serve-mcp needs its optional dependencies:\n"
                  "  pip install 'bunnyforge[mcp]'")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -74,6 +74,19 @@ class TestPackagedDoctrineIsPortable(unittest.TestCase):
             "AGENTS.md links to something a fresh workspace does not have, "
             "so `init` cannot ship it verbatim and still pass the gate")
 
+    def test_the_read_order_points_at_campaign_doctrine(self):
+        # The include is prose, not an import: nothing can force an agent to
+        # follow it, and the five root docs already in this list rest on the
+        # same footing. What IS enforceable is that the pointer exists and
+        # that its target resolves -- the second half is the wikilink test
+        # above, which is why both live in this class.
+        doctrine = init.packaged_bytes("doctrine/AGENTS.md").decode("utf-8")
+        self.assertIn("## Read order", doctrine)
+        read_order = doctrine.split("## Read order", 1)[1].split("\n## ", 1)[0]
+        self.assertIn("[[campaign-doctrine]]", read_order,
+                      "AGENTS.md no longer tells an agent to read the "
+                      "campaign-owned half; the split is inert without it")
+
 
 def _packaged_data_root() -> Path:
     """The data/ tree as a real directory.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,12 +29,12 @@ REPO = Path(__file__).resolve().parent.parent
 
 
 def _root_doc_only_workspace(case: unittest.TestCase) -> Path:
-    """A workspace holding the 8 default root docs and nothing else.
+    """A workspace holding the 9 default root docs and nothing else.
 
     The shape a fresh `init` produces before any entity file exists, and so
     the shape every wikilink in the packaged doctrine has to resolve against.
     The packaged AGENTS.md is written in — the copy `init` actually ships;
-    the other seven root docs are one-line stubs, because all this needs of
+    the other eight root docs are one-line stubs, because all this needs of
     them is that they be link targets.
     """
     tmp = Path(case.enterContext(tempfile.TemporaryDirectory())).resolve()
@@ -519,6 +519,16 @@ class TestGeneratedConfig(unittest.TestCase):
         cfg = self._config_of(name='My "Great" Campaign\\Two')
         self.assertEqual(cfg.name, 'My "Great" Campaign\\Two')
         self.assertEqual(cfg.namespace, "mygreatcampaigntwo")
+
+    def test_the_commented_root_docs_example_names_every_default(self):
+        # campaign.toml.in teaches what is overridable by showing each default
+        # commented out. That is a second copy of _DEFAULTS, and the class's
+        # docstring is right that a second copy is a second thing to drift --
+        # so guard the one list this change touches rather than trusting it.
+        template = init.packaged_bytes("campaign.toml.in").decode("utf-8")
+        for doc in _config._DEFAULTS["root_docs"]:
+            with self.subTest(doc=doc):
+                self.assertIn(f'"{doc}"', template)
 
 
 def _scrubbed_env(**extra: str) -> dict[str, str]:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -458,6 +458,17 @@ class TestWhatInitWrites(unittest.TestCase):
         # doc, so init leaves it to the author.
         self.assertFalse((_scaffold(self) / "reanchor.txt").exists())
 
+    def test_writes_the_campaign_doctrine_stub(self):
+        # The GM-owned half of the doctrine split (#32). It lands like the
+        # other root stubs -- authored, canonical=None -- because no packaged
+        # version of it may ever overwrite what a campaign writes there. That
+        # is the whole point: AGENTS.md becomes replaceable only once there is
+        # somewhere else for campaign-specific rules to live.
+        stub = _scaffold(self) / "campaign-doctrine.md"
+        self.assertTrue(stub.is_file())
+        self.assertEqual(stub.read_bytes(),
+                         init.packaged_bytes("root/campaign-doctrine.md"))
+
 
 class TestGeneratedConfig(unittest.TestCase):
     """The generated campaign.toml round-trips through _config.load, and every

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -538,10 +538,15 @@ class TestGeneratedConfig(unittest.TestCase):
         # commented out. That is a second copy of _DEFAULTS, and the class's
         # docstring is right that a second copy is a second thing to drift --
         # so guard the one list this change touches rather than trusting it.
+        # Anchored to the commented `root_docs = [...]` block itself (a bare
+        # assertIn would match a quoted name anywhere in the file) and
+        # bidirectional, so a default missing from the block *and* a stale
+        # entry left behind after a default was removed both fail.
         template = init.packaged_bytes("campaign.toml.in").decode("utf-8")
-        for doc in _config._DEFAULTS["root_docs"]:
-            with self.subTest(doc=doc):
-                self.assertIn(f'"{doc}"', template)
+        match = re.search(r"# root_docs\b.*?\]", template, re.DOTALL)
+        self.assertIsNotNone(match, "no commented root_docs example found")
+        block_docs = set(re.findall(r'"([^"]+)"', match.group()))
+        self.assertEqual(block_docs, set(_config._DEFAULTS["root_docs"]))
 
 
 def _scrubbed_env(**extra: str) -> dict[str, str]:

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -216,6 +216,11 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         server = serve_mcp.build_server(scaffold(self))
         uris = {str(r.uri) for r in await server.list_resources()}
         self.assertNotIn("bunnyforge://doctrine/situation-design.md", uris)
+        # docs/serve-mcp.md promises that "a workspace that predates it
+        # [campaign-doctrine.md] simply serves the other three" -- scaffold()
+        # does not create campaign-doctrine.md, so it must not be listed
+        # either, the same way an absent situation-design.md is not listed.
+        self.assertNotIn("bunnyforge://doctrine/campaign-doctrine.md", uris)
 
     async def test_campaign_doctrine_is_served_when_present(self):
         # The MCP agent follows no include directive: a "see also" inside

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -217,6 +217,21 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         uris = {str(r.uri) for r in await server.list_resources()}
         self.assertNotIn("bunnyforge://doctrine/situation-design.md", uris)
 
+    async def test_campaign_doctrine_is_served_when_present(self):
+        # The MCP agent follows no include directive: a "see also" inside
+        # AGENTS.md reaches it as literal text and nothing more. The GM-owned
+        # half is visible to it only because the server lists it too.
+        store = scaffold(self)
+        (store.ws.root / "campaign-doctrine.md").write_text(
+            "# Campaign Doctrine\nThe Language/ subtree has its own rules.\n",
+            encoding="utf-8")
+        server = serve_mcp.build_server(store)
+        uris = {str(r.uri) for r in await server.list_resources()}
+        self.assertIn("bunnyforge://doctrine/campaign-doctrine.md", uris)
+        parts = list(await server.read_resource(
+            "bunnyforge://doctrine/campaign-doctrine.md"))
+        self.assertIn("own rules", "".join(p.content for p in parts))
+
     async def test_inbound_tools_always_registered(self):
         server = serve_mcp.build_server(scaffold(self))
         names = {t.name for t in await server.list_tools()}


### PR DESCRIPTION
Splits the workspace's `AGENTS.md` into two halves with different owners, so
adopting new doctrine becomes a file copy instead of a merge.

`AGENTS.md` stays exactly what it was: generic, package-owned, byte-identical
in every workspace. A new authored stub, `campaign-doctrine.md`, lands beside
it at the workspace root with `canonical=None` — the same MANIFEST class as
the existing root stubs — so no drift guard ever tracks it and no release
will ever overwrite what a campaign writes there.

### Why now, and why this shape

The measurement behind it: against `v0.3.1` — the version the live workspace
actually pins, not `main` — that workspace's `AGENTS.md` is **the packaged
file plus one appended H2 section**. Zero in-place edits to doctrine prose,
no interleaving. The seam this PR formalises already existed; nothing has
ever crossed it. (The 46-line figure in issue #32 was measured against
`main`, which is the wrong baseline — 24 of those lines are unreleased
upstream work from #61.)

The stronger argument is the drift guard. The live campaign's
`test_campaign_drift.py` currently **allowlists `AGENTS.md` out of comparison
entirely** — the single most important doctrine file has no drift guard at
all, precisely because it was a fork. After the split the allowlist entry is
deleted and the file is compared byte for byte. This is not mainly an
adoption-cost optimisation; it is what lets the guard we already believe in
run on the file we least want unguarded.

`bunnyforge doctrine adopt` is **deliberately not built**, and `#32` closes as
**Won't Do** once this lands — not because the pain was imaginary, but
because the split removes the merge that made a tool necessary. The
`--check` half is already implemented: an exact-comparison drift test plus
the existing pin test *are* "your doctrine is behind, and here is the file".
Migration is a written recipe run once, against `n=1` workspaces.

### Files changed

| file | | what |
|---|---|---|
| `docs/superpowers/plans/2026-08-18-campaign-doctrine-split.md` | (new) | the implementation plan this PR executes |
| `src/bunnyforge/data/root/campaign-doctrine.md` | (new) | the packaged GM-owned stub |
| `docs/adopting-doctrine.md` | (new) | how to adopt a new version, and the one-time migration recipe |
| `src/bunnyforge/init.py` | (modified) | `campaign-doctrine.md` added to `ROOT_STUBS` |
| `src/bunnyforge/_config.py` | (modified) | added to the `root_docs` default |
| `src/bunnyforge/data/campaign.toml.in` | (modified) | the commented `root_docs` example, kept in sync |
| `src/bunnyforge/data/doctrine/AGENTS.md` | (modified) | new ownership section; Read order names `[[campaign-doctrine]]` first |
| `src/bunnyforge/serve_mcp.py` | (modified) | fourth `DOCTRINE_FILES` entry |
| `src/bunnyforge/README.md` | (modified) | inventory count 38 → 39 files, 8 → 9 root docs |
| `README.md` | (modified) | doctrine bullet rewritten; links the new adoption doc |
| `docs/serve-mcp.md` | (modified) | the resources sentence, now four files |
| `tests/test_init.py` | (modified) | 3 new guards + docstring counts |
| `tests/test_serve_mcp.py` | (modified) | 1 new test + a strengthened absence assertion |

### Work breakdown

Six commits, ordered by dependency.

1. **Scaffold the stub** (`5ef32a6`). The packaged file plus the `ROOT_STUBS`
   entry. `canonical=None` is the whole point — giving it a canonical would
   put it back under the drift guard this work exists to get it out from
   under. `MANIFEST` needed no edit: it already expands `ROOT_STUBS`.
2. **Make it a root doc** (`dc1336f`). Must precede step 3: `root_docs` is
   what `review.check_wikilinks` accepts as link targets, so the wikilink in
   step 3 only resolves once this lands.
3. **Point the doctrine at it** (`3d6a3e2`). A new ownership section plus
   `[[campaign-doctrine]]` first in the Read order. Precedence is stated
   explicitly, because real campaign content *overrides* doctrine rather than
   merely adding to it — and an exception must name the generic rule it
   displaces, so it is visible from both sides.
4. **Serve it over MCP** (`4dd2f5e`). The MCP agent follows no include
   directive; a "see also" in `AGENTS.md` reaches it as literal text. Safe
   for un-migrated workspaces because `serve_mcp` lists absent files as
   nothing at all — they get exactly the three resources they got before.
5. **Docs and the migration recipe** (`981416f`).
6. **Final-review fixes** (`fe78e6e`). See below.

Notable non-obvious property, worth a reviewer's attention: adding the file
to `root_docs` also puts it into `export_player.run_export`. It cannot leak
to players because a file with no front matter resolves through
`normalize_visibility` to `DEFAULT_VISIBILITY = "gm-only"` and `render_export`
skips it — the same treatment `AGENTS.md` already gets.

### Review findings fixed in `fe78e6e`

A whole-branch review found one real defect and six smaller ones, all fixed:

- `docs/adopting-doctrine.md` asserted a `requirements.txt` and a
  `tests/test_campaign_drift.py` that `bunnyforge init` **never creates** —
  making the doc's central "here is how you know it worked" promise false for
  every reader but the one campaign that hand-wrote them. Now conditional.
- `README.md` implied a *release* rewrites `AGENTS.md`. No command does;
  adoption is a manual copy. Now "adopting a new release".
- The migration steps registered `campaign-doctrine.md` in `root_docs`
  *after* adopting the `AGENTS.md` that links to it — a window where
  `checkup` reports a broken wikilink. Swapped.
- Step 2's command printed rather than wrote; the pin was bumped twice.
- The `root_docs` example guard matched the quoted name anywhere in the
  template and had no reverse direction. Now anchored and bidirectional.
- The serve-mcp backward-compat sentence was guarded only by proxy. Now
  asserted directly.

### Deliberately out of scope

- **`bunnyforge doctrine adopt` / `--check` / `doctrine split`** — see above.
- **`style-guide.skeleton.md` and `situation-design.skeleton.md`** — genuine
  skeletons (84→705 and 73→215 lines in the live campaign, interleaved beyond
  extraction) and already correctly outside the drift guard. There is no seam
  there and this change does not pretend otherwise.
- **The live campaign's migration** — separate repo, pinned to `0.3.1`,
  nothing breaks until that pin moves. It follows `docs/adopting-doctrine.md`
  after this ships, and after #62 and the release, so it adopts everything in
  one move.

### Test expectations

All green; no expected failures. `877 tests, OK` and `check_portability.py
PASSED`, verified in a throwaway checkout of the branch head with its own
fresh venv — not just in the working tree. The `init` → `checkup` gate was
run the way a user runs it:

```
Created campaign workspace /tmp/bf-fresh2 — 39 files (name 'Verify', namespace 'verify').
Summary: 0 error(s), 0 warning(s).
```

`docs/adopting-doctrine.md`'s own commands were executed verbatim rather than
assumed to work.

### Operational impact

None on upgrade. A workspace scaffolded before this change is unaffected on
every path: `init` is not re-run, `checkup` walks only root docs that exist,
and `serve_mcp` lists only files that are present. Adopting the split is a
deliberate act, documented in `docs/adopting-doctrine.md`.

### Known gap, filed rather than fixed here

The plan claimed `tests/check_portability.py` greps packaged data for
campaign-specific terms. It does not — it is a name-generator property check.
The campaign-term grep is `tests/test_portability.py::TestPortableBoundary`,
which scans only `tests/test_*.py` and never `data/`. So nothing currently
guards packaged data against campaign-specific wording. The new stub is
generic (checked by hand), so nothing bad landed, but the gap is real and
predates this PR.

### Provenance

- **Agent:** Claude Code (subagent-driven execution of the committed plan;
  a fresh implementer per task, an independent review between tasks, and a
  whole-branch review before opening)
- **Model / version:** session requested Opus 5 as controller; task
  implementers ran on Claude Haiku 4.5 and Claude Sonnet 5, as recorded in
  each commit's `Co-Authored-By:` trailer

Refs #32 — closes as **Won't Do**, not as work, once this lands.
