### PR TITLE
README: the wiki round-trip, and three claims that were wider than the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 An opinionated way to run a tabletop-RPG campaign as a plain-files
 workspace — designed to be managed collaboratively by a GM and an AI
-agent, with one-way publishing to a DokuWiki players' site.
+agent, with one-way publishing to a DokuWiki players' site and a separate
+one-way path back for what the players wrote there.
 
 Your campaign is a directory of Markdown files with front matter: NPCs,
 factions, places, sessions, mechanics. bunnyforge gives that directory a
 skeleton, reviews its integrity, generates names from culture inventories
-you define, and exports the player-visible slice to DokuWiki. Everything
-is a text file; the only state is your git history. Every command works
-offline except the wiki deploy itself — and even that keeps a fully
-offline path via `deploy-export --render-only`.
+you define, exports the player-visible slice to DokuWiki, and imports the
+players' own pages back as *perceptions* — recorded belief, never canon.
+Everything is a text file; the only state is your git history. Three
+things reach the network — the wiki deploy, `serve-mcp`, and `vscode
+install`/`update` fetching the extension — and the deploy keeps a fully
+offline path via `deploy-export --render-only`. The perceptions import is
+offline too: it reads DokuWiki's data directory, not its API.
 
 - **Python ≥ 3.11, zero runtime dependencies.**
 - **Agent-first doctrine.** `init` writes an `AGENTS.md` contract that
@@ -22,8 +26,10 @@ offline path via `deploy-export --render-only`.
   filling them in is answering questions rather than staring at a blank
   file. See [`docs/adopting-doctrine.md`](docs/adopting-doctrine.md) for
   how to adopt a new version.
-- **Player-visibility model.** Every file carries a `visibility` field;
-  the exporter enforces it, so GM-only material cannot leak to the wiki.
+- **Player-visibility model.** Every entity file carries a `visibility`
+  field, and the exporter enforces it on everything it walks — an unset or
+  unreadable value fails safe to `gm-only` — so GM-only material cannot
+  leak to the wiki.
 
 ## Install
 
@@ -51,7 +57,7 @@ entity files from the templates in `_Templates/`.
 | `build-sheets` | build one-page HTML reference sheets for a session |
 | `names` | generate culture-appropriate names |
 | `vscode` | install the preview extension and toggle editor colouring |
-| `serve-mcp` | serve the workspace to a remote AI agent over MCP — [guide](docs/serve-mcp.md) (needs `bunnyforge[mcp]`) |
+| `serve-mcp` | serve the workspace to a remote AI agent over MCP — reads, plus drafts and proposed revisions it writes for your review — [guide](docs/serve-mcp.md) (needs `bunnyforge[mcp]`) |
 | `test` | run the workspace test suite |
 
 Run `bunnyforge <command> --help` for a command's own options.
@@ -85,6 +91,15 @@ directory layout, wiki namespace, name-generator inventories. Commands
 work from any subdirectory (they walk up to the marker), from
 `$BUNNYFORGE_WORKSPACE`, or from anywhere with `--workspace PATH`.
 
+`_ExtractInbound/` is the third way material arrives, after authoring it
+yourself and importing perceptions: an inbound queue for text brought in
+from elsewhere — typically wiki pages unpacked from a tarball. Nothing in
+it is canon; it is unreviewed source, kept out of the canon read tools, and
+an agent reads it only when you ask it to extract. Spent sources move to
+`_ExtractInbound/_Done/` rather than being deleted. There is no CLI command
+for the queue — it is reachable over MCP, and
+[`docs/serve-mcp.md`](docs/serve-mcp.md) describes the flow.
+
 `init` also scaffolds a `tests/` folder. Its `README.md` explains the
 campaign tests it invites you to write — the setting-specific invariants
 `review checkup` cannot know, like "every NPC's faction actually exists" —
@@ -111,24 +126,36 @@ The [`samples/`](samples/) directory is a ladder of eight worked
 configurations, from a single people to a full multi-culture setting with
 registers and spelling variants.
 
-## DokuWiki export
+## DokuWiki: publishing out, perceptions back
 
 `export-player` renders the player-visible slice; `deploy-export` renders it
-into DokuWiki markup and deploys it to the wiki over its JSON-RPC API. Sync
-is strictly one-way: the wiki is a published artifact, never a source of
-truth. `import-perceptions` brings player-authored pages back as
-*perceptions* — recorded belief, explicitly not canon.
+into DokuWiki markup and deploys it to the wiki over its JSON-RPC API.
+Publishing is strictly one-way: the wiki is a published artifact, never a
+source of truth.
+
+`import-perceptions` is the return path, and it is one-way in its own
+direction — it reads the wiki and never writes to it. Player-authored pages
+land in `Perceptions/` carrying `canon: perception`: a record of what the
+players believed at a point in time, explicitly not canon, and never to be
+corrected in place — correcting them destroys the only thing they are good
+for. It reads DokuWiki's data directory rather than its API, which is what
+makes it offline and what makes `--as-of` exact: every historical revision
+is already on disk, so a session-boundary snapshot costs nothing.
 
 ## Dry runs and --go
 
-Every mutating command follows one convention: **the default run is a dry
-run; `--go` performs the writes.** A bare `bunnyforge deploy-export` fetches
-and prints the full deploy plan without writing anything; a bare
-`bunnyforge import-perceptions` reports what it would import. Re-run with
-`--go` to act. (`deploy-export --render-only` is not a rehearsal — it is a
-different, offline deliverable, and needs no wiki config at all.)
+The two commands that write across the wiki boundary follow one convention:
+**the default run is a dry run; `--go` performs the writes.** A bare
+`bunnyforge deploy-export` fetches and prints the full deploy plan without
+writing anything; a bare `bunnyforge import-perceptions` reports what it
+would import. Re-run with `--go` to act. (`deploy-export --render-only` is
+not a rehearsal — it is a different, offline deliverable, and needs no wiki
+config at all.)
 
