### PR TITLE
Release 0.5.0: changelog, and the version bump that lets the tag land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+Notable changes to bunnyforge, in the format of
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html); while
+the major version is `0`, breaking changes arrive in minor bumps.
+
+This file starts at 0.5.0. For anything earlier, see the
+[releases page](https://github.com/dcltdw/bunnyforge/releases) and the git
+history.
+
+## [0.5.0] — 2026-08-18
+
+The release where retrieval became scoped and ordered, and where the
+workspace's own vocabulary got a rule: a leading underscore means not-canon.
+Read **Migration** before upgrading a live campaign — this one is not a clean
+drop-in for an existing workspace.
+
+### Added
+
+- **Scoped retrieval.** `search` and `list_entities` take
+  `scope: live | archive | both` (default `both`), every result carries an
+  `archived` flag, and `campaign_overview` reports `archive_sections`
+  alongside the flat archive count. Sections resolve across both trees, so
+  `section="NPCs"` covers `NPCs/` and `Archive/NPCs/` together. Doctrine
+  states that the scope is the GM's call for creative work. (#72)
+- **Task-start context doctrine.** Packaged `AGENTS.md` gains a
+  `## Task-start context` section: four questions an agent answers before
+  work begins — what is being built, whether NPCs are new or reused, the
+  retrieval scope, and whether the output is player-visible — asked as one
+  bundled message, with answers that persist for the task. The
+  `campaign-doctrine.md` scaffold gains a stub for campaign-specific
+  questions, and `campaign_overview`'s description points at the list. (#76)
+- **`campaign-doctrine.md`.** A GM-owned doctrine file beside the
+  package-owned `AGENTS.md`, scaffolded by `init`, never overwritten by an
+  adoption. (#64)
+- **Staging is readable over MCP.** `list_staged` and `read_staged` let an
+  agent read back drafts it wrote in an earlier session. The canon read tools
+  are untouched, and promotion stays manual and GM-only. (#60)
+
+### Changed
+
+- **A leading underscore means not-canon, biconditionally.** `_Archive/`
+  becomes `Archive/` — it is the record of what happened, so it is canon and
+  is now ordinary walked content, reaching review, player export and wiki
+  deploy under normal visibility rules. Generated output takes the marker
+  instead: `Sheets/`, `Reviews/` and `Export/` become `_Sheets/`,
+  `_Reviews/`, `_Export/`. The repo-infrastructure directories (`docs/`,
+  `scripts/`, `tests/`) keep their ecosystem names and are named as exempt in
+  doctrine. One predicate, `_common.is_machinery`, now backs every surface
+  that used to decide this separately. (#67)
+- **`AGENTS.md` is package-owned and byte-identical in every workspace,**
+  so adopting new doctrine is a file copy rather than a merge; anything
+  campaign-specific belongs in `campaign-doctrine.md`. (#64)
+- **`serve-mcp`'s staging directory split in two,** with separate
+  vocabularies and guards: `_AgentDrafts/` for agent output with a full draft
+  lifecycle, and `_ExtractInbound/` for the GM's inbound queue, read-only and
+  only when asked. (#61)
+- **`search` result order is now a contract:** live hits before archived
+  ones, workspace-path order within each tree. Deliberately not a relevance
+  promise. (#75)
+- **README** corrects three claims that were wider than the code — which
+  commands reach the network, which ones honour the `--go` dry-run
+  convention, and which files carry a `visibility` field — and documents the
+  wiki round-trip and `_ExtractInbound/`. (#77)
+
+### Fixed
+
+- **`search` no longer starves live results under its cap.** `Archive/`
+  sorts before every live section, so on a campaign whose archive had
+  outgrown `SEARCH_CAP` a default search could return 50 archived hits and
+  zero live ones, hiding the current answer. Live-first ordering means every
+  live hit is in the reply whenever live matches fit under the cap. The
+  truncation notice now names which tree was cut and no longer fires on a
+  reply that exactly fills the cap. `SEARCH_CAP` stays 50. (#75)
+- **Name collisions across the canon trees now fail review.** A
+  `name-collisions` check runs as a `checkup` **error**, closing a gap where
+  a collision could pass review and surface only at deploy. (#67)
+
+### Internal
+
+- Enumerator exclusion tests assert exact equality on the whole enumerated
+  result, one fixture per filter, so they can actually fail: three mutations
+  that previously left the entire suite green now break it. Test-only, no
+  production change. (#73)
+
+### Migration
+
+**Existing workspaces need a hand-reconcile.** `AGENTS.md` ships
+byte-identical, and both #64 and #67 rewrote it substantially, as did the
+task-start section in #76. The one-time recipe is in
+[`docs/adopting-doctrine.md`](docs/adopting-doctrine.md) →
+"Migrating to the not-canon underscore".
+
+**The archive now flows into player export and wiki deploy** under normal
+visibility rules. A campaign with retired `player-visible` files will
+republish them under a new `ns:archive:…` namespace and orphan the old pages.
+See step 5 of the migration recipe.
+
+**Packaged prose in this release was cleared by deliberate human reads at PR
+time, not by an automated check** — nothing yet screens `src/bunnyforge/data/`
+for campaign-specific terms. That is the basis for the portability claim.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bunnyforge"
-version = "0.4.0"
+version = "0.5.0"
 description = "Tools for running a TTRPG campaign workspace: review, export, deploy, name generation."
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Release prep for **0.5.0**, per #69. Two files: a new `CHANGELOG.md` and the one-line version bump. Merging this publishes nothing — it unblocks the tag, which is pushed separately per `README.md` → "Releasing".

Follows the shape of the last release (PR #58 → `release/0.4.0`), with the changelog added on top.

## Files changed

- `CHANGELOG.md` *(new)* — starts at 0.5.0, deliberately not backfilled.
- `pyproject.toml` *(modified)* — `version = "0.4.0"` → `version = "0.5.0"`. Confirmed the only occurrence of the version string in the repo (grepped `*.py`, `*.toml`, `*.md`, `*.yml`, excluding `docs/superpowers/`).

## Work breakdown

**Why 0.5.0, not 0.4.1 or 1.0.0.** New features and changed workspace vocabulary, so not a patch. Pre-1.0, where breaking changes conventionally ride the minor bump, so not a major — and #69 already argued the doctrine changes call for minor. This is nonetheless a **breaking release for existing workspaces**: `Archive/` moved, generated directories were renamed, and `AGENTS.md` was rewritten three times over. The changelog's Migration section says so up front rather than burying it.

**The changelog starts at 0.5.0 on purpose.** Reconstructing entries for 0.2.x–0.4.0 after the fact would be invention dressed as record — the releases page and git history are the honest source for those. The file's header says where to look instead.

**Format** is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — Added / Changed / Fixed, plus two extensions this release needs: an **Internal** section, so the test-only work is recorded without implying user-facing change, and a **Migration** section, because #69 explicitly asks that the release notes point at the migration recipe rather than assume a clean upgrade.

**Contents were derived from the ten commits since `v0.4.0`, not from #69's checklist**, which turned out to be incomplete. Alongside the six tickets it tracks (#64, #62, #66, #68, #71, #70) the release also carries:

- **#60** — `list_staged` / `read_staged`, so an MCP agent can read back drafts from an earlier session;
- **#61** — the staging split into `_AgentDrafts/` and `_ExtractInbound/`;
- **#77** — the README audit.

All three merged after #69 was written and were unreleased but unlisted there. Worth noting for whoever reconciles the tracking issue.

Each entry was written from the merged PR's own description rather than from the commit subject, and the migration recipe's section title was checked against `docs/adopting-doctrine.md:66` rather than copied from #69, which cites it with a `(#62)` suffix the heading does not have.

## Test expectations

All green, no expected failures.

- System python: `Ran 935 tests … OK (skipped=58)`.
- With the `mcp` extra installed in a throwaway venv: `Ran 935 tests … OK` — zero skips, so the MCP and OAuth tests actually executed rather than being `HAVE_MCP`-skipped. Same footing as PR #58's release check.

Nothing here is covered by tests — no test reads `CHANGELOG.md`, and none pins the version string — so these runs are a regression check on the tree being tagged, not evidence about the changed lines. The version bump was verified by parsing `pyproject.toml` the way the build will read it (`tomllib` → `0.5.0`).

## Operational impact

**Merging this publishes nothing.** The tag is the publishing step, and it is deliberately not part of this PR: PyPI never lets a version number be reused, so `v0.5.0` should be pushed only once this has landed on `main` and the version is confirmed there. `publish.yml` verifies the tag against `pyproject.toml` and will fail a tag that disagrees.

After the tag, per the README's procedure: confirm the release is actually installable in a clean virtualenv on a path holding no checkout, checking the version `pip show` reports rather than trusting the workflow's green tick — and expect index lag for a few minutes.

Two follow-ups #69 names for after the release cuts, neither done here: the **Anjeong campaign migration** (pinned to `0.3.1`; the recipe is already written and shipped, and #69 says it deserves its own ticket), and the two deferred guards **#65** and **#74**.

## Provenance

- **Agent:** Claude Code (VS Code extension), inline execution.
- **Model / version:** session `/model` directive: Opus 5 (1M context).
