### PR TITLE
Scoped retrieval: scope live|archive|both across search and list_entities, with the scope-is-the-GM's-call doctrine (#66)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-scoped-retrieval.md
+++ b/docs/superpowers/plans/2026-08-18-scoped-retrieval.md
@@ -1,0 +1,668 @@
+# Scoped Retrieval (#66) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `scope: "live" | "archive" | "both"` to the MCP `search` and `list_entities` tools with symmetric scope-resolved section semantics, label every result with `archived`, add `campaign_overview`'s `archive_sections` breakdown, and ship the ask-the-GM-at-task-start retrieval doctrine.
+
+**Architecture:** All filtering lives in `_store.py` — one validator (`_check_retrieval`) and one membership predicate (`_in_scope`) shared by both tools so they cannot drift. `serve_mcp.py` only threads the parameter and carries the condensed guidance in docstrings. The packaged doctrine gets one new section (the primary home for the scope-is-the-GM's-call rule).
+
+**Tech Stack:** Python ≥ 3.11, stdlib only at runtime. Tests via `unittest` discovery. The `mcp` SDK is an optional extra used only by `serve_mcp` tests (they skip without it).
+
+**Spec:** `docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md` — the plan argues from the spec; read both. The spec's decisions table is binding (notably: symmetric scope-resolution, `both` as the default token, the revision of #62's listings record).
+
+## Global Constraints
+
+- Python ≥ 3.11, **stdlib only at runtime**; no new dependencies.
+- **No new packaged files** — the doctrine edit is in-place, so `init.MANIFEST` must not change (`tests/test_init.py` proves it complete both ways).
+- Default scope is `"both"` — the union behavior stays the default (ticket decision of record).
+- No test may write into the repo (CI enforces); every test scaffolds into `tempfile.TemporaryDirectory()`.
+- Fresh-workspace gate must stay green: `bunnyforge init` → `bunnyforge review checkup` reports `Summary: 0 error(s), 0 warning(s)`.
+- **Worktree Python:** bare `python3` resolves `bunnyforge` to the primary clone. Run every test/gate command with `PYTHONPATH=src` from the worktree root, and verify once with `PYTHONPATH=src python3 -c "import bunnyforge; print(bunnyforge.__file__)"` (must print this worktree's path). Never pip install into any shared environment.
+- The `mcp` extra is not installed in the worktree environment: `test_serve_mcp`'s `HAVE_MCP` tests **skip locally** (baseline: 901 tests, 54 skips) and run in CI's dedicated mcp job. Write them anyway; do not chase local skips.
+- Never commit to `main`; work stays on this worktree branch (`worktree-scoped-retrieval-66`); every commit carries a `Co-Authored-By:` trailer naming the current model.
+- **Human vocabulary read (spec §7):** with #65 deferred, no automated check scans packaged prose for campaign vocabulary. Every line of new prose in `src/bunnyforge/data/` and the new tool docstrings needs a deliberate GM read before the PR merges — Task 5 ends at that checkpoint; it is a review step, not a test.
+
+---
+
+### Task 1: Store — scope validation and scoped `search`
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (constant near `SEARCH_CAP:33`; two new methods after `_check_section:74`; rewrite `search:163`)
+- Test: `tests/test_store.py` (helper on `StoreCase:23`; new class after `TestSearch`, which ends ~line 222)
+
+**Interfaces:**
+- Consumes: `_common.iter_content_files(ws)` (existing), `self._check_section(section)` (existing), `self.ws.config.archive_dir` (existing, default `"Archive"`).
+- Produces (Tasks 2–4 rely on these exact names):
+  - `_store.SCOPES = ("live", "archive", "both")` (module constant)
+  - `WorkspaceStore._check_retrieval(section: str | None, scope: str) -> None` — raises `StoreError` on a bad scope token, unknown section, or the `live`+`Archive` contradiction.
+  - `WorkspaceStore._in_scope(parts: tuple[str, ...], section: str | None, scope: str) -> bool` — membership of one walked file, `parts` being its workspace-relative path components.
+  - `WorkspaceStore.search(query, section=None, scope="both")` — hits now carry `"archived": bool`.
+  - Test helper `StoreCase.make_archived_ws()` — `make_ws()` plus `Archive/NPCs/old-hag.md` and stray `Archive/stray.md`.
+
+- [ ] **Step 1: Add the archive fixture helper and write the failing tests**
+
+In `tests/test_store.py`, add to `StoreCase` (below `make_ws`):
+
+```python
+    def make_archived_ws(self, toml_extra: str = "") -> _config.Workspace:
+        """make_ws plus a mirrored archive: one archived NPC, and one
+        stray file directly at the archive root (no mirror section)."""
+        ws = self.make_ws(toml_extra)
+        arch = ws.root / "Archive" / "NPCs"
+        arch.mkdir(parents=True)
+        (arch / "old-hag.md").write_text(
+            "---\ntitle: The Old Hag\nsummary: Retired rival on the "
+            "ferry route.\nstatus: retired\n---\n"
+            "She haunted the ferry route.\n", encoding="utf-8")
+        (ws.root / "Archive" / "stray.md").write_text(
+            "---\ntitle: Stray\nsummary: A stray archived note.\n---\n"
+            "ferry flotsam\n", encoding="utf-8")
+        return ws
+```
+
+(`"ferry"` now matches all four content files: the live NPC's front matter, `front-burner.md`, the archived NPC, and the stray — one query exercises every bucket.)
+
+Add a new test class directly after `TestSearch`:
+
+```python
+class TestScopedSearch(StoreCase):
+    """#66: scope: live | archive | both, section resolving inside the
+    scope's tree(s), every hit labelled archived."""
+
+    def test_default_scope_is_both_and_labels_every_hit(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        by_path = {h["path"]: h["archived"] for h in store.search("ferry")}
+        self.assertEqual(by_path, {
+            "NPCs/kim-ha-eun.md": False,
+            "front-burner.md": False,
+            "Archive/NPCs/old-hag.md": True,
+            "Archive/stray.md": True,
+        })
+
+    def test_scope_live_excludes_archived_hits_keeps_root_docs(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        paths = {h["path"] for h in store.search("ferry", scope="live")}
+        self.assertEqual(paths, {"NPCs/kim-ha-eun.md", "front-burner.md"})
+
+    def test_scope_archive_returns_only_archived_hits(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        paths = {h["path"] for h in store.search("ferry", scope="archive")}
+        self.assertEqual(paths,
+                         {"Archive/NPCs/old-hag.md", "Archive/stray.md"})
+
+    def test_sectioned_both_is_the_union_of_the_trees(self):
+        # section="NPCs" covers NPCs/ AND Archive/NPCs/ under the default.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        paths = {h["path"] for h in store.search("ferry", section="NPCs")}
+        self.assertEqual(paths,
+                         {"NPCs/kim-ha-eun.md", "Archive/NPCs/old-hag.md"})
+
+    def test_sectioned_archive_scope_resolves_the_mirror(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        hits = store.search("ferry", section="NPCs", scope="archive")
+        self.assertEqual([h["path"] for h in hits],
+                         ["Archive/NPCs/old-hag.md"])
+
+    def test_sectioned_live_scope_stays_pure_live(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        hits = store.search("ferry", section="NPCs", scope="live")
+        self.assertEqual([h["path"] for h in hits], ["NPCs/kim-ha-eun.md"])
+
+    def test_section_archive_means_the_whole_archive(self):
+        # Under "both" and "archive" alike; strays included.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        for scope in ("both", "archive"):
+            paths = {h["path"] for h in
+                     store.search("ferry", section="Archive", scope=scope)}
+            self.assertEqual(
+                paths, {"Archive/NPCs/old-hag.md", "Archive/stray.md"},
+                scope)
+
+    def test_a_stray_archive_file_is_in_no_mirror_section(self):
+        # "flotsam" appears only in Archive/stray.md, which has no mirror.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(store.search("flotsam", section="NPCs"), [])
+        self.assertEqual(
+            [h["path"] for h in store.search("flotsam")],
+            ["Archive/stray.md"])
+
+    def test_scope_live_with_section_archive_is_a_refused_contradiction(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.search("ferry", section="Archive", scope="live")
+        self.assertIn("contradicts", str(ctx.exception))
+        self.assertIn("archive", str(ctx.exception).lower())
+
+    def test_unknown_scope_is_refused_naming_the_valid_ones(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.search("ferry", scope="everything")
+        for token in ("live", "archive", "both"):
+            self.assertIn(token, str(ctx.exception))
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestScopedSearch -v`
+Expected: FAIL/ERROR on every test — `search() got an unexpected keyword argument 'scope'` and, for the default-scope test, a missing `archived` key.
+
+- [ ] **Step 3: Implement scope in `_store.py`**
+
+Add the constant next to the other module constants (after `NAME_COUNT_CAP`):
+
+```python
+SCOPES = ("live", "archive", "both")  # exactly two trees exist (#62), so
+                                      # "both" is the honest union token
+```
+
+Add two methods to `WorkspaceStore` directly after `_check_section`:
+
+```python
+    def _check_retrieval(self, section: str | None, scope: str) -> None:
+        """Validate a search/list_entities filter pair before any walk.
+
+        scope names which tree(s) to read. One combination is a
+        contradiction rather than an empty answer -- the archive
+        section under a scope that excludes archived files -- and a
+        contradiction is refused, not served (#66).
+        """
+        if scope not in SCOPES:
+            raise StoreError(f"unknown scope {scope!r} — one of: "
+                             + ", ".join(SCOPES))
+        if section is not None:
+            self._check_section(section)
+            if scope == "live" and section == self.ws.config.archive_dir:
+                raise StoreError(
+                    f"section {section!r} contradicts scope 'live': "
+                    "archived files are exactly what it excludes — drop "
+                    "the section, or use scope 'archive'")
+
+    def _in_scope(self, parts: tuple[str, ...], section: str | None,
+                  scope: str) -> bool:
+        """One walked file's membership under a validated filter (#66).
+
+        A file is archived iff its first component is the archive dir.
+        section names the CONTENT section and resolves inside the
+        scope's tree(s): live files match on parts[0], archived files
+        on their mirror (parts[1]); the archive dir's own name denotes
+        the archive tree. A stray directly at Archive/*.md has no
+        mirror, so it matches whole-archive queries and no section.
+        """
+        archive = self.ws.config.archive_dir
+        archived = parts[0] == archive
+        if (scope == "live" and archived) or \
+                (scope == "archive" and not archived):
+            return False
+        if section is None:
+            return True
+        if section == archive:
+            return archived
+        if archived:
+            return len(parts) > 2 and parts[1] == section
+        return parts[0] == section
+```
+
+Rewrite `search` (replacing the `_check_section` call and the
+`rel.startswith` filter; the docstring's first paragraph is unchanged):
+
+```python
+    def search(self, query: str, section: str | None = None,
+               scope: str = "both") -> list[dict]:
+        """Case-insensitive substring search across content files.
+
+        Deliberately literal rather than clever: an agent that can see the
+        matched text decides relevance better than a ranking heuristic
+        would, and a substring match is explainable when it surprises.
+
+        scope and section resolve per _in_scope (#66); every hit says
+        whether it is archived, so the caller buckets hits without
+        parsing paths.
+        """
+        q = query.strip().lower()
+        if not q:
+            raise StoreError("empty search query")
+        self._check_retrieval(section, scope)
+
+        archive = self.ws.config.archive_dir
+        hits: list[dict] = []
+        for rec in _common.iter_content_files(self.ws):
+            rel = rec.path.relative_to(self.ws.root)
+            if not self._in_scope(rel.parts, section, scope):
+                continue
+            text = rec.path.read_text(encoding="utf-8")
+            i = text.lower().find(q)
+            if i == -1:
+                continue
+            lo = max(0, i - SNIPPET_RADIUS)
+            hi = min(len(text), i + len(q) + SNIPPET_RADIUS)
+            hits.append({"path": rel.as_posix(), "snippet": text[lo:hi],
+                         "archived": rel.parts[0] == archive})
+            if len(hits) >= SEARCH_CAP:
+                # Say so rather than truncating silently: a capped reply that
+                # looks complete is worse than a short one that admits it.
+                hits.append({"path": "", "snippet":
+                             f"(truncated at {SEARCH_CAP} hits — "
+                             "narrow the query)"})
+                break
+        return hits
+```
+
+(The truncation sentinel keeps its exact two-key shape — spec §2: it is a notice, not a result.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestScopedSearch tests.test_store.TestSearch tests.test_store.TestOverview -v`
+Expected: all PASS (existing `TestSearch`/`TestOverview` prove no regression — their assertions are key-access/subset style and tolerate the new field).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py tests/test_store.py
+git commit -m "feat: scoped search — scope live|archive|both, archived flag (#66)"
+```
+
+(Append the `Co-Authored-By:` trailer naming the current model — here and on every commit below.)
+
+---
+
+### Task 2: Store — scoped `list_entities`
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (`list_entities:138`)
+- Test: `tests/test_store.py` (new class after `TestScopedSearch`; amend `TestListEntities.test_lists_title_and_summary:118`)
+
+**Interfaces:**
+- Consumes: `_check_retrieval`, `_in_scope`, `make_archived_ws` (Task 1, exact signatures above).
+- Produces: `WorkspaceStore.list_entities(section: str, scope: str = "both") -> list[dict]`, rows `{"path", "title", "summary", "archived"}` — Task 4's tool layer passes `scope` straight through.
+
+- [ ] **Step 1: Write the failing tests**
+
+New class after `TestScopedSearch`:
+
+```python
+class TestScopedListEntities(StoreCase):
+
+    def test_sectioned_both_lists_live_and_mirrored_archived_rows(self):
+        # #62's collision check makes archived names taken; the listing
+        # that says "what already exists" must therefore show them.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        rows = {r["path"]: r for r in store.list_entities("NPCs")}
+        self.assertEqual(set(rows), {"NPCs/kim-ha-eun.md",
+                                     "Archive/NPCs/old-hag.md"})
+        self.assertFalse(rows["NPCs/kim-ha-eun.md"]["archived"])
+        self.assertTrue(rows["Archive/NPCs/old-hag.md"]["archived"])
+        self.assertEqual(rows["Archive/NPCs/old-hag.md"]["title"],
+                         "The Old Hag")
+
+    def test_scope_live_lists_only_the_live_tree(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(
+            [r["path"] for r in store.list_entities("NPCs", scope="live")],
+            ["NPCs/kim-ha-eun.md"])
+
+    def test_scope_archive_resolves_the_mirror(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(
+            [r["path"] for r in
+             store.list_entities("NPCs", scope="archive")],
+            ["Archive/NPCs/old-hag.md"])
+
+    def test_section_archive_lists_the_whole_archive_strays_included(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(
+            {r["path"] for r in store.list_entities("Archive")},
+            {"Archive/NPCs/old-hag.md", "Archive/stray.md"})
+
+    def test_scope_live_with_section_archive_is_refused(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.list_entities("Archive", scope="live")
+        self.assertIn("contradicts", str(ctx.exception))
+
+    def test_unknown_scope_is_refused(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError):
+            store.list_entities("NPCs", scope="everything")
+```
+
+Amend the existing full-equality test (`TestListEntities.test_lists_title_and_summary`) — the row gains the always-present flag:
+
+```python
+    def test_lists_title_and_summary(self):
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertEqual(store.list_entities("NPCs"), [{
+            "path": "NPCs/kim-ha-eun.md",
+            "title": "Kim Ha-eun",
+            "summary": "Kim Ha-eun is a ferry captain in Testmere harbor.",
+            "archived": False,
+        }])
+```
+
+- [ ] **Step 2: Run to verify the new class fails**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestScopedListEntities tests.test_store.TestListEntities -v`
+Expected: `TestScopedListEntities` FAILS (`unexpected keyword argument 'scope'`; union row missing); the amended equality test FAILS (no `archived` key yet).
+
+- [ ] **Step 3: Implement**
+
+Replace `list_entities` in `_store.py`:
+
+```python
+    def list_entities(self, section: str, scope: str = "both") -> list[dict]:
+        """One section's files: workspace path, title, one-line summary,
+        and whether the file is archived.
+
+        Summaries come from front matter, where this workspace's convention
+        puts a retrievable one-sentence description — which is what makes a
+        listing useful to an agent that has not read the files.
+
+        section resolves inside the scope's tree(s) (#66): the default
+        "both" lists live and mirrored archived members together, each
+        row labelled, because archived names are still taken (#62's
+        collision check) and a listing that hides them invites reuse.
+        """
+        self._check_retrieval(section, scope)
+        archive = self.ws.config.archive_dir
+        out = []
+        for rec in _common.iter_content_files(self.ws):
+            rel = rec.path.relative_to(self.ws.root)
+            if not self._in_scope(rel.parts, section, scope):
+                continue
+            out.append({"path": rel.as_posix(),
+                        "title": rec.fm.get("title") or rec.path.stem,
+                        "summary": rec.fm.get("summary", ""),
+                        "archived": rel.parts[0] == archive})
+        return out
+```
+
+- [ ] **Step 4: Run the store suite to verify everything passes**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store -v`
+Expected: all PASS (including `TestOverview.test_archive_is_a_section_of_its_own` and `TestOverview.test_counts_agree_with_list_entities`, which exercise the old call shapes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py tests/test_store.py
+git commit -m "feat: scoped list_entities — union sections, archived flag (#66)"
+```
+
+---
+
+### Task 3: Store — `campaign_overview`'s `archive_sections`
+
+**Files:**
+- Modify: `src/bunnyforge/_store.py` (`overview:109`)
+- Test: `tests/test_store.py` (add to `TestOverview:37`)
+
+**Interfaces:**
+- Consumes: `make_archived_ws` (Task 1).
+- Produces: `overview()` result gains `"archive_sections": dict[str, int]` — present iff the archive directory exists; counts by mirror section (`parts[1]`, only when `len(parts) > 2`). Task 4's `campaign_overview` docstring names this key.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestOverview`:
+
+```python
+    def test_archive_sections_breaks_the_archive_down_by_mirror(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        ov = store.overview()
+        # The stray at Archive/stray.md is in the flat total but no
+        # breakdown entry -- the sections rule applied one level down,
+        # exactly as root docs are absent from sections.
+        self.assertEqual(ov["sections"]["Archive"], 2)
+        self.assertEqual(ov["archive_sections"], {"NPCs": 1})
+
+    def test_archive_sections_absent_without_an_archive(self):
+        # Absent, not empty: same philosophy as sections.
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertNotIn("archive_sections", store.overview())
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestOverview -v`
+Expected: the two new tests FAIL with `KeyError: 'archive_sections'` (first) — the second may pass trivially before implementation; that is fine, it pins the absence rule against regression.
+
+- [ ] **Step 3: Implement**
+
+In `overview()`, replace the counting loop and the `out` construction (the docstring, root-doc, and pending-count code are untouched):
+
+```python
+        counts: dict[str, int] = {}
+        archive_counts: dict[str, int] = {}
+        archive = cfg.archive_dir
+        for rec in _common.iter_content_files(self.ws):
+            parts = rec.path.relative_to(self.ws.root).parts
+            if len(parts) > 1:
+                counts[parts[0]] = counts.get(parts[0], 0) + 1
+            # The archive breakdown applies the sections rule one level
+            # down (#66): count the mirror when there is one. A stray at
+            # Archive/*.md stays in the flat Archive total only, as root
+            # docs are absent from sections.
+            if parts[0] == archive and len(parts) > 2:
+                archive_counts[parts[1]] = archive_counts.get(parts[1], 0) + 1
+        # Only directories that exist: a section the campaign has not created
+        # yet is absent, not empty. Reporting it as 0 would present an unused
+        # part of the layout as an emptied one.
+        sections = {d: counts.get(d, 0) for d in self._sections()
+                    if (self.ws.root / d).is_dir()}
+
+        out: dict = {"name": cfg.name, "sections": sections}
+        if (self.ws.root / archive).is_dir():
+            out["archive_sections"] = archive_counts
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_store.TestOverview -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/_store.py tests/test_store.py
+git commit -m "feat: campaign_overview archive_sections breakdown (#66)"
+```
+
+---
+
+### Task 4: serve_mcp — thread `scope`, docstring guidance
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (`campaign_overview:91`, `list_entities:103`, `search:116`)
+- Test: `tests/test_serve_mcp.py` (add to `TestBuildServer:98`)
+
+**Interfaces:**
+- Consumes: `store.search(query, section, scope)`, `store.list_entities(section, scope)` (Tasks 1–2), `overview()`'s `archive_sections` key (Task 3).
+- Produces: the MCP tool surface — `search(query, section=None, scope="both")`, `list_entities(section, scope="both")`. Docstrings are the condensed guidance (spec §4): they are part of the deliverable and of the Task 5 vocabulary read.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestBuildServer` (async, `HAVE_MCP`-gated by the class decorator; they will SKIP locally and run in CI's mcp job — verify by inspection and CI, not by forcing a local venv):
+
+```python
+    async def test_search_and_list_entities_expose_scope(self):
+        server = serve_mcp.build_server(scaffold(self))
+        tools = {t.name: t for t in await server.list_tools()}
+        for name in ("search", "list_entities"):
+            scope = tools[name].inputSchema["properties"]["scope"]
+            self.assertEqual(scope.get("default"), "both", name)
+
+    async def test_scope_guidance_reaches_the_descriptions(self):
+        # The description is the API the remote agent reads: it must name
+        # the scope choices and say the scope is the GM's call to make.
+        server = serve_mcp.build_server(scaffold(self))
+        descs = {t.name: " ".join((t.description or "").split())
+                 for t in await server.list_tools()}
+        for name in ("search", "list_entities"):
+            self.assertIn("scope", descs[name], name)
+            self.assertIn("ask", descs[name], name)
+        self.assertIn("archive_sections", descs["campaign_overview"])
+
+    async def test_search_scope_live_excludes_archived_hits(self):
+        store = scaffold(self)
+        arch = store.ws.root / "Archive" / "NPCs"
+        arch.mkdir(parents=True)
+        (arch / "old.md").write_text(
+            "---\ntitle: Old\nsummary: Retired.\n---\nShe knows the "
+            "tides.\n", encoding="utf-8")
+        server = serve_mcp.build_server(store)
+        payload = await self._text(await server.call_tool(
+            "search", {"query": "tides", "scope": "live"}))
+        self.assertIn("kim-ha-eun", payload)
+        self.assertNotIn("Archive/NPCs/old.md", payload)
+```
+
+- [ ] **Step 2: Run to verify state**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_serve_mcp.TestBuildServer -v`
+Expected locally: the three new tests report SKIP (`mcp extra not installed`). That is the environment working as documented, not a pass — correctness lands with CI's mcp job in Task 6. If your environment does have the extra: they must FAIL now (no `scope` parameter yet) and pass after Step 3.
+
+- [ ] **Step 3: Implement the tool layer**
+
+Replace the three tool definitions in `build_server`:
+
+```python
+    @server.tool()
+    def campaign_overview() -> dict:
+        """Get your bearings in one call: the campaign's name, each section
+        with how many entities it holds (the Archive count is the flat
+        total; archive_sections breaks it down by mirrored section), the
+        current front-burner and open-questions documents, and two
+        counts — drafts_pending (your own unpromoted drafts; list_drafts
+        to resume them) and inbound_pending (files in the GM's inbound
+        queue). If inbound_pending is non-zero you may mention it and
+        offer to extract; do not list or read the queue unless the GM
+        asks. Call this before anything else."""
+        return store.overview()
+
+    @server.tool()
+    def list_entities(section: str, scope: str = "both") -> list[dict]:
+        """List one section's files with titles, one-line summaries, and
+        an archived flag. section names the content section in either
+        tree: the default scope="both" lists live and archived members
+        together (section="NPCs" covers NPCs/ and Archive/NPCs/), while
+        scope="live" or scope="archive" narrows to one tree. Use it to
+        see what already exists before inventing something new —
+        archived names are still taken. For creative work the scope is
+        the GM's call: ask at task start if the request has not said
+        (the AGENTS.md doctrine resource carries the rule)."""
+        return store.list_entities(section, scope)
+
+    @server.tool()
+    def search(query: str, section: str | None = None,
+               scope: str = "both") -> list[dict]:
+        """Search the workspace for a phrase, returning each file that
+        matches, the text around the match, and an archived flag. scope
+        narrows retrieval to live canon ("live"), archived canon
+        ("archive"), or both (default — every hit is labelled). Use it
+        to check what has already been established about a name, place,
+        or idea. For creative work the scope is the GM's call: ask at
+        task start if the request has not said (the AGENTS.md doctrine
+        resource carries the rule)."""
+        return store.search(query, section, scope)
+```
+
+- [ ] **Step 4: Run the file's suite**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_serve_mcp -v`
+Expected: no failures; the `HAVE_MCP` tests skip locally (CI's mcp job runs them in Task 6's PR).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: serve-mcp threads scope; docstrings carry the scope guidance (#66)"
+```
+
+---
+
+### Task 5: Doctrine — "Retrieval scope" section, then the human vocabulary read
+
+**Files:**
+- Modify: `src/bunnyforge/data/doctrine/AGENTS.md` (insert a new `##` section between "Never invent canon", which ends at line 217, and "## Speculative material stays speculative" at line 219)
+
+No automated test asserts doctrine prose (deliberately — it is the GM's text, not the code's). The gates for this task are `test_init`'s manifest checks staying green (in-place edit, no manifest change) and the human read below.
+
+- [ ] **Step 1: Insert the doctrine section**
+
+After the "Never invent canon" bullet list (after line 217's end of section, before `## Speculative material stays speculative`), insert exactly:
+
+```markdown
+## Retrieval scope: live, archive, or both
+
+- When answering questions or reporting what is established, read live and
+  archived material freely. Results are labelled, and the rules above
+  govern presentation: the archive is never current, and where it disagrees
+  with a live file, the live file wins.
+- Creative work on canon — inventing new material, or revising it later —
+  runs under a retrieval scope I own. Drawing on retired material can be
+  deliberate (a successor, an echo) or contamination (a "new" thing that
+  quietly re-skins a retired one). Labels do not protect generation:
+  material read is material that shapes the output. Only I can tell the
+  two intents apart.
+- So at the start of a task that will create or revise canon, ask me
+  whether its retrieval should be live-only, archive-only, or both —
+  unless my request already answers it, or the work's scope is already
+  established. The scope attaches to the work and persists: picking a
+  piece back up later continues under the scope it was made with. One ask
+  per task; hold it until the task changes or I re-scope it.
+- Mechanically: over MCP, pass `scope=` to `search` and `list_entities`;
+  on the filesystem, read or skip `Archive/` accordingly.
+```
+
+- [ ] **Step 2: Verify the packaging gates**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_init tests.test_portability -v`
+Expected: all PASS (in-place edit: manifest complete both ways; no structural markers in the new prose).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/bunnyforge/data/doctrine/AGENTS.md
+git commit -m "docs: doctrine — retrieval scope is the GM's call, asked at task start (#66)"
+```
+
+- [ ] **Step 4: CHECKPOINT — human vocabulary read (blocks the PR)**
+
+Present to the GM, verbatim and in one place, every line of new prose this branch ships: the doctrine section above and the three tool docstrings from Task 4. Ask for an explicit read for campaign-specific vocabulary (setting coinages, character/place names, machine paths). **No automated check covers this** (#65 deferred; spec §7). Do not open the PR until the GM confirms the prose is clean or supplies replacements — apply any replacements and amend/commit before proceeding.
+
+---
+
+### Task 6: Full verification and PR
+
+**Files:** none new — verification and delivery.
+
+- [ ] **Step 1: Full suite from the worktree**
+
+```bash
+PYTHONPATH=src python3 -c "import bunnyforge; print(bunnyforge.__file__)"
+PYTHONPATH=src python3 -m unittest discover -s tests -t .
+```
+Expected: the import path is inside THIS worktree; suite reports `OK` — baseline was `Ran 901 tests … OK (skipped=54)`, now more tests, same skip count.
+
+- [ ] **Step 2: Fresh-workspace gate**
+
+```bash
+GATE=$(mktemp -d)
+PYTHONPATH=src python3 -m bunnyforge init "$GATE/demo" --name Demo
+PYTHONPATH=src python3 -m bunnyforge review checkup --workspace "$GATE/demo"
+```
+Expected: `Summary: 0 error(s), 0 warning(s)`.
+
+- [ ] **Step 3: Repo hygiene**
+
+```bash
+git -C . status --porcelain
+```
+Expected: empty (no test wrote into the repo; nothing uncommitted).
+
+- [ ] **Step 4: Push and open the PR**
+
+Scan the outgoing diff for secrets if the gitleaks pre-push hook is unavailable. Then push the branch and open a PR against `main` **using the `dcltdw:opening-a-pr` skill** (required by the collaboration rules). The PR body must:
+- link issue #66 and the spec (`docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md`);
+- state the #62-record revision (sectioned default listings now include labelled archived rows) so the reviewer sees it was deliberate;
+- record that the Task 5 human vocabulary read happened and what it covered.
+
+Wait for four green checks and the GM's approval — do not merge unprompted. On merge, use `dcltdw:cleaning-up-after-pr-merge`.

--- a/docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md
+++ b/docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md
@@ -1,0 +1,268 @@
+# Scoped retrieval: live vs Archive/ — design
+
+**Date:** 2026-08-18
+**Issue:** https://github.com/dcltdw/bunnyforge/issues/66
+**Status:** approved design, awaiting implementation plan
+**Depends on:** #62 (landed as PR #67) — `Archive/` is ordinary walked canon,
+mirrored section layout, walked by `iter_content_files` and served by every
+MCP retrieval tool.
+
+## The problem
+
+With #62 landed, `search` and `list_entities` return live and archived
+material together, distinguishable only by the `Archive/` path prefix. That
+is the right *default* — the uniform behavior is a decision of record — but
+it leaves the retrieval ergonomics unaddressed. The ticket names three use
+cases:
+
+1. **Generating a new story about a new place.** Archived material can
+   contaminate the invention even when labelled: material read is material
+   that shapes the output. This case wants archive material *absent at
+   retrieval time*, not merely marked.
+2. **Brainstorming about an established place or character.** The historical
+   context is exactly what is wanted: archive-only, or both.
+3. **New story in an established space.** Current player perceptions *and*
+   the history of the last visit — two deliberate retrievals, composed.
+
+Between design and this spec, use case 1 sharpened into something better
+(§4): whether new invention draws on history is a *choice the GM owns*, not
+a rule the tooling can hard-code — a successor faction rising from a retired
+one's ashes is deliberate; a "new" place that quietly re-skins a retired one
+is contamination. Same retrieval, opposite intent, and only the GM can tell
+them apart.
+
+## Decisions record
+
+Settled on the ticket and in brainstorming with the GM, 2026-08-18:
+
+| question | decision |
+|---|---|
+| Default scope | The union of live and archive — the uniform behavior #62 ships stays the default (ticket record). |
+| Scope token names | `live` \| `archive` \| `both`. `both` rather than `all`: the domain has exactly two trees, and #62's `_`-means-not-canon design makes that structural (there is live canon and there is `Archive/`; a third tree has nowhere to come from). |
+| Self-aware results | Every search hit and listing row carries `archived: true|false` — always present, never inferred from the path (ticket record). |
+| scope × section | **Scope-resolved**: `section` resolves inside the chosen scope's tree. Under `scope="archive"`, `section="NPCs"` means `Archive/NPCs/`. Under the default `scope="both"`, `section` keeps today's top-level meaning exactly — every existing call is backward-identical. |
+| The asymmetry | Accepted and documented: `scope="both"` + `section="NPCs"` returns live NPCs only (today's behavior), not the union of the live and archive resolutions. Backward-identical defaults are what it buys. |
+| `campaign_overview` | Additive only: `sections` keeps its exact shape; a new `archive_sections` key breaks the archive down by mirror section. |
+| Guidance home | Doctrine as primary (packaged `AGENTS.md`), tool descriptions carry the condensed form and point at the doctrine resource. |
+| What the doctrine says | Not a use-case→scope mapping. **Scope is the GM's call, asked once at task start** (§4). |
+| Revisions | No new-vs-revision carve-out. The scope attaches to the *work*, not the tool or the conversation: revising a piece later is the same creative task resumed, under the scope that governed its creation. |
+| CLI surfaces | No change. `review` must validate all canon; exports follow visibility rules uniformly (#62); the GM has the filesystem. |
+| Sequencing | #68 lands first, then #66; one release carries #62 + #68 + #66. Nothing released has seen #62's intermediate MCP behavior, so additive shape choices here are externally invisible until that release. |
+| Generalization | The task-start ask is the first instance of a broader "establish context before work begins" doctrine — filed as #70, out of scope here. |
+
+## Design
+
+### 1. Parameter shape and semantics
+
+`search` and `list_entities` gain `scope: str = "both"`. Valid values
+`"live"`, `"archive"`, `"both"`; anything else is a `StoreError` naming the
+valid values. A file is *archived* iff its first workspace-relative path
+component equals `config.archive_dir`.
+
+New signatures:
+
+```python
+def search(self, query: str, section: str | None = None,
+           scope: str = "both") -> list[dict]: ...
+def list_entities(self, section: str, scope: str = "both") -> list[dict]: ...
+```
+
+Semantics, by scope:
+
+- **`both`** (default): today's behavior verbatim. `section` names the
+  top-level directory; `Archive` is its own section (#62's record — live
+  section listings stay uninflated). The only observable change is the new
+  `archived` field on results (§2).
+- **`live`**: archived files are excluded from the walk's results. `section`
+  keeps its top-level meaning. Root docs are live and stay included in
+  unsectioned search. `section="Archive"` + `scope="live"` is a
+  contradiction and is refused with a `StoreError` that names the working
+  alternatives (drop the section, or use `scope="archive"`).
+- **`archive`**: archived files only, and `section` resolves *inside* the
+  archive tree by mirror: `section="NPCs"` matches `Archive/NPCs/*` (first
+  component is the archive dir, second is the section); `section=None` or
+  `section="Archive"` means the whole archive. Section validation is
+  unchanged (`_check_section`; unknown sections get the existing error).
+  Files directly at `Archive/*.md` (no mirror) appear in whole-archive
+  queries and in no mirror section — consistent with #62's
+  default-to-entity handling of strays: visible, never a silent hole.
+
+Untouched surfaces: `read_entity` (path-addressed; the caller knows what it
+asked for), `generate_names`, the drafts and inbound families, and the write
+side — `propose_revision`/`write_entity` keep accepting archive paths, which
+are ordinary canon (#62).
+
+### 2. Self-aware results
+
+Every `list_entities` row and every `search` hit gains
+`"archived": true|false`, computed from the first path component, present on
+every element — so an agent buckets results without path parsing. The
+search-truncation sentinel row (`{"path": "", "snippet": "(truncated …)"}`)
+is a notice, not a result, and is unchanged. Draft and inbound listings are
+not canon and get no marker.
+
+Adding a key to result dicts is additive; nothing released consumes these
+shapes yet (see sequencing decision).
+
+### 3. `campaign_overview`
+
+`sections` keeps its exact current shape: live top-level counts plus the
+flat `Archive` total. One new key:
+
+- `archive_sections`: counts of archived files by mirror section, using the
+  same counting rule one level down — count `parts[1]` when
+  `len(parts) > 2`. `Archive/NPCs/old-hag.md` counts under `"NPCs"`; a stray
+  `Archive/x.md` is in the `Archive` total but no breakdown entry, exactly
+  symmetric with how root docs are absent from `sections` today.
+- Existence rule mirrors `sections`: the key is present only when the
+  archive directory exists. A campaign that has never retired anything sees
+  no `archive_sections`, absent-not-empty, the same philosophy the
+  `sections` comment already records.
+
+### 4. Guidance: scope is the GM's call, asked at task start
+
+**Doctrine (primary home).** A short subsection in packaged
+`data/doctrine/AGENTS.md`, adjacent to the existing "Do not present
+`Archive/` material as current" bullet, in the doctrine's first-person GM
+voice. Draft text — final wording at implementation, subject to the human
+vocabulary read (§7):
+
+> ### Retrieval scope: live, archive, or both
+>
+> - When answering questions or reporting what is established, read live
+>   and archived material freely. Results are labelled, and the rules above
+>   govern presentation: the archive is never current, and where it
+>   disagrees with a live file, the live file wins.
+> - Creative work on canon — inventing new material, or revising it later —
+>   runs under a retrieval scope I own. Drawing on retired material can be
+>   deliberate (a successor, an echo) or contamination (a "new" thing that
+>   quietly re-skins a retired one). Labels do not protect generation:
+>   material read is material that shapes the output. Only I can tell the
+>   two intents apart.
+> - So at the start of a task that will create or revise canon, ask me
+>   whether its retrieval should be live-only, archive-only, or both —
+>   unless my request already answers it, or the work's scope is already
+>   established. The scope attaches to the work and persists: picking a
+>   piece back up later continues under the scope it was made with. One ask
+>   per task; hold it until the task changes or I re-scope it.
+> - Mechanically: over MCP, pass `scope=` to `search` and `list_entities`;
+>   on the filesystem, read or skip `Archive/` accordingly.
+
+This governs filesystem agents (who never see MCP tool descriptions) as
+well as the MCP surface, which is why the doctrine is the primary home. The
+hand-reconcile cost to live campaigns is accepted: this release already
+carries #62's edits to the same doctrine passages, so campaigns hand-diff
+that region of `AGENTS.md` once either way.
+
+**Tool descriptions (condensed form).** `search` and `list_entities`
+docstrings gain roughly: *scope narrows retrieval to live canon only
+(`"live"`), archived canon only (`"archive"`), or both (default; every
+result is labelled `archived`). Under `scope="archive"`, `section` names
+the mirrored section inside the archive (`section="NPCs"` →
+`Archive/NPCs/`). When gathering material for creative work, the scope is
+the GM's call — ask at task start if the request hasn't said. The AGENTS.md
+doctrine resource carries the full rule.* `campaign_overview`'s description
+mentions `archive_sections`. Final wording at implementation; also subject
+to the human vocabulary read.
+
+### 5. CLI surfaces: no change
+
+Recorded as a decision, no code. `review`/checkup must validate *all*
+canon — a scope parameter there would weaken the validator. Exports follow
+per-file visibility rules uniformly, archive included (#62's decision). The
+GM browsing history has the filesystem, where #62's layout (`Archive/` as a
+plain mirrored tree) is already the ergonomic answer.
+
+### 6. Implementation shape
+
+All filtering lives in `_store.py`; `serve_mcp.py` only threads the new
+parameter through the tool signatures and updates docstrings.
+
+- One scope validator (valid-token check) and one match predicate shared by
+  `search` and `list_entities`, so the two tools cannot drift: given a
+  workspace-relative path's parts, the configured archive dir, a section,
+  and a scope, decide membership. The contradiction refusal
+  (`live` + `Archive`) lives beside the validator.
+- `archived` computed in the same place membership is decided.
+- `overview()` grows the `archive_sections` tally inside its existing
+  single walk.
+- No config changes, no new packaged files (`init.MANIFEST` untouched — the
+  doctrine edit is in-place), no new dependencies, stdlib only.
+
+### 7. Review step: human read for campaign vocabulary
+
+With #65 deferred, **no automated check in either repo scans packaged prose
+for campaign-specific vocabulary** (the campaign-side term guard's scan
+roots all left at the switchover; it scans zero bytes). Every line of prose
+this ticket ships into `src/bunnyforge/data/` — the doctrine subsection —
+and, for the same reason, the new tool-description text, needs a deliberate
+human read for setting coinages before merge. This is an explicit step in
+the implementation plan and the PR checklist, not an assumption that a test
+covers it.
+
+### 8. Testing (contours; the plan makes these concrete)
+
+- **Store, `search`:** live/archive/both × sectioned/unsectioned; archived
+  hits excluded under `live`; mirror resolution under `archive`
+  (`section="NPCs"` → `Archive/NPCs/` only); `section="Archive"` under
+  `archive` equals unsectioned `archive`; strays at `Archive/*.md` visible
+  in whole-archive queries; contradiction and bad-token refusals; `both`
+  backward-identical to today plus the `archived` field; sentinel row
+  unchanged; root docs present under `live`.
+- **Store, `list_entities`:** the same matrix; `archived` present and
+  correct on every row.
+- **Store, `overview`:** `archive_sections` counts by mirror; stray files
+  counted in the `Archive` total but no breakdown entry; key absent when no
+  archive dir exists; `sections` byte-identical to today.
+- **serve_mcp:** tool signatures expose `scope` with default `"both"`;
+  docstrings mention the scope guidance (the existing suite's
+  description-surface tests extend, if present).
+- **Gate:** `bunnyforge init` → `bunnyforge review checkup` reports
+  `Summary: 0 error(s), 0 warning(s)` unchanged.
+- All tests scaffold into `tempfile.TemporaryDirectory()`; nothing writes
+  into the repo (CI enforces this).
+
+## Alternatives rejected
+
+- **Orthogonal filters** (`section` keeps top-level meaning under every
+  scope; `section="NPCs"` + `scope="archive"` refused as empty-by-
+  construction): simplest and fully backward-compatible, but makes
+  "archived NPCs" inexpressible as a filter — the mirror layout exists
+  precisely to keep that addressable.
+- **Mirror-section semantics everywhere** (archived files match both
+  `Archive` and their mirror section under every scope): conceptually
+  uniform, but sectioned listings under the default scope would include
+  archived rows — revising #62's "live section listings stay uninflated"
+  record for no gain the scope-resolved shape doesn't already provide.
+- **`all` as the union token:** invites "all of what?"; with exactly two
+  structurally-guaranteed trees, `both` says it.
+- **Per-section live/archived count pairs in `overview`** (restructuring
+  `sections` values into `{"live": n, "archived": m}`): most informative,
+  but changes the type of an existing key when an additive sibling carries
+  the same information.
+- **A hard use-case→scope mapping in doctrine** ("generation ⇒ live-only"):
+  the first design draft, revised away — history-informed invention is
+  legitimate and deliberate; the mapping would forbid it. The ask-the-GM
+  rule routes the decision to the only party who can make it.
+- **Tool descriptions only / one doctrine sentence:** zero-to-minimal
+  reconcile cost, but filesystem agents — the campaign repo's primary
+  consumers — never see tool descriptions, and the ask-at-task-start rule
+  governs them equally.
+- **Recording a work's scope in draft front matter:** rejected as scope
+  creep; the mechanism is the ask, and "same as when we made it" is a
+  complete answer from the GM.
+
+## Out of scope — deliberately
+
+- **#70 — task-start context questions as a general doctrine.** The scope
+  ask ships here as doctrine because #66 needs it; #70 designs the
+  framework it folds into (what are we building; new NPCs or reused; the
+  question list improving itself).
+- **CLI scoping** for `review` and exports (§5 — a decision, not a
+  deferral).
+- **#65** (campaign-term guard over packaged data): deferred on its own
+  ticket; §7 is this design's inherited mitigation.
+- **The release and the live campaign's migration** (Anjeong pins a
+  published version; migrates after the release carrying #62 + #68 + #66).
+- **Any change to `read_entity`, the drafts/inbound families, or the write
+  side.**

--- a/docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md
+++ b/docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md
@@ -40,8 +40,9 @@ Settled on the ticket and in brainstorming with the GM, 2026-08-18:
 | Default scope | The union of live and archive — the uniform behavior #62 ships stays the default (ticket record). |
 | Scope token names | `live` \| `archive` \| `both`. `both` rather than `all`: the domain has exactly two trees, and #62's `_`-means-not-canon design makes that structural (there is live canon and there is `Archive/`; a third tree has nowhere to come from). |
 | Self-aware results | Every search hit and listing row carries `archived: true|false` — always present, never inferred from the path (ticket record). |
-| scope × section | **Scope-resolved**: `section` resolves inside the chosen scope's tree. Under `scope="archive"`, `section="NPCs"` means `Archive/NPCs/`. Under the default `scope="both"`, `section` keeps today's top-level meaning exactly — every existing call is backward-identical. |
-| The asymmetry | Accepted and documented: `scope="both"` + `section="NPCs"` returns live NPCs only (today's behavior), not the union of the live and archive resolutions. Backward-identical defaults are what it buys. |
+| scope × section | **Scope-resolved, symmetric**: `section` names the content section and resolves inside the chosen scope's tree(s). `scope="archive"` + `section="NPCs"` means `Archive/NPCs/`; `scope="both"` (the default) is the union — `NPCs/` ∪ `Archive/NPCs/`, every row labelled. Amended 2026-08-18 during spec review: the first draft kept sectioned `both` backward-identical (live rows only), rejected as a trap — an explicit "both" must mean both. |
+| #62's listings record | Revised with eyes open: sectioned listings under the default scope now include archived rows. Rows are labelled `archived`, `campaign_overview` takes no scope so its counts keep #62's honest top-level meaning, and #62's collision check makes archived names *taken* — a listing that hides them hides exactly the names an agent must not reuse. |
+| `section="Archive"` | Stays a valid section token, denoting the archive tree: whole archive under `archive` and `both`; refused as a contradiction under `live`. |
 | `campaign_overview` | Additive only: `sections` keeps its exact shape; a new `archive_sections` key breaks the archive down by mirror section. |
 | Guidance home | Doctrine as primary (packaged `AGENTS.md`), tool descriptions carry the condensed form and point at the doctrine resource. |
 | What the doctrine says | Not a use-case→scope mapping. **Scope is the GM's call, asked once at task start** (§4). |
@@ -67,25 +68,36 @@ def search(self, query: str, section: str | None = None,
 def list_entities(self, section: str, scope: str = "both") -> list[dict]: ...
 ```
 
+`section` names the *content* section and resolves inside the chosen
+scope's tree(s): a live file is in section `X` when its first path
+component is `X`; an archived file is in section `X` when its mirror is
+(`Archive/X/…`). `section="Archive"` denotes the archive tree itself.
+Section validation is unchanged (`_check_section`; unknown sections get
+the existing error).
+
 Semantics, by scope:
 
-- **`both`** (default): today's behavior verbatim. `section` names the
-  top-level directory; `Archive` is its own section (#62's record — live
-  section listings stay uninflated). The only observable change is the new
-  `archived` field on results (§2).
-- **`live`**: archived files are excluded from the walk's results. `section`
-  keeps its top-level meaning. Root docs are live and stay included in
-  unsectioned search. `section="Archive"` + `scope="live"` is a
-  contradiction and is refused with a `StoreError` that names the working
-  alternatives (drop the section, or use `scope="archive"`).
-- **`archive`**: archived files only, and `section` resolves *inside* the
-  archive tree by mirror: `section="NPCs"` matches `Archive/NPCs/*` (first
-  component is the archive dir, second is the section); `section=None` or
-  `section="Archive"` means the whole archive. Section validation is
-  unchanged (`_check_section`; unknown sections get the existing error).
-  Files directly at `Archive/*.md` (no mirror) appear in whole-archive
-  queries and in no mirror section — consistent with #62's
-  default-to-entity handling of strays: visible, never a silent hole.
+- **`both`** (default): the union of the two scopes below. Unsectioned
+  calls behave as today — everything, now labelled (§2). Sectioned calls
+  return live *and* mirrored archived members: `section="NPCs"` →
+  `NPCs/` ∪ `Archive/NPCs/`, each row marked. `section="Archive"` → the
+  whole archive.
+- **`live`**: archived files excluded; `section` matches the top level.
+  Root docs are live and stay included in unsectioned search.
+  `section="Archive"` + `scope="live"` is a contradiction and is refused
+  with a `StoreError` that names the working alternatives (drop the
+  section, or use `scope="archive"`).
+- **`archive`**: archived files only: `section="NPCs"` matches
+  `Archive/NPCs/*`; `section=None` or `section="Archive"` means the whole
+  archive. Files directly at `Archive/*.md` (no mirror) appear in
+  whole-archive and unsectioned-`both` queries and in no mirror section —
+  consistent with #62's default-to-entity handling of strays: visible,
+  never a silent hole.
+
+The behavior change vs #62-as-landed is confined to sectioned queries
+under the default scope, which now include labelled archived rows; that
+revision is recorded in the decisions table, and nothing released has
+seen the intermediate behavior.
 
 Untouched surfaces: `read_entity` (path-addressed; the caller knows what it
 asked for), `generate_names`, the drafts and inbound families, and the write
@@ -106,8 +118,10 @@ shapes yet (see sequencing decision).
 
 ### 3. `campaign_overview`
 
-`sections` keeps its exact current shape: live top-level counts plus the
-flat `Archive` total. One new key:
+`campaign_overview` takes no scope, and `sections` keeps its exact current
+shape: live top-level counts plus the flat `Archive` total — the counts
+stay honest by top-level location, which is where #62's uninflation record
+now lives. One new key:
 
 - `archive_sections`: counts of archived files by mirror section, using the
   same counting rule one level down — count `parts[1]` when
@@ -157,11 +171,12 @@ that region of `AGENTS.md` once either way.
 **Tool descriptions (condensed form).** `search` and `list_entities`
 docstrings gain roughly: *scope narrows retrieval to live canon only
 (`"live"`), archived canon only (`"archive"`), or both (default; every
-result is labelled `archived`). Under `scope="archive"`, `section` names
-the mirrored section inside the archive (`section="NPCs"` →
-`Archive/NPCs/`). When gathering material for creative work, the scope is
-the GM's call — ask at task start if the request hasn't said. The AGENTS.md
-doctrine resource carries the full rule.* `campaign_overview`'s description
+result is labelled `archived`). `section` names the content section in
+either tree: `section="NPCs"` covers `NPCs/` and `Archive/NPCs/` under the
+default, only one of them under a narrowed scope. When gathering material
+for creative work, the scope is the GM's call — ask at task start if the
+request hasn't said. The AGENTS.md doctrine resource carries the full
+rule.* `campaign_overview`'s description
 mentions `archive_sections`. Final wording at implementation; also subject
 to the human vocabulary read.
 
@@ -204,13 +219,17 @@ covers it.
 
 - **Store, `search`:** live/archive/both × sectioned/unsectioned; archived
   hits excluded under `live`; mirror resolution under `archive`
-  (`section="NPCs"` → `Archive/NPCs/` only); `section="Archive"` under
-  `archive` equals unsectioned `archive`; strays at `Archive/*.md` visible
-  in whole-archive queries; contradiction and bad-token refusals; `both`
-  backward-identical to today plus the `archived` field; sentinel row
-  unchanged; root docs present under `live`.
-- **Store, `list_entities`:** the same matrix; `archived` present and
-  correct on every row.
+  (`section="NPCs"` → `Archive/NPCs/` only); sectioned `both` is the
+  union (`section="NPCs"` finds hits in `NPCs/` *and* `Archive/NPCs/`,
+  correctly labelled); `section="Archive"` under `archive` and `both`
+  equals unsectioned `archive`; unsectioned `both` behaves as today plus
+  the `archived` field; strays at `Archive/*.md` visible in whole-archive
+  and unsectioned-`both` queries but no mirror section; contradiction and
+  bad-token refusals; sentinel row unchanged; root docs present under
+  `live`.
+- **Store, `list_entities`:** the same matrix — in particular
+  `list_entities("NPCs")` includes `Archive/NPCs/` rows marked
+  `archived: true`; `archived` present and correct on every row.
 - **Store, `overview`:** `archive_sections` counts by mirror; stray files
   counted in the `Archive` total but no breakdown entry; key absent when no
   archive dir exists; `sections` byte-identical to today.
@@ -229,11 +248,13 @@ covers it.
   construction): simplest and fully backward-compatible, but makes
   "archived NPCs" inexpressible as a filter — the mirror layout exists
   precisely to keep that addressable.
-- **Mirror-section semantics everywhere** (archived files match both
-  `Archive` and their mirror section under every scope): conceptually
-  uniform, but sectioned listings under the default scope would include
-  archived rows — revising #62's "live section listings stay uninflated"
-  record for no gain the scope-resolved shape doesn't already provide.
+- **Asymmetric scope-resolution** (the first draft of this spec: mirror
+  resolution only under `scope="archive"`, sectioned `both` stays
+  backward-identical, returning live rows only): rejected on review — an
+  explicit `scope="both"` that does not mean both is a trap, the
+  backward-compat it bought was internal-only (nothing released has seen
+  #62's behavior), and hiding archived rows from sectioned listings hides
+  exactly the names #62's collision check makes unavailable for reuse.
 - **`all` as the union token:** invites "all of what?"; with exactly two
   structurally-guaranteed trees, `both` says it.
 - **Per-section live/archived count pairs in `overview`** (restructuring

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -180,22 +180,30 @@ class WorkspaceStore:
         out["drafts_pending"] = len(self.list_drafts())
         return out
 
-    def list_entities(self, section: str) -> list[dict]:
-        """One section's files: workspace path, title, one-line summary.
+    def list_entities(self, section: str, scope: str = "both") -> list[dict]:
+        """One section's files: workspace path, title, one-line summary,
+        and whether the file is archived.
 
         Summaries come from front matter, where this workspace's convention
         puts a retrievable one-sentence description — which is what makes a
         listing useful to an agent that has not read the files.
+
+        section resolves inside the scope's tree(s) (#66): the default
+        "both" lists live and mirrored archived members together, each
+        row labelled, because archived names are still taken (#62's
+        collision check) and a listing that hides them invites reuse.
         """
-        self._check_section(section)
+        self._check_retrieval(section, scope)
+        archive = self.ws.config.archive_dir
         out = []
         for rec in _common.iter_content_files(self.ws):
             rel = rec.path.relative_to(self.ws.root)
-            if rel.parts[0] != section:
+            if not self._in_scope(rel.parts, section, scope):
                 continue
             out.append({"path": rel.as_posix(),
                         "title": rec.fm.get("title") or rec.path.stem,
-                        "summary": rec.fm.get("summary", "")})
+                        "summary": rec.fm.get("summary", ""),
+                        "archived": rel.parts[0] == archive})
         return out
 
     def read_entity(self, path: str) -> str:

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -159,10 +159,18 @@ class WorkspaceStore:
         # the list it promises cannot disagree. A bare rglob would include
         # files inside excluded subdirectories that list_entities omits.
         counts: dict[str, int] = {}
+        archive_counts: dict[str, int] = {}
+        archive = cfg.archive_dir
         for rec in _common.iter_content_files(self.ws):
             parts = rec.path.relative_to(self.ws.root).parts
             if len(parts) > 1:
                 counts[parts[0]] = counts.get(parts[0], 0) + 1
+            # The archive breakdown applies the sections rule one level
+            # down (#66): count the mirror when there is one. A stray at
+            # Archive/*.md stays in the flat Archive total only, as root
+            # docs are absent from sections.
+            if parts[0] == archive and len(parts) > 2:
+                archive_counts[parts[1]] = archive_counts.get(parts[1], 0) + 1
         # Only directories that exist: a section the campaign has not created
         # yet is absent, not empty. Reporting it as 0 would present an unused
         # part of the layout as an emptied one.
@@ -178,6 +186,8 @@ class WorkspaceStore:
         # non-empty and offer to extract, without reading it unbidden.
         out["inbound_pending"] = len(self.list_inbound())
         out["drafts_pending"] = len(self.list_drafts())
+        if (self.ws.root / archive).is_dir():
+            out["archive_sections"] = archive_counts
         return out
 
     def list_entities(self, section: str, scope: str = "both") -> list[dict]:

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -33,6 +33,8 @@ from bunnyforge._config import Workspace
 SEARCH_CAP = 50       # hits per search reply; the reply says when it truncated
 SNIPPET_RADIUS = 80   # characters of context on each side of a match
 NAME_COUNT_CAP = 50   # names per request; a brainstorm needs a handful, not a page
+SCOPES = ("live", "archive", "both")  # exactly two trees exist (#62), so
+                                      # "both" is the honest union token
 
 # Draft names become filenames. No path separators, no leading dot or
 # underscore (dot-files hide; the _-prefix is the workspace's own marker
@@ -75,6 +77,49 @@ class WorkspaceStore:
         if section not in self._sections():
             raise StoreError(f"unknown section {section!r} — one of: "
                              + ", ".join(self._sections()))
+
+    def _check_retrieval(self, section: str | None, scope: str) -> None:
+        """Validate a search/list_entities filter pair before any walk.
+
+        scope names which tree(s) to read. One combination is a
+        contradiction rather than an empty answer -- the archive
+        section under a scope that excludes archived files -- and a
+        contradiction is refused, not served (#66).
+        """
+        if scope not in SCOPES:
+            raise StoreError(f"unknown scope {scope!r} — one of: "
+                             + ", ".join(SCOPES))
+        if section is not None:
+            self._check_section(section)
+            if scope == "live" and section == self.ws.config.archive_dir:
+                raise StoreError(
+                    f"section {section!r} contradicts scope 'live': "
+                    "archived files are exactly what it excludes — drop "
+                    "the section, or use scope 'archive'")
+
+    def _in_scope(self, parts: tuple[str, ...], section: str | None,
+                  scope: str) -> bool:
+        """One walked file's membership under a validated filter (#66).
+
+        A file is archived iff its first component is the archive dir.
+        section names the CONTENT section and resolves inside the
+        scope's tree(s): live files match on parts[0], archived files
+        on their mirror (parts[1]); the archive dir's own name denotes
+        the archive tree. A stray directly at Archive/*.md has no
+        mirror, so it matches whole-archive queries and no section.
+        """
+        archive = self.ws.config.archive_dir
+        archived = parts[0] == archive
+        if (scope == "live" and archived) or \
+                (scope == "archive" and not archived):
+            return False
+        if section is None:
+            return True
+        if section == archive:
+            return archived
+        if archived:
+            return len(parts) > 2 and parts[1] == section
+        return parts[0] == section
 
     def _canonical(self, path: str) -> Path:
         """Resolve a workspace-relative path, refusing what is not canon.
@@ -160,23 +205,28 @@ class WorkspaceStore:
             raise StoreError(f"no such file: {path}")
         return p.read_text(encoding="utf-8")
 
-    def search(self, query: str, section: str | None = None) -> list[dict]:
+    def search(self, query: str, section: str | None = None,
+               scope: str = "both") -> list[dict]:
         """Case-insensitive substring search across content files.
 
         Deliberately literal rather than clever: an agent that can see the
         matched text decides relevance better than a ranking heuristic
         would, and a substring match is explainable when it surprises.
+
+        scope and section resolve per _in_scope (#66); every hit says
+        whether it is archived, so the caller buckets hits without
+        parsing paths.
         """
         q = query.strip().lower()
         if not q:
             raise StoreError("empty search query")
-        if section is not None:
-            self._check_section(section)
+        self._check_retrieval(section, scope)
 
+        archive = self.ws.config.archive_dir
         hits: list[dict] = []
         for rec in _common.iter_content_files(self.ws):
-            rel = rec.path.relative_to(self.ws.root).as_posix()
-            if section is not None and not rel.startswith(section + "/"):
+            rel = rec.path.relative_to(self.ws.root)
+            if not self._in_scope(rel.parts, section, scope):
                 continue
             text = rec.path.read_text(encoding="utf-8")
             i = text.lower().find(q)
@@ -184,7 +234,8 @@ class WorkspaceStore:
                 continue
             lo = max(0, i - SNIPPET_RADIUS)
             hi = min(len(text), i + len(q) + SNIPPET_RADIUS)
-            hits.append({"path": rel, "snippet": text[lo:hi]})
+            hits.append({"path": rel.as_posix(), "snippet": text[lo:hi],
+                         "archived": rel.parts[0] == archive})
             if len(hits) >= SEARCH_CAP:
                 # Say so rather than truncating silently: a capped reply that
                 # looks complete is worse than a short one that admits it.

--- a/src/bunnyforge/_store.py
+++ b/src/bunnyforge/_store.py
@@ -97,11 +97,17 @@ class WorkspaceStore:
                     "archived files are exactly what it excludes — drop "
                     "the section, or use scope 'archive'")
 
+    def _is_archived(self, parts: tuple[str, ...]) -> bool:
+        """A walked file's parts are archived iff its first component is
+        the archive dir (#66) -- the one definition of "archived", shared
+        by the membership predicate below and every result row that
+        carries the flag."""
+        return parts[0] == self.ws.config.archive_dir
+
     def _in_scope(self, parts: tuple[str, ...], section: str | None,
                   scope: str) -> bool:
         """One walked file's membership under a validated filter (#66).
 
-        A file is archived iff its first component is the archive dir.
         section names the CONTENT section and resolves inside the
         scope's tree(s): live files match on parts[0], archived files
         on their mirror (parts[1]); the archive dir's own name denotes
@@ -109,7 +115,7 @@ class WorkspaceStore:
         mirror, so it matches whole-archive queries and no section.
         """
         archive = self.ws.config.archive_dir
-        archived = parts[0] == archive
+        archived = self._is_archived(parts)
         if (scope == "live" and archived) or \
                 (scope == "archive" and not archived):
             return False
@@ -155,9 +161,15 @@ class WorkspaceStore:
         """One call to orient a fresh conversation: what this campaign is,
         what it holds, and what is currently live."""
         cfg = self.ws.config
-        # Counted from the same walk list_entities uses, so a count here and
-        # the list it promises cannot disagree. A bare rglob would include
-        # files inside excluded subdirectories that list_entities omits.
+        # Counted from the same walk list_entities uses, so a file inside an
+        # excluded subdirectory cannot be counted here and omitted there (a
+        # bare rglob would let the two drift). The counts are by top-level
+        # location, not by scope, so what actually holds is narrower than
+        # "agrees with list_entities": sections[X] == len(list_entities(X,
+        # scope="live")) for a live section X, and sections["Archive"] ==
+        # len(list_entities("Archive")) -- a live section's count excludes
+        # its archived mirror, which the default scope="both" would include
+        # (#66).
         counts: dict[str, int] = {}
         archive_counts: dict[str, int] = {}
         archive = cfg.archive_dir
@@ -178,6 +190,8 @@ class WorkspaceStore:
                     if (self.ws.root / d).is_dir()}
 
         out: dict = {"name": cfg.name, "sections": sections}
+        if (self.ws.root / archive).is_dir():
+            out["archive_sections"] = archive_counts
         for key, fname in (("front_burner", "front-burner.md"),
                            ("open_questions", "open-questions.md")):
             p = self.ws.root / fname
@@ -186,8 +200,6 @@ class WorkspaceStore:
         # non-empty and offer to extract, without reading it unbidden.
         out["inbound_pending"] = len(self.list_inbound())
         out["drafts_pending"] = len(self.list_drafts())
-        if (self.ws.root / archive).is_dir():
-            out["archive_sections"] = archive_counts
         return out
 
     def list_entities(self, section: str, scope: str = "both") -> list[dict]:
@@ -204,7 +216,6 @@ class WorkspaceStore:
         collision check) and a listing that hides them invites reuse.
         """
         self._check_retrieval(section, scope)
-        archive = self.ws.config.archive_dir
         out = []
         for rec in _common.iter_content_files(self.ws):
             rel = rec.path.relative_to(self.ws.root)
@@ -213,7 +224,7 @@ class WorkspaceStore:
             out.append({"path": rel.as_posix(),
                         "title": rec.fm.get("title") or rec.path.stem,
                         "summary": rec.fm.get("summary", ""),
-                        "archived": rel.parts[0] == archive})
+                        "archived": self._is_archived(rel.parts)})
         return out
 
     def read_entity(self, path: str) -> str:
@@ -240,7 +251,6 @@ class WorkspaceStore:
             raise StoreError("empty search query")
         self._check_retrieval(section, scope)
 
-        archive = self.ws.config.archive_dir
         hits: list[dict] = []
         for rec in _common.iter_content_files(self.ws):
             rel = rec.path.relative_to(self.ws.root)
@@ -253,13 +263,17 @@ class WorkspaceStore:
             lo = max(0, i - SNIPPET_RADIUS)
             hi = min(len(text), i + len(q) + SNIPPET_RADIUS)
             hits.append({"path": rel.as_posix(), "snippet": text[lo:hi],
-                         "archived": rel.parts[0] == archive})
+                         "archived": self._is_archived(rel.parts)})
             if len(hits) >= SEARCH_CAP:
                 # Say so rather than truncating silently: a capped reply that
                 # looks complete is worse than a short one that admits it.
+                # Archived hits sort first (#66), so a large archive can
+                # fill the cap before any live hit is seen -- name the
+                # scope that actually works around it, not just "narrow".
                 hits.append({"path": "", "snippet":
-                             f"(truncated at {SEARCH_CAP} hits — "
-                             "narrow the query)"})
+                             f"(truncated at {SEARCH_CAP} hits — narrow "
+                             "the query, or pass scope='live' to exclude "
+                             "archived material)"})
                 break
         return hits
 

--- a/src/bunnyforge/data/doctrine/AGENTS.md
+++ b/src/bunnyforge/data/doctrine/AGENTS.md
@@ -216,6 +216,27 @@ include the separator, even if the GM notes section is empty. A handout is a
   draft I delete it or move it to `_AgentDrafts/_Rejected/`, which is
   never read, like `_Ignore/`.
 
+## Retrieval scope: live, archive, or both
+
+- When answering questions or reporting what is established, read live and
+  archived material freely. Results are labelled, and the rules above
+  govern presentation: the archive is never current, and where it disagrees
+  with a live file, the live file wins.
+- Creative work on canon — inventing new material, or revising it later —
+  runs under a retrieval scope I own. Drawing on retired material can be
+  deliberate (a successor, an echo) or contamination (a "new" thing that
+  quietly re-skins a retired one). Labels do not protect generation:
+  material read is material that shapes the output. Only I can tell the
+  two intents apart.
+- So at the start of a task that will create or revise canon, ask me
+  whether its retrieval should be live-only, archive-only, or both —
+  unless my request already answers it, or the work's scope is already
+  established. The scope attaches to the work and persists: picking a
+  piece back up later continues under the scope it was made with. One ask
+  per task; hold it until the task changes or I re-scope it.
+- Mechanically: over MCP, pass `scope=` to `search` and `list_entities`;
+  on the filesystem, read or skip `Archive/` accordingly.
+
 ## Speculative material stays speculative
 
 Anything you propose that I have not accepted is `speculative`. Do not carry a

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -91,21 +91,28 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
     @server.tool()
     def campaign_overview() -> dict:
         """Get your bearings in one call: the campaign's name, each section
-        with how many entities it holds, the current front-burner and
-        open-questions documents, and two counts — drafts_pending (your
-        own unpromoted drafts; list_drafts to resume them) and
-        inbound_pending (files in the GM's inbound queue). If
-        inbound_pending is non-zero you may mention it and offer to
-        extract; do not list or read the queue unless the GM asks. Call
-        this before anything else."""
+        with how many entities it holds (the Archive count is the flat
+        total; archive_sections breaks it down by mirrored section), the
+        current front-burner and open-questions documents, and two
+        counts — drafts_pending (your own unpromoted drafts; list_drafts
+        to resume them) and inbound_pending (files in the GM's inbound
+        queue). If inbound_pending is non-zero you may mention it and
+        offer to extract; do not list or read the queue unless the GM
+        asks. Call this before anything else."""
         return store.overview()
 
     @server.tool()
-    def list_entities(section: str) -> list[dict]:
-        """List one section's files with their titles and one-line
-        summaries. Use it to see what already exists before inventing
-        something new."""
-        return store.list_entities(section)
+    def list_entities(section: str, scope: str = "both") -> list[dict]:
+        """List one section's files with titles, one-line summaries, and
+        an archived flag. section names the content section in either
+        tree: the default scope="both" lists live and archived members
+        together (section="NPCs" covers NPCs/ and Archive/NPCs/), while
+        scope="live" or scope="archive" narrows to one tree. Use it to
+        see what already exists before inventing something new —
+        archived names are still taken. For creative work the scope is
+        the GM's call: ask at task start if the request has not said
+        (the AGENTS.md doctrine resource carries the rule)."""
+        return store.list_entities(section, scope)
 
     @server.tool()
     def read_entity(path: str) -> str:
@@ -114,11 +121,17 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         return store.read_entity(path)
 
     @server.tool()
-    def search(query: str, section: str | None = None) -> list[dict]:
+    def search(query: str, section: str | None = None,
+               scope: str = "both") -> list[dict]:
         """Search the workspace for a phrase, returning each file that
-        matches and the text around the match. Use it to check what has
-        already been established about a name, place, or idea."""
-        return store.search(query, section)
+        matches, the text around the match, and an archived flag. scope
+        narrows retrieval to live canon ("live"), archived canon
+        ("archive"), or both (default — every hit is labelled). Use it
+        to check what has already been established about a name, place,
+        or idea. For creative work the scope is the GM's call: ask at
+        task start if the request has not said (the AGENTS.md doctrine
+        resource carries the rule)."""
+        return store.search(query, section, scope)
 
     @server.tool()
     def generate_names(culture: str, count: int = 10) -> dict:

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -92,8 +92,9 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
     def campaign_overview() -> dict:
         """Get your bearings in one call: the campaign's name, each section
         with how many entities it holds (the Archive count is the flat
-        total; archive_sections breaks it down by mirrored section), the
-        current front-burner and open-questions documents, and two
+        total; archive_sections breaks it down by mirrored section, present
+        when the campaign has an archive), the current front-burner and
+        open-questions documents, and two
         counts — drafts_pending (your own unpromoted drafts; list_drafts
         to resume them) and inbound_pending (files in the GM's inbound
         queue). If inbound_pending is non-zero you may mention it and
@@ -126,7 +127,9 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         """Search the workspace for a phrase, returning each file that
         matches, the text around the match, and an archived flag. scope
         narrows retrieval to live canon ("live"), archived canon
-        ("archive"), or both (default — every hit is labelled). Use it
+        ("archive"), or both (default — every hit is labelled); section
+        resolves inside the scope's tree(s) the same way as list_entities
+        (section="NPCs" covers NPCs/ and Archive/NPCs/). Use it
         to check what has already been established about a name, place,
         or idea. For creative work the scope is the GM's call: ask at
         task start if the request has not said (the AGENTS.md doctrine

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -275,7 +275,9 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
                  for t in await server.list_tools()}
         for name in ("search", "list_entities"):
             self.assertIn("scope", descs[name], name)
-            self.assertIn("ask", descs[name], name)
+            # A substring that dies if the ask-the-GM sentence is removed --
+            # bare "ask" is also satisfied by the unrelated word "task".
+            self.assertIn("ask at task start", descs[name], name)
         self.assertIn("archive_sections", descs["campaign_overview"])
 
     async def test_search_scope_live_excludes_archived_hits(self):

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -264,7 +264,9 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         server = serve_mcp.build_server(scaffold(self))
         tools = {t.name: t for t in await server.list_tools()}
         for name in ("search", "list_entities"):
-            scope = tools[name].inputSchema["properties"]["scope"]
+            # mcp>=2.0 names this attribute input_schema; the camelCase
+            # inputSchema is only the wire alias.
+            scope = tools[name].input_schema["properties"]["scope"]
             self.assertEqual(scope.get("default"), "both", name)
 
     async def test_scope_guidance_reaches_the_descriptions(self):

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -260,6 +260,37 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
         server = serve_mcp.build_server(scaffold(self))
         self.assertTrue(callable(serve_mcp.build_app(server)))
 
+    async def test_search_and_list_entities_expose_scope(self):
+        server = serve_mcp.build_server(scaffold(self))
+        tools = {t.name: t for t in await server.list_tools()}
+        for name in ("search", "list_entities"):
+            scope = tools[name].inputSchema["properties"]["scope"]
+            self.assertEqual(scope.get("default"), "both", name)
+
+    async def test_scope_guidance_reaches_the_descriptions(self):
+        # The description is the API the remote agent reads: it must name
+        # the scope choices and say the scope is the GM's call to make.
+        server = serve_mcp.build_server(scaffold(self))
+        descs = {t.name: " ".join((t.description or "").split())
+                 for t in await server.list_tools()}
+        for name in ("search", "list_entities"):
+            self.assertIn("scope", descs[name], name)
+            self.assertIn("ask", descs[name], name)
+        self.assertIn("archive_sections", descs["campaign_overview"])
+
+    async def test_search_scope_live_excludes_archived_hits(self):
+        store = scaffold(self)
+        arch = store.ws.root / "Archive" / "NPCs"
+        arch.mkdir(parents=True)
+        (arch / "old.md").write_text(
+            "---\ntitle: Old\nsummary: Retired.\n---\nShe knows the "
+            "tides.\n", encoding="utf-8")
+        server = serve_mcp.build_server(store)
+        payload = await self._text(await server.call_tool(
+            "search", {"query": "tides", "scope": "live"}))
+        self.assertIn("kim-ha-eun", payload)
+        self.assertNotIn("Archive/NPCs/old.md", payload)
+
 
 
 @unittest.skipUnless(HAVE_MCP, "mcp extra not installed")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -127,6 +127,20 @@ class TestOverview(StoreCase):
         hits = store.search("recorded", section="Archive")
         self.assertEqual(hits[0]["path"], "Archive/NPCs/old-hag.md")
 
+    def test_archive_sections_breaks_the_archive_down_by_mirror(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        ov = store.overview()
+        # The stray at Archive/stray.md is in the flat total but no
+        # breakdown entry -- the sections rule applied one level down,
+        # exactly as root docs are absent from sections.
+        self.assertEqual(ov["sections"]["Archive"], 2)
+        self.assertEqual(ov["archive_sections"], {"NPCs": 1})
+
+    def test_archive_sections_absent_without_an_archive(self):
+        # Absent, not empty: same philosophy as sections.
+        store = _store.WorkspaceStore(self.make_ws())
+        self.assertNotIn("archive_sections", store.overview())
+
 
 class TestListEntities(StoreCase):
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -60,10 +60,13 @@ class TestOverview(StoreCase):
         self.assertIsNone(ov["open_questions"])
 
     def test_counts_agree_with_list_entities(self):
-        # An overview count and the list it promises must never disagree.
-        # A bare rglob would count a file inside an excluded subdirectory
-        # that list_entities then omits, so the two are derived from one
-        # walk rather than from two that can drift.
+        # A live section's count agrees with the live-scoped listing it
+        # promises: sections[X] == len(list_entities(X, scope="live")).
+        # Both come from one walk, so a file inside an excluded
+        # subdirectory cannot be counted here and omitted there (a bare
+        # rglob would let the two drift). See
+        # test_counts_reconcile_with_archive_scope for the archive-side
+        # half of the invariant (#66).
         ws = self.make_ws()
         archived = ws.root / "NPCs" / "_Archive"
         archived.mkdir()
@@ -71,6 +74,25 @@ class TestOverview(StoreCase):
         store = _store.WorkspaceStore(ws)
         self.assertEqual(store.overview()["sections"]["NPCs"], 1)
         self.assertEqual(len(store.list_entities("NPCs")), 1)
+
+    def test_counts_reconcile_with_archive_scope(self):
+        # The other half of the invariant (#66): a live section's count
+        # excludes its archived mirror -- it equals list_entities under
+        # scope="live", not the default "both" -- while the Archive
+        # section's count is the whole archive tree, flat, equal to
+        # unsectioned list_entities("Archive").
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        ov = store.overview()
+        self.assertEqual(
+            ov["sections"]["NPCs"],
+            len(store.list_entities("NPCs", scope="live")))
+        self.assertEqual(
+            ov["sections"]["Archive"],
+            len(store.list_entities("Archive")))
+        # Pin the actual numbers too, so a regression that breaks both
+        # sides identically still gets caught.
+        self.assertEqual(ov["sections"]["NPCs"], 1)
+        self.assertEqual(ov["sections"]["Archive"], 2)
 
     def test_existing_but_empty_section_reports_zero(self):
         ws = self.make_ws()
@@ -250,6 +272,26 @@ class TestSearch(StoreCase):
         store = _store.WorkspaceStore(self.make_ws())
         self.assertEqual(store.search("nothing here says this"), [])
 
+    def test_truncation_sentinel_shape_and_position(self):
+        # Spec #66 §2: the sentinel is a notice, not a result -- exactly
+        # {"path", "snippet"}, no "archived" key, and last in the list.
+        ws = self.make_ws()
+        for i in range(_store.SEARCH_CAP + 5):
+            (ws.root / "NPCs" / f"extra-{i:03d}.md").write_text(
+                f"---\ntitle: Extra {i}\nsummary: x\n---\nferry\n",
+                encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        hits = store.search("ferry")
+        self.assertEqual(len(hits), _store.SEARCH_CAP + 1)
+        for hit in hits[:-1]:
+            self.assertIn("archived", hit)
+        sentinel = hits[-1]
+        self.assertEqual(set(sentinel), {"path", "snippet"})
+        self.assertEqual(sentinel["path"], "")
+        self.assertIn(f"truncated at {_store.SEARCH_CAP} hits",
+                      sentinel["snippet"])
+        self.assertIn("scope='live'", sentinel["snippet"])
+
 
 class TestScopedSearch(StoreCase):
     """#66: scope: live | archive | both, section resolving inside the
@@ -326,6 +368,24 @@ class TestScopedSearch(StoreCase):
         for token in ("live", "archive", "both"):
             self.assertIn(token, str(ctx.exception))
 
+    def test_scope_split_follows_a_non_default_archive_dir(self):
+        # archive_dir is config-driven, not the literal "Archive" -- pin
+        # it against a future hardcode (#66). make_archived_ws hardcodes
+        # "Archive", so this fixture is built by hand under a renamed
+        # archive_dir instead.
+        ws = self.make_ws('\n[workspace]\narchive_dir = "History"\n')
+        arch = ws.root / "History" / "NPCs"
+        arch.mkdir(parents=True)
+        (arch / "old-hag.md").write_text(
+            "---\ntitle: The Old Hag\nsummary: Retired rival on the "
+            "ferry route.\n---\nShe haunted the ferry route.\n",
+            encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        live = {h["path"] for h in store.search("ferry", scope="live")}
+        archived = {h["path"] for h in store.search("ferry", scope="archive")}
+        self.assertEqual(live, {"NPCs/kim-ha-eun.md", "front-burner.md"})
+        self.assertEqual(archived, {"History/NPCs/old-hag.md"})
+
 
 class TestScopedListEntities(StoreCase):
 
@@ -370,6 +430,19 @@ class TestScopedListEntities(StoreCase):
         store = _store.WorkspaceStore(self.make_archived_ws())
         with self.assertRaises(_store.StoreError):
             store.list_entities("NPCs", scope="everything")
+
+    def test_scope_archive_with_no_mirror_is_empty_not_an_error(self):
+        # The non-contradiction counterpart to the refused live+Archive
+        # pair (#66): a live section with no archived mirror simply has
+        # nothing under scope="archive" -- refusal is reserved for
+        # section=archive_dir itself, not for an ordinary miss.
+        ws = self.make_archived_ws()
+        (ws.root / "Factions").mkdir()
+        (ws.root / "Factions" / "harbor-guild.md").write_text(
+            "---\ntitle: Harbor Guild\nsummary: x\n---\nferry\n",
+            encoding="utf-8")
+        store = _store.WorkspaceStore(ws)
+        self.assertEqual(store.list_entities("Factions", scope="archive"), [])
 
 
 # A self-contained culture, built here rather than copied from the shipped

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -33,6 +33,21 @@ class StoreCase(unittest.TestCase):
             "- resolve the ferry plot\n", encoding="utf-8")
         return _config.open_workspace(root)
 
+    def make_archived_ws(self, toml_extra: str = "") -> _config.Workspace:
+        """make_ws plus a mirrored archive: one archived NPC, and one
+        stray file directly at the archive root (no mirror section)."""
+        ws = self.make_ws(toml_extra)
+        arch = ws.root / "Archive" / "NPCs"
+        arch.mkdir(parents=True)
+        (arch / "old-hag.md").write_text(
+            "---\ntitle: The Old Hag\nsummary: Retired rival on the "
+            "ferry route.\nstatus: retired\n---\n"
+            "She haunted the ferry route.\n", encoding="utf-8")
+        (ws.root / "Archive" / "stray.md").write_text(
+            "---\ntitle: Stray\nsummary: A stray archived note.\n---\n"
+            "ferry flotsam\n", encoding="utf-8")
+        return ws
+
 
 class TestOverview(StoreCase):
 
@@ -220,6 +235,81 @@ class TestSearch(StoreCase):
         store = _store.WorkspaceStore(self.make_ws())
         self.assertEqual(store.search("nothing here says this"), [])
 
+
+class TestScopedSearch(StoreCase):
+    """#66: scope: live | archive | both, section resolving inside the
+    scope's tree(s), every hit labelled archived."""
+
+    def test_default_scope_is_both_and_labels_every_hit(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        by_path = {h["path"]: h["archived"] for h in store.search("ferry")}
+        self.assertEqual(by_path, {
+            "NPCs/kim-ha-eun.md": False,
+            "front-burner.md": False,
+            "Archive/NPCs/old-hag.md": True,
+            "Archive/stray.md": True,
+        })
+
+    def test_scope_live_excludes_archived_hits_keeps_root_docs(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        paths = {h["path"] for h in store.search("ferry", scope="live")}
+        self.assertEqual(paths, {"NPCs/kim-ha-eun.md", "front-burner.md"})
+
+    def test_scope_archive_returns_only_archived_hits(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        paths = {h["path"] for h in store.search("ferry", scope="archive")}
+        self.assertEqual(paths,
+                         {"Archive/NPCs/old-hag.md", "Archive/stray.md"})
+
+    def test_sectioned_both_is_the_union_of_the_trees(self):
+        # section="NPCs" covers NPCs/ AND Archive/NPCs/ under the default.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        paths = {h["path"] for h in store.search("ferry", section="NPCs")}
+        self.assertEqual(paths,
+                         {"NPCs/kim-ha-eun.md", "Archive/NPCs/old-hag.md"})
+
+    def test_sectioned_archive_scope_resolves_the_mirror(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        hits = store.search("ferry", section="NPCs", scope="archive")
+        self.assertEqual([h["path"] for h in hits],
+                         ["Archive/NPCs/old-hag.md"])
+
+    def test_sectioned_live_scope_stays_pure_live(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        hits = store.search("ferry", section="NPCs", scope="live")
+        self.assertEqual([h["path"] for h in hits], ["NPCs/kim-ha-eun.md"])
+
+    def test_section_archive_means_the_whole_archive(self):
+        # Under "both" and "archive" alike; strays included.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        for scope in ("both", "archive"):
+            paths = {h["path"] for h in
+                     store.search("ferry", section="Archive", scope=scope)}
+            self.assertEqual(
+                paths, {"Archive/NPCs/old-hag.md", "Archive/stray.md"},
+                scope)
+
+    def test_a_stray_archive_file_is_in_no_mirror_section(self):
+        # "flotsam" appears only in Archive/stray.md, which has no mirror.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(store.search("flotsam", section="NPCs"), [])
+        self.assertEqual(
+            [h["path"] for h in store.search("flotsam")],
+            ["Archive/stray.md"])
+
+    def test_scope_live_with_section_archive_is_a_refused_contradiction(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.search("ferry", section="Archive", scope="live")
+        self.assertIn("contradicts", str(ctx.exception))
+        self.assertIn("archive", str(ctx.exception).lower())
+
+    def test_unknown_scope_is_refused_naming_the_valid_ones(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.search("ferry", scope="everything")
+        for token in ("live", "archive", "both"):
+            self.assertIn(token, str(ctx.exception))
 
 
 # A self-contained culture, built here rather than copied from the shipped

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -136,6 +136,7 @@ class TestListEntities(StoreCase):
             "path": "NPCs/kim-ha-eun.md",
             "title": "Kim Ha-eun",
             "summary": "Kim Ha-eun is a ferry captain in Testmere harbor.",
+            "archived": False,
         }])
 
     def test_title_falls_back_to_the_stem(self):
@@ -310,6 +311,51 @@ class TestScopedSearch(StoreCase):
             store.search("ferry", scope="everything")
         for token in ("live", "archive", "both"):
             self.assertIn(token, str(ctx.exception))
+
+
+class TestScopedListEntities(StoreCase):
+
+    def test_sectioned_both_lists_live_and_mirrored_archived_rows(self):
+        # #62's collision check makes archived names taken; the listing
+        # that says "what already exists" must therefore show them.
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        rows = {r["path"]: r for r in store.list_entities("NPCs")}
+        self.assertEqual(set(rows), {"NPCs/kim-ha-eun.md",
+                                     "Archive/NPCs/old-hag.md"})
+        self.assertFalse(rows["NPCs/kim-ha-eun.md"]["archived"])
+        self.assertTrue(rows["Archive/NPCs/old-hag.md"]["archived"])
+        self.assertEqual(rows["Archive/NPCs/old-hag.md"]["title"],
+                         "The Old Hag")
+
+    def test_scope_live_lists_only_the_live_tree(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(
+            [r["path"] for r in store.list_entities("NPCs", scope="live")],
+            ["NPCs/kim-ha-eun.md"])
+
+    def test_scope_archive_resolves_the_mirror(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(
+            [r["path"] for r in
+             store.list_entities("NPCs", scope="archive")],
+            ["Archive/NPCs/old-hag.md"])
+
+    def test_section_archive_lists_the_whole_archive_strays_included(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        self.assertEqual(
+            {r["path"] for r in store.list_entities("Archive")},
+            {"Archive/NPCs/old-hag.md", "Archive/stray.md"})
+
+    def test_scope_live_with_section_archive_is_refused(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError) as ctx:
+            store.list_entities("Archive", scope="live")
+        self.assertIn("contradicts", str(ctx.exception))
+
+    def test_unknown_scope_is_refused(self):
+        store = _store.WorkspaceStore(self.make_archived_ws())
+        with self.assertRaises(_store.StoreError):
+            store.list_entities("NPCs", scope="everything")
 
 
 # A self-contained culture, built here rather than copied from the shipped


### PR DESCRIPTION
Closes #66.

Adds `scope: "live" | "archive" | "both"` to the MCP `search` and `list_entities` tools, labels every result `archived`, breaks the archive down in `campaign_overview`, and ships the doctrine that decides who picks the scope.

Design of record: [`docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md`](docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md) — its decisions table is binding. Executed from [`docs/superpowers/plans/2026-08-18-scoped-retrieval.md`](docs/superpowers/plans/2026-08-18-scoped-retrieval.md).

## Files changed

| File | | |
|---|---|---|
| `docs/superpowers/specs/2026-08-18-scoped-retrieval-design.md` | (new) | approved design + decisions table |
| `docs/superpowers/plans/2026-08-18-scoped-retrieval.md` | (new) | six-task implementation plan |
| `src/bunnyforge/_store.py` | (modified) | all filtering: `SCOPES`, `_check_retrieval`, `_in_scope`, `_is_archived`; scoped `search` / `list_entities`; `archive_sections` in `overview` |
| `src/bunnyforge/serve_mcp.py` | (modified) | threads `scope` through three tools; docstrings carry the condensed guidance |
| `src/bunnyforge/data/doctrine/AGENTS.md` | (modified) | new "Retrieval scope" section (in-place edit — `init.MANIFEST` unchanged) |
| `tests/test_store.py` | (modified) | `make_archived_ws` fixture; `TestScopedSearch`, `TestScopedListEntities`; overview and reconciliation tests |
| `tests/test_serve_mcp.py` | (modified) | three MCP-surface tests (`HAVE_MCP`-gated) |

No new packaged files, no new dependencies, stdlib only at runtime.

## Work breakdown

**Store — one validator, one predicate.** `_check_retrieval` validates the filter pair before any walk; `_in_scope` decides one walked file's membership. Both `search` and `list_entities` route through them, so the two tools cannot drift — that sharing is the whole architectural point, and `serve_mcp.py` stays a pure pass-through with no filtering logic of its own.

**Symmetric scope-resolved sections.** `section` names the *content* section and resolves inside the chosen scope's tree(s): live files match on `parts[0]`, archived files on their mirror `parts[1]`. `section="Archive"` denotes the archive tree — valid under `archive` and `both`, refused as a contradiction under `live` with an error naming both working alternatives. A stray at `Archive/*.md` has no mirror, so it appears in whole-archive and unsectioned queries and in no mirror section.

**⚠️ This revises #62's listings record, deliberately.** Sectioned listings under the default scope now include archived rows. `list_entities("NPCs")` returns `NPCs/` ∪ `Archive/NPCs/`, each row labelled. The spec considered and rejected the backward-compatible alternative (sectioned `both` returning live rows only) on two grounds: an explicit `scope="both"` that does not mean both is a trap, and #62's collision check makes archived names *taken* — so a listing that hides them hides exactly the names an agent must not reuse. The backward-compat it would have bought is internal-only; nothing released has consumed #62's intermediate MCP behavior.

**Self-aware results.** Every hit and row carries `archived: true|false`, computed where membership is decided. The search-truncation sentinel keeps its exact two-key shape — it is a notice, not a result — and a test now pins that.

**`campaign_overview` is additive only.** `sections` keeps its exact shape and meaning (top-level counts, flat `Archive` total). New `archive_sections` applies the same counting rule one level down, present only when the archive directory exists — absent, not empty, matching `sections`' existing philosophy.

**Doctrine is the primary home for the rule.** Scope for creative work is the GM's call, asked once at task start, attaching to the work rather than the conversation. It lives in packaged `AGENTS.md` because filesystem agents never see MCP tool descriptions but are bound by the same rule; the tool docstrings carry the condensed form and point back at it.

### Review findings fixed before this PR

A whole-branch review raised two Important issues, both fixed in `4e85b35`:

- `overview()`'s comment asserted an invariant the union listings break. Restated truthfully, and the real reconciliation rule is now pinned by a test: `sections[X] == len(list_entities(X, scope="live"))` and `sections["Archive"] == len(list_entities("Archive"))`.
- `search`'s 50-hit cap can fill entirely with archived hits, because `Archive/` sorts first. **Scoped down deliberately:** this PR takes only the truncation-notice change, which now names `scope='live'` as the working alternative. Reordering the walk live-first is a change to `search`'s result-ordering contract, which the design spec never covered — filed as #71 rather than landed unreviewed here.

Seven Minors also fixed: `search`'s missing section-resolution clause, the `archive_sections` key placement, an over-promising `campaign_overview` description, a sentinel-shape test, two test-matrix gaps (non-default `archive_dir`; `scope="archive"` on a section with no mirror), a weak `assertIn("ask", …)` that the substring in "t**ask**" satisfied, and three copies of the "is archived" predicate collapsed into one helper.

### Human vocabulary read (spec §7)

With #65 deferred, no automated check scans packaged prose for campaign-specific vocabulary. Every line of new prose this branch ships was read by the GM before this PR opened, and confirmed clean with no replacements: the doctrine section, all three tool docstrings (`campaign_overview`, `list_entities`, `search`), and the new truncation-notice string. This was a required checkpoint in the plan, not an assumption that a test covers it.

## Test expectations

All green, no expected failures. `Ran 926 tests … OK (skipped=57)` (baseline before this branch: 901 / 54 skips).

The 57 skips are the optional `mcp` extra, which is not installed in the dev worktree. **The three new `serve_mcp` tests are among them and have never run locally** — CI's dedicated `mcp` job is their first real execution, so that job is the one to watch on this PR.

Fresh-workspace gate: `bunnyforge init` → `bunnyforge review checkup` → `Summary: 0 error(s), 0 warning(s)`. The new doctrine section was confirmed present in a freshly `init`-ed workspace's `AGENTS.md`.

## Operational impact

**Live campaigns hand-reconcile one region of `AGENTS.md`.** The doctrine edit is in-place, so a campaign that has customized its copy must merge the new "Retrieval scope" section by hand. The cost is accepted rather than incurred: this release already carries #62's edits to the same doctrine passages, so that region gets hand-diffed once either way.

No config changes, no migration, no new packaged files (`init.MANIFEST` untouched).

**Release sequencing:** #68 lands before #66; one release carries #62 + #68 + #66 (tracked on #69). Nothing released has seen #62's intermediate MCP behavior, which is what makes the additive shape changes and the listings revision externally invisible until that release.

## Provenance

- **Agent:** Claude Code (subagent-driven execution of the committed plan; fresh implementer per task, independent review after each, plus a whole-branch review and one fix wave)
- **Model / version:** the session was directed to Claude Opus 5; implementer and reviewer subagents ran on Claude Haiku 4.5 and Claude Sonnet 5, with Claude Opus 5 for the whole-branch review
