### PR TITLE
Task-start context: four questions, one bundled ask, and the scope ask discipline gets a single owner (#70)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-task-start-context.md
+++ b/docs/superpowers/plans/2026-08-18-task-start-context.md
@@ -1,0 +1,322 @@
+# Task-Start Context (#70) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generalize #66's task-start retrieval-scope question into a packaged doctrine framework of four contextual questions answered before any task's work begins, with a GM-owned growth point and a `campaign_overview` docstring pointer.
+
+**Architecture:** Prose-first change. A new `## Task-start context` section in the packaged `AGENTS.md` owns the question list and the ask discipline; the retrieval-scope section's own ask sentences collapse into a pointer to it. The `campaign-doctrine.md` scaffold gains a commented stub for campaign-specific questions. `serve_mcp.py` changes by exactly one docstring sentence. Tests pin sections and phrases the way `test_init.py` / `test_serve_mcp.py` already do.
+
+**Tech Stack:** Python ≥ 3.11, stdlib only, `unittest`. The `mcp>=2.0` extra is optional and absent from the local environment.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-task-start-context-design.md` (committed on this branch — read it first; the plan argues from it).
+
+## Global Constraints
+
+- Python ≥ 3.11, stdlib only, no new dependencies.
+- No test may write into the repo — temp dirs only.
+- Never pip install into any shared environment; the primary clone's venv runs a live campaign. A throwaway venv in the session scratchpad directory is fine (Task 3 uses one).
+- Never commit to `main`. Work stays on branch `worktree-issue-70-task-start-context` in the worktree `/Users/dcltdw/Github/bunnyforge/.claude/worktrees/issue-68-enumerator-test` (already checked out there, spec committed). Run `git branch --show-current` before every commit.
+- Suite, from the worktree root: `PYTHONPATH=src python3 -m unittest discover -s tests -t .`
+  Baseline on `main` (2800873): `Ran 931 tests … OK (skipped=57)` — the 57 skips are the optional mcp extra.
+- Once, before starting: `PYTHONPATH=src python3 -c "import bunnyforge; print(bunnyforge.__file__)"` must print a path inside the worktree, not the primary clone.
+- #65 is deferred: nothing mechanically screens packaged prose for campaign-specific terms. Every packaged-prose change in this plan (Tasks 1–2) must be cleared by a deliberate human read at PR time, and the PR body must say that is the basis for the portability claim (same footing as PRs #72 and #75).
+- Commit trailer: stamp the current AI model, e.g. `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Packaged doctrine — `## Task-start context` section, and the retrieval-scope collapse
+
+**Files:**
+- Modify: `src/bunnyforge/data/doctrine/AGENTS.md` (insert new section after "Clarify before proceeding", ends at line 71; replace one bullet in "Retrieval scope: live, archive, or both", lines 230–236)
+- Test: `tests/test_init.py` (class `TestPackagedDoctrineIsPortable`)
+
+**Interfaces:**
+- Consumes: `init.packaged_bytes("doctrine/AGENTS.md")` (existing helper, returns the shipped bytes).
+- Produces: the literal heading `## Task-start context` and the phrase `Task-start context` inside the retrieval-scope section — Task 2's stub comment and Task 3's docstring refer to the section by name.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestPackagedDoctrineIsPortable` in `tests/test_init.py`, after `test_the_underscore_convention_is_stated_once`:
+
+```python
+    def test_task_start_context_carries_the_question_list(self):
+        # #70: the standing checklist every task is held against before
+        # work begins. Pin the section, the four questions, the bundling
+        # discipline, and the campaign-side growth pointer.
+        doctrine = init.packaged_bytes("doctrine/AGENTS.md").decode("utf-8")
+        self.assertIn("## Task-start context", doctrine)
+        section = doctrine.split("## Task-start context", 1)[1]
+        section = section.split("\n## ", 1)[0]
+        for needle in ("What are we building",
+                       "new NPCs",
+                       "live canon, the archive, or both",
+                       "player-visible",
+                       "in one message",
+                       "[[campaign-doctrine]]"):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+
+    def test_the_ask_discipline_has_one_owner(self):
+        # #70 collapsed the retrieval-scope section's own ask discipline
+        # into Task-start context; the scope section must point there
+        # instead of restating it. "ask me whether" and "One ask per task"
+        # were the old restatement's spine.
+        doctrine = init.packaged_bytes("doctrine/AGENTS.md").decode("utf-8")
+        scope = doctrine.split("## Retrieval scope", 1)[1]
+        scope = scope.split("\n## ", 1)[0]
+        self.assertIn("Task-start context", scope)
+        self.assertNotIn("ask me whether", scope)
+        self.assertNotIn("One ask per task", scope)
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_init.TestPackagedDoctrineIsPortable -v`
+Expected: the two new tests FAIL (`'## Task-start context' not found` / `'Task-start context' not found`); the three existing tests in the class still PASS.
+
+- [ ] **Step 3: Insert the new section**
+
+In `src/bunnyforge/data/doctrine/AGENTS.md`, immediately after the "Clarify before proceeding" section — i.e. after the line `writing it.` (line 71) and before `## Verify against the files, not against earlier prose` — insert:
+
+```markdown
+## Task-start context
+
+Some questions recur at the start of every task, and missing one is how
+work goes wrong quietly. Before work begins, check each question below.
+Skip the ones my request already answers and the ones that do not apply
+to the kind of task at hand — skipping all of them is the normal case
+for a complete request, and this list licenses no manufactured asks (see
+**Clarify before proceeding** above). Ask me the rest **in one
+message**, not one at a time.
+
+1. **What are we building** — a plot, an encounter, a combat? A writeup
+   or a brief? (**What gets written where**, below, carries the
+   distinction.)
+2. **Will new NPCs be created, or existing ones reused?**
+3. **Should retrieval draw on live canon, the archive, or both?**
+   (**Retrieval scope**, below, carries the full rule.)
+4. **Is any of the output meant to be player-visible?** `gm-only` is the
+   fail-safe default (**Player visibility**, below), but a wrong silent
+   default costs a re-edit later.
+
+Answers attach to the work and persist: picking a piece back up later
+continues under the answers it was made with. One bundled ask per task;
+hold the answers until the task changes or I re-answer.
+
+The list is doctrine, and it grows as gaps appear. Questions specific to
+one campaign belong in `[[campaign-doctrine]]`; a gap that would bite
+any campaign belongs upstream as a bunnyforge ticket.
+```
+
+- [ ] **Step 4: Collapse the retrieval-scope ask bullet**
+
+In the same file, in `## Retrieval scope: live, archive, or both`, replace this bullet (exact current text):
+
+```markdown
+- So at the start of a task that will create or revise canon, ask me
+  whether its retrieval should be live-only, archive-only, or both —
+  unless my request already answers it, or the work's scope is already
+  established. The scope attaches to the work and persists: picking a
+  piece back up later continues under the scope it was made with. One ask
+  per task; hold it until the task changes or I re-scope it.
+```
+
+with:
+
+```markdown
+- So the scope question is one of the standing questions in **Task-start
+  context** above, and runs under its discipline: raised when a task
+  will create or revise canon and my request has not already answered
+  it, bundled with the other open questions, held for the task.
+```
+
+The bullet's rationale siblings (answering vs. creative work, the contamination argument, the `scope=` mechanics bullet) stay untouched.
+
+- [ ] **Step 5: Run the class to verify it passes**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_init.TestPackagedDoctrineIsPortable -v`
+Expected: all five tests PASS — including `test_agents_md_wikilinks_resolve_with_only_root_docs`, which now also covers the new section's `[[campaign-doctrine]]` link.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current   # must print worktree-issue-70-task-start-context
+git add src/bunnyforge/data/doctrine/AGENTS.md tests/test_init.py
+git commit -m "feat: task-start context section in packaged doctrine; scope ask collapses into it (#70)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `campaign-doctrine.md` scaffold — stub section for campaign-specific questions
+
+**Files:**
+- Modify: `src/bunnyforge/data/root/campaign-doctrine.md` (insert one section between "Exemptions from the generic contract" and "Extra tools and checks")
+- Test: `tests/test_init.py` (alongside `test_writes_the_campaign_doctrine_stub`, ~line 493)
+
+**Interfaces:**
+- Consumes: `init.packaged_bytes("root/campaign-doctrine.md")`; Task 1's section name "Task-start context".
+- Produces: the literal heading `## Task-start questions for this campaign` in every newly scaffolded workspace. Existing workspaces lack it harmlessly — nothing reads it mechanically (the graceful-absence stance `serve_mcp.py`'s `DOCTRINE_FILES` comment documents).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_init.py`, in the same class as `test_writes_the_campaign_doctrine_stub`, directly after that test:
+
+```python
+    def test_campaign_doctrine_stub_carries_task_start_section(self):
+        # #70: campaign-specific task-start questions get a designated
+        # home in the GM-owned half. Only new scaffolds receive it;
+        # existing workspaces lack the section harmlessly because
+        # nothing reads it mechanically.
+        stub = init.packaged_bytes(
+            "root/campaign-doctrine.md").decode("utf-8")
+        self.assertIn("## Task-start questions for this campaign", stub)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_init -k task_start -v`
+Expected: `test_campaign_doctrine_stub_carries_task_start_section` FAILS; Task 1's two tests PASS.
+
+- [ ] **Step 3: Insert the stub section**
+
+In `src/bunnyforge/data/root/campaign-doctrine.md`, between the "Exemptions from the generic contract" comment block and `## Extra tools and checks`, insert:
+
+```markdown
+## Task-start questions for this campaign
+
+<!-- Extra questions this campaign's tasks must answer before work begins,
+     beyond the generic set in AGENTS.md's "Task-start context" section.
+     Also the place to strike or rephrase a generic question -- name the
+     rule displaced, as with any exemption. -->
+```
+
+Match the file's comment style exactly: `<!--` flush with the margin, continuation lines indented five spaces, `-->` closing the last line.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m unittest tests.test_init -v`
+Expected: all PASS — including `test_writes_the_campaign_doctrine_stub`, which compares the scaffolded file byte-for-byte to the packaged one and so covers the new section automatically.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current   # must print worktree-issue-70-task-start-context
+git add src/bunnyforge/data/root/campaign-doctrine.md tests/test_init.py
+git commit -m "feat: campaign-doctrine scaffold gains a task-start questions stub (#70)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `campaign_overview` docstring — the task-start pointer
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py:92-102` (the `campaign_overview` docstring only)
+- Test: `tests/test_serve_mcp.py` (after `test_scope_guidance_reaches_the_descriptions`, ~line 283)
+
+**Interfaces:**
+- Consumes: the doctrine resource name "AGENTS.md" (already served as `bunnyforge://doctrine/AGENTS.md`); Task 1's phrase "task-start questions".
+- Produces: nothing later tasks rely on. The `search`/`list_entities` scope mirrors are untouched — they are parameter-justified pointers, pinned by the existing `test_scope_guidance_reaches_the_descriptions`.
+
+- [ ] **Step 1: Write the test**
+
+Add to `tests/test_serve_mcp.py`, directly after `test_scope_guidance_reaches_the_descriptions`:
+
+```python
+    async def test_task_start_pointer_reaches_campaign_overview(self):
+        # #70: campaign_overview is the "call this before anything else"
+        # moment, so its description is where the task-start ritual gets
+        # its hook. Pin the pointer phrases, not the list -- the AGENTS.md
+        # doctrine resource owns the list.
+        server = serve_mcp.build_server(scaffold(self))
+        descs = {t.name: " ".join((t.description or "").split())
+                 for t in await server.list_tools()}
+        self.assertIn("task-start questions", descs["campaign_overview"])
+        self.assertIn("in one message", descs["campaign_overview"])
+```
+
+- [ ] **Step 2: Build a scratchpad venv so the test can actually run**
+
+The local environment lacks the `mcp` extra (that is the baseline's 57 skips), so without this the new test reports SKIP, not FAIL. In the session scratchpad directory (never the repo, never any shared venv):
+
+```bash
+python3 -m venv "$SCRATCHPAD/mcp-venv"
+"$SCRATCHPAD/mcp-venv/bin/pip" install 'mcp>=2.0'
+```
+
+(`$SCRATCHPAD` = the session's scratchpad directory.) If the install cannot run (offline), skip Steps 3 and 5's venv runs, note in the commit/PR that the test was verified only as SKIP locally, and rely on the same footing the existing `test_scope_guidance_reaches_the_descriptions` has.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `PYTHONPATH=src "$SCRATCHPAD/mcp-venv/bin/python" -m unittest tests.test_serve_mcp -k task_start_pointer -v`
+Expected: FAIL — `'task-start questions' not found in 'Get your bearings in one call: …'`.
+
+- [ ] **Step 4: Append the docstring sentence**
+
+In `src/bunnyforge/serve_mcp.py`, the `campaign_overview` docstring currently ends `Call this before anything else."""`. Extend it so the ending reads:
+
+```python
+        asks. Call this before anything else. Then, before work begins,
+        answer the task-start questions in the AGENTS.md doctrine
+        resource — ask the GM the ones the request has not answered, in
+        one message."""
+```
+
+No other tool's docstring changes.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `PYTHONPATH=src "$SCRATCHPAD/mcp-venv/bin/python" -m unittest tests.test_serve_mcp -v`
+Expected: all PASS (none skipped in the venv run).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current   # must print worktree-issue-70-task-start-context
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: campaign_overview points at the task-start questions (#70)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full-suite verification
+
+**Files:**
+- None created or modified. This task gates the branch, per superpowers:verification-before-completion.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the verified branch the PR is opened from.
+
+- [ ] **Step 1: Confirm the import resolves inside the worktree**
+
+Run: `PYTHONPATH=src python3 -c "import bunnyforge; print(bunnyforge.__file__)"`
+Expected: a path under `/Users/dcltdw/Github/bunnyforge/.claude/worktrees/issue-68-enumerator-test/src/`.
+
+- [ ] **Step 2: Run the full suite with the system python**
+
+Run: `PYTHONPATH=src python3 -m unittest discover -s tests -t .`
+Expected: `Ran 935 tests … OK (skipped=58)` — baseline 931 + four new tests (two in Task 1, one each in Tasks 2–3), skips 57 + Task 3's test (skipped without the mcp extra). If the numbers differ from this arithmetic, stop and investigate before claiming done.
+
+- [ ] **Step 3: Run the full suite with the scratchpad mcp venv**
+
+Run: `PYTHONPATH=src "$SCRATCHPAD/mcp-venv/bin/python" -m unittest discover -s tests -t .`
+Expected: `Ran 935 tests … OK` with far fewer skips (the mcp-gated tests now run, including Task 3's). Skip this step only if Task 2's venv could not be built.
+
+- [ ] **Step 4: Confirm the working tree is clean and the repo untouched by tests**
+
+Run: `git status --porcelain`
+Expected: empty output. Any untracked file here means a test wrote into the repo — a constraint violation to fix, not ignore.
+
+---
+
+## Self-review notes (done at plan time)
+
+- **Spec coverage:** Component 1 → Task 1 (both the new section and the collapse). Component 2 → Task 2. Component 3 → Task 3. Testing section → Tasks 1–3 tests + Task 4. Release/portability note → Global Constraints (human-read requirement, worded for the PR body). Out-of-scope items introduce no tasks. No gaps found.
+- **Consistency:** the pinned phrases ("Task-start context", "task-start questions", "in one message", "live canon, the archive, or both") appear verbatim in the prose/docstring steps that must satisfy them; the negative pins ("ask me whether", "One ask per task") appear nowhere in the replacement bullet.
+- **Skip arithmetic (Task 4) re-derived:** 931 baseline + 2 tests (Task 1) + 1 (Task 2) + 1 (Task 3) = 935; 57 baseline skips + Task 3's test = 58 under the system python. Task 4's expectations state exactly this.

--- a/docs/superpowers/specs/2026-08-18-task-start-context-design.md
+++ b/docs/superpowers/specs/2026-08-18-task-start-context-design.md
@@ -1,0 +1,150 @@
+# Task-start context: contextual questions before work begins (#70)
+
+Design for issue #70. Generalizes the one task-start question #66 shipped
+(retrieval scope: live/archive/both) into the framework it turned out to be an
+instance of: a small, explicit set of contextual questions answered before any
+task's work begins, so nothing falls between the cracks.
+
+Decisions below were settled with the GM in brainstorming on 2026-08-18.
+
+## Decisions
+
+1. **The framework governs all tasks.** Not only creative/canon work. A
+   question that does not apply to the task's kind is skipped silently, and a
+   question the request already answers is skipped silently — so a Q&A task
+   typically skips everything and pays no friction.
+2. **Initial question set — four questions:**
+   - What are we building — plot, encounter, combat; writeup or brief?
+   - Will new NPCs be created, or existing ones reused?
+   - Retrieval scope: live, archive, or both? (#66's question, folded in.)
+   - Is any of the output meant to be player-visible?
+3. **One bundled ask.** All applicable-and-unanswered questions go to the GM
+   in a single message at task start. "One ask per task" now means literally
+   one message, not one per question.
+4. **Placement: split.** The framework and the four generic questions live in
+   packaged doctrine (`src/bunnyforge/data/doctrine/AGENTS.md`).
+   Campaign-specific growth — extra questions, or striking/rephrasing a
+   generic one — lives in the GM-owned `campaign-doctrine.md`, whose scaffold
+   gains a commented stub section. Release cost: this enlarges the single
+   hand-reconcile diff the current release (#69) already forces, rather than
+   creating a second reconcile event a release later — which is exactly the
+   cost #69 accepted when it pulled #70 into this release.
+5. **Composition: doctrine owns the list; the tool surface carries pointers
+   only.** The existing `search`/`list_entities` scope mirrors stay exactly
+   as they are — they exist because those tools have a `scope=` parameter the
+   question governs, which is not an N-questions pattern and does not
+   generalize. `campaign_overview`'s docstring — the designated "call this
+   before anything else" moment — gains one pointer sentence. No new tools,
+   no new resources, no question list in any payload.
+
+## Component 1: packaged doctrine — new section "Task-start context"
+
+A new `## Task-start context` section in
+`src/bunnyforge/data/doctrine/AGENTS.md`, placed immediately after "Clarify
+before proceeding". They are siblings: clarify governs the task-specific
+questions that emerge from a request; task-start context is the standing
+checklist every task is held against first.
+
+Content shape (final prose written at implementation time, under the style of
+the surrounding file):
+
+- **The rule.** At the start of any task, before work begins, check the
+  questions below. Skip silently any the request already answers and any
+  that do not apply to the task's kind. Ask the GM the rest **in one
+  message**.
+- **The generic list**, each question one line plus a pointer to the section
+  carrying its full rule:
+  1. What are we building — plot, encounter, combat; writeup or brief?
+     (→ "What gets written where".)
+  2. Will new NPCs be created, or existing ones reused?
+  3. Retrieval scope: live, archive, or both? (→ "Retrieval scope: live,
+     archive, or both", which keeps its rationale and mechanics.)
+  4. Is any of the output meant to be player-visible? (→ "Player
+     visibility"; `gm-only` remains the fail-safe default, but a wrong
+     silent default costs a re-edit later.)
+- **Persistence**, generalized from #66: answers attach to the work and
+  persist — picking a piece back up later continues under the answers it was
+  made with. One bundled ask per task, held until the task changes or the GM
+  re-answers.
+- **Growth.** The list is doctrine and grows as gaps appear.
+  Campaign-specific questions belong in `[[campaign-doctrine]]`; a gap that
+  is generic goes upstream as a ticket.
+- **Relation to "Clarify before proceeding".** These questions do not license
+  manufacturing asks: skipping all four is the normal case for a task whose
+  request is complete.
+
+**Duplication collapse.** The "Retrieval scope: live, archive, or both"
+section currently carries its own ask discipline ("ask at task start …
+One ask per task; hold it until the task changes or I re-scope it"). Those
+sentences are replaced with a pointer to the task-start section, so the ask
+discipline has a single owner. The scope section keeps what is genuinely its
+own: the answering-vs-creative distinction, the contamination rationale, and
+the `scope=` mechanics.
+
+## Component 2: campaign-doctrine.md scaffold — one stub section
+
+`src/bunnyforge/data/root/campaign-doctrine.md` gains one commented stub
+section alongside the existing three, e.g.:
+
+```markdown
+## Task-start questions for this campaign
+
+<!-- Extra questions this campaign's tasks must answer before work begins,
+     beyond the generic set in AGENTS.md. Also the place to strike or
+     rephrase a generic question — name the rule displaced, as with any
+     exemption. -->
+```
+
+No migration machinery. Workspaces scaffolded before this change simply lack
+the section; nothing reads it mechanically, and the packaged section's
+`[[campaign-doctrine]]` pointer covers them. Same graceful-absence stance the
+doctrine-resource listing already takes for an absent `campaign-doctrine.md`.
+
+## Component 3: serve_mcp.py — one docstring sentence
+
+Append one sentence to `campaign_overview`'s docstring, roughly:
+
+> Then, before work begins, answer the task-start questions in the AGENTS.md
+> doctrine resource — ask the GM the ones the request has not answered, in
+> one message.
+
+Tool docstrings are the remote agent's decision surface (the file says so),
+so the sentence is a pointer, not a restatement of the list. The
+`search`/`list_entities` scope mirrors are untouched. No other code changes.
+
+## Testing
+
+Follow the established patterns; all tests run against packaged bytes or
+temp-dir workspaces — no test writes into the repo.
+
+- `test_init.py` style, section-scoped assertions on
+  `init.packaged_bytes("doctrine/AGENTS.md")`:
+  - `## Task-start context` exists and names all four questions.
+  - The retrieval-scope section points at the task-start section and no
+    longer carries its own ask-discipline sentences.
+  - The existing wikilink-resolution test automatically covers any new
+    `[[...]]` links the section introduces.
+- Scaffold assertion that the packaged `campaign-doctrine.md` carries the new
+  stub section.
+- `test_serve_mcp.py` style assertion that `campaign_overview`'s advertised
+  description carries the task-start pointer.
+
+Suite: `PYTHONPATH=src python3 -m unittest discover -s tests -t .` from the
+worktree root. Baseline on main (2800873): `Ran 931 tests … OK (skipped=57)`;
+the 57 skips are the optional mcp extra.
+
+## Release and portability notes
+
+- #65 is deferred: nothing mechanically screens packaged data for
+  campaign-specific terms. The new `AGENTS.md` and scaffold prose must be
+  cleared by a deliberate human read at PR time — the same basis recorded on
+  PRs #72 and #75. The implementation plan must say so.
+- #69's release notes already anticipate #70 changing the packaged
+  `AGENTS.md`; this design adds one section and edits one, covered by the
+  existing hand-reconcile/migration-recipe pointer.
+
+## Out of scope
+
+- Any mechanical enforcement of the questions (payloads, new tools, checks).
+- Migrating existing campaigns' `campaign-doctrine.md` to carry the stub.
+- #65 (packaged-prose screening) and #74 remain deferred.

--- a/src/bunnyforge/data/doctrine/AGENTS.md
+++ b/src/bunnyforge/data/doctrine/AGENTS.md
@@ -70,6 +70,34 @@ knows, what the scene has to accomplish. Ask those before drafting, not after.
 If you think the requested thing is the wrong thing to write, say so before
 writing it.
 
+## Task-start context
+
+Some questions recur at the start of every task, and missing one is how
+work goes wrong quietly. Before work begins, check each question below.
+Skip the ones my request already answers and the ones that do not apply
+to the kind of task at hand — skipping all of them is the normal case
+for a complete request, and this list licenses no manufactured asks (see
+**Clarify before proceeding** above). Ask me the rest **in one
+message**, not one at a time.
+
+1. **What are we building** — a plot, an encounter, a combat? A writeup
+   or a brief? (**What gets written where**, below, carries the
+   distinction.)
+2. **Will new NPCs be created, or existing ones reused?**
+3. **Should retrieval draw on live canon, the archive, or both?**
+   (**Retrieval scope**, below, carries the full rule.)
+4. **Is any of the output meant to be player-visible?** `gm-only` is the
+   fail-safe default (**Player visibility**, below), but a wrong silent
+   default costs a re-edit later.
+
+Answers attach to the work and persist: picking a piece back up later
+continues under the answers it was made with. One bundled ask per task;
+hold the answers until the task changes or I re-answer.
+
+The list is doctrine, and it grows as gaps appear. Questions specific to
+one campaign belong in `[[campaign-doctrine]]`; a gap that would bite
+any campaign belongs upstream as a bunnyforge ticket.
+
 ## Verify against the files, not against earlier prose
 
 A fact restated in a conversation summary is not verified. Before relying on a
@@ -228,12 +256,10 @@ include the separator, even if the GM notes section is empty. A handout is a
   quietly re-skins a retired one). Labels do not protect generation:
   material read is material that shapes the output. Only I can tell the
   two intents apart.
-- So at the start of a task that will create or revise canon, ask me
-  whether its retrieval should be live-only, archive-only, or both —
-  unless my request already answers it, or the work's scope is already
-  established. The scope attaches to the work and persists: picking a
-  piece back up later continues under the scope it was made with. One ask
-  per task; hold it until the task changes or I re-scope it.
+- So the scope question is one of the standing questions in **Task-start
+  context** above, and runs under its discipline: raised when a task
+  will create or revise canon and my request has not already answered
+  it, bundled with the other open questions, held for the task.
 - Mechanically: over MCP, pass `scope=` to `search` and `list_entities`;
   on the filesystem, read or skip `Archive/` accordingly.
 

--- a/src/bunnyforge/data/root/campaign-doctrine.md
+++ b/src/bunnyforge/data/root/campaign-doctrine.md
@@ -26,6 +26,13 @@ unchanged. Nothing here is required.
      how it changes, and say why. An exemption nobody wrote a reason for gets
      re-litigated every few months. -->
 
+## Task-start questions for this campaign
+
+<!-- Extra questions this campaign's tasks must answer before work begins,
+     beyond the generic set in AGENTS.md's "Task-start context" section.
+     Also the place to strike or rephrase a generic question -- name the
+     rule displaced, as with any exemption. -->
+
 ## Extra tools and checks
 
 <!-- Commands this campaign runs that bunnyforge does not ship: campaign

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -99,7 +99,10 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
         to resume them) and inbound_pending (files in the GM's inbound
         queue). If inbound_pending is non-zero you may mention it and
         offer to extract; do not list or read the queue unless the GM
-        asks. Call this before anything else."""
+        asks. Call this before anything else. Then, before work begins,
+        answer the task-start questions in the AGENTS.md doctrine
+        resource — ask the GM the ones the request has not answered, in
+        one message."""
         return store.overview()
 
     @server.tool()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -532,6 +532,15 @@ class TestWhatInitWrites(unittest.TestCase):
         self.assertEqual(stub.read_bytes(),
                          init.packaged_bytes("root/campaign-doctrine.md"))
 
+    def test_campaign_doctrine_stub_carries_task_start_section(self):
+        # #70: campaign-specific task-start questions get a designated
+        # home in the GM-owned half. Only new scaffolds receive it;
+        # existing workspaces lack the section harmlessly because
+        # nothing reads it mechanically.
+        stub = init.packaged_bytes(
+            "root/campaign-doctrine.md").decode("utf-8")
+        self.assertIn("## Task-start questions for this campaign", stub)
+
 
 class TestGeneratedConfig(unittest.TestCase):
     """The generated campaign.toml round-trips through _config.load, and every

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -106,6 +106,37 @@ class TestPackagedDoctrineIsPortable(unittest.TestCase):
         self.assertNotIn("`Export/`", doctrine)
         self.assertNotIn("`Reviews/`", doctrine)
 
+    def test_task_start_context_carries_the_question_list(self):
+        # #70: the standing checklist every task is held against before
+        # work begins. Pin the section, the four questions, the bundling
+        # discipline, and the campaign-side growth pointer.
+        doctrine = init.packaged_bytes("doctrine/AGENTS.md").decode("utf-8")
+        self.assertIn("## Task-start context", doctrine)
+        section = doctrine.split("## Task-start context", 1)[1]
+        section = section.split("\n## ", 1)[0]
+        section = " ".join(section.split())
+        for needle in ("What are we building",
+                       "new NPCs",
+                       "live canon, the archive, or both",
+                       "player-visible",
+                       "in one message",
+                       "[[campaign-doctrine]]"):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+
+    def test_the_ask_discipline_has_one_owner(self):
+        # #70 collapsed the retrieval-scope section's own ask discipline
+        # into Task-start context; the scope section must point there
+        # instead of restating it. "ask me whether" and "One ask per task"
+        # were the old restatement's spine.
+        doctrine = init.packaged_bytes("doctrine/AGENTS.md").decode("utf-8")
+        scope = doctrine.split("## Retrieval scope", 1)[1]
+        scope = scope.split("\n## ", 1)[0]
+        scope = " ".join(scope.split())
+        self.assertIn("Task-start context", scope)
+        self.assertNotIn("ask me whether", scope)
+        self.assertNotIn("One ask per task", scope)
+
 
 def _packaged_data_root() -> Path:
     """The data/ tree as a real directory.

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -282,6 +282,17 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
             self.assertIn("ask at task start", descs[name], name)
         self.assertIn("archive_sections", descs["campaign_overview"])
 
+    async def test_task_start_pointer_reaches_campaign_overview(self):
+        # #70: campaign_overview is the "call this before anything else"
+        # moment, so its description is where the task-start ritual gets
+        # its hook. Pin the pointer phrases, not the list -- the AGENTS.md
+        # doctrine resource owns the list.
+        server = serve_mcp.build_server(scaffold(self))
+        descs = {t.name: " ".join((t.description or "").split())
+                 for t in await server.list_tools()}
+        self.assertIn("task-start questions", descs["campaign_overview"])
+        self.assertIn("in one message", descs["campaign_overview"])
+
     async def test_search_scope_live_excludes_archived_hits(self):
         store = scaffold(self)
         arch = store.ws.root / "Archive" / "NPCs"

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -292,6 +292,7 @@ class TestBuildServer(unittest.IsolatedAsyncioTestCase):
                  for t in await server.list_tools()}
         self.assertIn("task-start questions", descs["campaign_overview"])
         self.assertIn("in one message", descs["campaign_overview"])
+        self.assertIn("AGENTS.md", descs["campaign_overview"])
 
     async def test_search_scope_live_excludes_archived_hits(self):
         store = scaffold(self)


### PR DESCRIPTION
Closes #70.

#66 shipped one task-start question — *should retrieval draw on live canon, the archive, or both?* — asked once when a task starts, held for the task, because the scope is a creative decision the GM owns. That question turned out to be an instance of a framework rather than a one-off, and it was carrying its own ask discipline in a section that had no business owning it.

This branch generalizes it: four contextual questions, one bundled ask, answers that persist with the work — and the retrieval-scope section's ask discipline collapses into a pointer, so the discipline has exactly one owner.

It is a prose-first change. No behavioral code changes; the only Python touched is one docstring sentence.

## Files changed

- `docs/superpowers/specs/2026-08-18-task-start-context-design.md` *(new)* — the design, with the five decisions settled with the GM in brainstorming.
- `docs/superpowers/plans/2026-08-18-task-start-context.md` *(new)* — the implementation plan the branch was executed from.
- `src/bunnyforge/data/doctrine/AGENTS.md` *(modified)* — new `## Task-start context` section between "Clarify before proceeding" and "Verify against the files, not against earlier prose"; the retrieval-scope section's ask bullet replaced by a pointer.
- `src/bunnyforge/data/root/campaign-doctrine.md` *(modified)* — one commented stub section, `## Task-start questions for this campaign`, between "Exemptions from the generic contract" and "Extra tools and checks".
- `src/bunnyforge/serve_mcp.py` *(modified)* — one sentence appended to `campaign_overview`'s docstring. No other tool's description changes.
- `tests/test_init.py` *(modified)* — three new tests (two pinning the doctrine section and the collapse, one pinning the scaffold stub).
- `tests/test_serve_mcp.py` *(modified)* — one new test pinning the pointer in the advertised `campaign_overview` description.

## Work breakdown

**The framework governs all tasks, not just creative work.** A question that does not apply to the task's kind is skipped silently, and a question the request already answers is skipped silently — so a Q&A task typically skips all four and pays no friction. The section says this explicitly ("skipping all of them is the normal case for a complete request") and defers to **Clarify before proceeding**, which already prohibits manufacturing questions. That deferral is what stops a standing checklist from becoming a licence to interrogate the GM.

**One bundled ask.** "One ask per task" now means literally one message, not one message per question. Answers attach to the work and persist: picking a piece back up later continues under the answers it was made with, held until the task changes or the GM re-answers. This is #66's persistence rule, generalized from scope to all four answers.

**The duplication collapse is the structural half of the change.** "Retrieval scope: live, archive, or both" was carrying its own trigger, its own escape clause, and its own persistence rule — a second copy of an ask discipline that now has a general owner. Those sentences become a pointer. Mapped clause by clause, nothing was dropped: the create-or-revise-canon trigger and the request-already-answers escape survive in the new bullet; "the work's scope is already established" and "the scope attaches to the work and persists" generalize into the new section's persistence paragraph. The scope section keeps what is genuinely its own — the answering-vs-creative distinction, the contamination rationale, and the `scope=` mechanics bullet. `test_the_ask_discipline_has_one_owner` pins both directions: the pointer must be present, and the old restatement's spine must be absent.

**Placement is split, deliberately.** The framework and the four generic questions are packaged doctrine, so every workspace gets them and adoption replaces them wholesale. Campaign-specific growth — extra questions, or striking/rephrasing a generic one — lives in the GM-owned `campaign-doctrine.md`, whose scaffold gains a commented stub. The section names both destinations: campaign-specific gaps go to `[[campaign-doctrine]]`, generic ones go upstream as a bunnyforge ticket.

**Doctrine owns the list; the tool surface carries a pointer only.** The `search`/`list_entities` scope mirrors are untouched — they exist because those tools have a `scope=` parameter the question governs, which is not an N-questions pattern and does not generalize. `campaign_overview` is the designated "call this before anything else" moment, so its docstring gains one sentence pointing at the AGENTS.md doctrine resource. No new tools, no new resources, no question list in any payload.

**No migration machinery.** Workspaces scaffolded before this change simply lack the stub section; nothing reads it mechanically. Same graceful-absence stance the doctrine-resource listing already takes for an absent `campaign-doctrine.md`.

## Portability read — please confirm before merging

With #65 deferred, no automated check scans packaged prose for campaign-specific vocabulary, so a deliberate line-by-line read is the only thing between this prose and every downstream workspace. **That read was a required checkpoint at every review stage on this branch and it came back clean — but it was performed by review agents, not by the GM.** Unlike #72 and #75, where the GM had read every shipped line before the PR opened, this branch was executed autonomously and no human has yet read the prose. So the basis is one step weaker than those PRs, and the GM's own read is the remaining gate rather than a formality.

What the agent read covered: every added line of `AGENTS.md` and `campaign-doctrine.md`, plus the `serve_mcp.py` docstring sentence, read against the ships-to-every-workspace lens at each of the three per-task reviews and again at the whole-branch review. Finding: every term is generic bunnyforge/TTRPG vocabulary already established elsewhere in the packaged file — NPCs, live canon, archive, `gm-only`, player-visible, `[[campaign-doctrine]]`, "a bunnyforge ticket". No campaign names, no setting nouns, no references to any particular workspace's contents. The first-person GM voice matches the file's existing convention and is workspace-neutral by construction.

One prose point worth the GM's eye specifically: question 1 offers **"a plot"** as a build-target category, while a later section in the same doctrine is titled **"Situations, not plots"**. The wording is the spec's own GM-settled decision and the two are arguably about different things (a category name vs. scenario structure), so it was left as designed — but it is the one line an agent holding both sections could stumble over.

## Test expectations

All green, no expected failures.

- System python: `Ran 935 tests … OK (skipped=58)` — baseline at `2800873` was `931 / OK / 57 skips`, so four new tests and one new skip (the mcp-gated one).
- With the optional `mcp` extra installed in a throwaway venv: `Ran 935 tests … OK` — **zero failures and zero skips, so the new `serve_mcp` test actually ran locally rather than being deferred to CI.** It was also watched failing for real (not skipping) before the docstring sentence was written. This is stronger evidence than #72 had, where the equivalent tests reached CI unrun.

Each new test was watched failing before its implementation landed. Two of them needed a correction the plan did not anticipate: the plan asserted on raw sliced prose, but the doctrine wraps at ~70 columns, so `"in one message"` and `"Task-start context"` straddle line breaks — the assertions would have failed against a correct implementation, and the two negative pins (`"ask me whether"`, `"One ask per task"`) were verified to be *vacuous* as raw-text checks, passing before the change they exist to guard. All four tests now normalize whitespace the way `test_serve_mcp.py` already does, and each was confirmed able to fail for the right reason — the defect class #73 exists to prevent.

## Operational impact

**Adoption reconcile, already anticipated.** This changes packaged `AGENTS.md`, so existing workspaces need the usual hand-reconcile on adoption; #69's release notes already anticipate #70 doing exactly this, and this branch adds one section and edits one, covered by the existing hand-reconcile/migration-recipe pointer. Existing `campaign-doctrine.md` files are not migrated and need not be — the stub only reaches new scaffolds, and nothing reads it mechanically.

No new dependencies, no config changes, no schema changes. The `mcp` extra stays optional.

**One follow-up worth a ticket, out of scope here.** The documented suite command `PYTHONPATH=src python3 -m unittest discover …` uses a *relative* path, which subprocess-spawning tests inherit and then fail to resolve from their temp-dir cwd. On a machine where `bunnyforge` is importable from the primary clone, those children silently import the primary clone's code instead of the tree under test. Pre-existing at the merge base and unrelated to this branch, but it means the documented command partially verifies the wrong artifact from a worktree. Every suite run reported above used an absolute `PYTHONPATH` for this reason.

## Provenance

- **Agent:** Claude Code (VS Code extension), executed via `superpowers:subagent-driven-development` — a fresh implementer subagent per task, a spec-and-quality review between tasks, and a whole-branch review before opening.
- **Model / version:** session `/model` directive: Opus 5 (1M context). Subagents were dispatched across cheaper tiers by task complexity; the whole-branch review ran on the most capable tier available.