-Future mutating commands inherit this convention.
+The commands that only generate derived output inside the workspace —
+`export-player`, `build-sheets` — just write, because `_Export/` and
+`_Sheets/` are disposable and regenerable. Future commands that cross the
+wiki boundary inherit the `--go` convention.
 
 ## Development
 


### PR DESCRIPTION
Closes #78.

Started from a single question — does "one-way publishing to a DokuWiki players' site" still hold now that perceptions come back? — and turned into a full audit of the README against the code. The short answer is that "one-way" was never wrong, but it named one of two one-way flows; the audit then turned up three separate claims that were wider than the code supports.

No code changes. README only.

## Files changed

- `README.md` *(modified)* — tagline and intro paragraph, the player-visibility bullet, the `serve-mcp` table row, the DokuWiki section, the dry-run section, and a new paragraph on `_ExtractInbound/` under "The workspace".

## Work breakdown

**The wiki round-trip.** `import_perceptions.py` dates to the initial public tree — the same commit as the tagline — so this is a framing gap, not drift. Its own docstring calls it "one-way export of player-authored DokuWiki pages", direction wiki → workspace, "never writes to the wiki". So there are two one-way flows, and the README named one. The tagline now names both, the intro paragraph mentions the import, and the section formerly titled "DokuWiki export" is now "DokuWiki: publishing out, perceptions back" and explains the mechanism: reading DokuWiki's data directory instead of its API is what makes the import offline *and* what makes `--as-of` exact, since every historical revision is already in `data/attic/`.

**"Every command works offline except the wiki deploy itself" — wrong.** Three things reach the network, not one:
- `deploy-export`, over JSON-RPC (unless `--render-only`);
- `serve-mcp`, which serves remotely and whose `--check URL` makes an outbound HTTP request (`serve_mcp.py:302`);
- `bunnyforge vscode install`/`update`, which fetches `api.github.com/repos/.../releases/latest` (`vscode.py:56-57, 468`).

Worth noting the one that surprised me: `import-perceptions` touches the wiki but is fully offline, because it reads the filesystem rather than the API. The README now says so, since "touches the wiki" is the natural reason a reader would assume otherwise.

**"Every mutating command follows one convention: the default run is a dry run; `--go` performs the writes" — wrong.** Only `deploy-export` and `import-perceptions` implement `--go`. `export-player` and `build-sheets` write immediately and have no dry-run flag at all. That is a defensible design — `export-player`'s own docstring calls `_Export/` "disposable, generated output… safe to delete and regenerate at any time" — so the fix narrows the claim to the commands that write across the wiki boundary and says explicitly why the others are exempt, rather than pretending they follow a convention they don't. "Future mutating commands inherit this convention" becomes "future commands that cross the wiki boundary".

**"Every file carries a `visibility` field" — overstated.** Entity files do. Briefs are explicitly exempt (`_common.py:108-109`), and root documents like `front-burner.md` carry no entity front matter at all; `review.py:144-147` only requires the field on `category == "entity"`. The enforcement half is the part that actually protects you, and it is stronger than the sentence implied: the exporter normalizes visibility on every file it walks and fails safe to `gm-only` on an unset or unreadable value. The bullet now says that.

**`_ExtractInbound/` had zero README presence.** It is the third way material enters a workspace, after authoring it yourself and importing perceptions, and it is thoroughly documented in `docs/serve-mcp.md` — just nowhere in the README. Added a short paragraph under "The workspace" covering what it is, that nothing in it is canon, that an agent reads it only when asked, that spent sources move to `_Done/` rather than being deleted, and that there is no CLI command for it — it is MCP-only, which is itself worth a reader knowing.

**`serve-mcp` read/write.** The table row said "serve the workspace to a remote AI agent over MCP", which reads as read-only. A connected agent writes drafts and proposed revisions by default (and can edit canon directly behind `--allow-direct-edits`). The row now says so; the flag detail stays in the linked guide.

## What was checked and found correct

Recorded so the next audit need not redo it: the subcommand table matches `cli.py`'s `_COMMANDS`/`_SUMMARIES` exactly, all ten; the review suite names `checkup` and `wiki` match `review.py:536`; "Python ≥ 3.11, zero runtime dependencies" matches `pyproject.toml` (the only dependency is the optional `mcp` extra); the DokuWiki export section's description of the JSON-RPC deploy and of perceptions as non-canon is accurate; and the development install/test commands work as written.

Deliberately **not** added, to keep the README a README rather than a manual: `review --html`, the `[[review.accepted]]` suppression mechanism, `deploy-export`'s drift handling, `--fetch-latest`, and `scripts/mcp-session.py`. All are real and all are documented elsewhere; none is needed to orient a new reader.

## Test expectations

All green, no expected failures. `Ran 931 tests … OK (skipped=57)` — identical to the baseline on `main` at `2800873`, as expected for a documentation-only change. No test reads the root `README.md`, so this is a regression check rather than coverage of the change; the claims above were verified by reading the source, with file:line cited in the work breakdown.

## Operational impact

None. No code, no dependencies, no packaged data. The packaged `src/bunnyforge/README.md` (which *is* pinned by `test_init.py`) is untouched — this is the repository README only.

## Provenance

- **Agent:** Claude Code (VS Code extension), inline execution with a background subagent for the audit sweep, whose findings I verified independently before acting on them (it read the offline claim as accurate; checking `serve-mcp` and `vscode` myself is what turned that into a finding).
- **Model / version:** session `/model` directive: Opus 5 (1M context).
