### PR TITLE
Document how to create the named tunnel serve-mcp already recommends

### DIFF
--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -32,13 +32,90 @@ is refused with `421` before it reaches authentication.
 
 A **named tunnel** (free with a Cloudflare-managed domain) is the
 recommended recipe: the hostname — and therefore the connector URL in
-claude.ai and the OAuth trust it anchors — survives restarts. A quick
-tunnel (`cloudflared tunnel --url http://127.0.0.1:8765`) also works, but
-its hostname changes every run: pass the new hostname to `--public-host`
-and update the connector URL in claude.ai each time.
+claude.ai and the OAuth trust it anchors — survives restarts. Creating
+one is six commands, once: see the next section. A quick tunnel
+(`cloudflared tunnel --url http://127.0.0.1:8765`) also works and needs
+no domain, but its hostname changes every run: pass the new hostname to
+`--public-host` and update the connector URL in claude.ai each time.
 
 Local testing needs no tunnel: `--no-auth` (unauthenticated, loud
 warning) or `--auth-key` with the default localhost issuer.
+
+## Set up a named tunnel (once)
+
+Needs a domain whose nameservers are Cloudflare's. Everything below is
+free, and once it is done the hostname is permanent.
+
+1. **Authorise `cloudflared` against your zone.**
+
+        cloudflared tunnel login
+
+   Opens a browser, asks which zone, and writes
+   `~/.cloudflared/cert.pem`. That certificate is what lets the next two
+   commands create tunnels and edit DNS on your account — treat it as a
+   credential.
+
+2. **Create the tunnel.**
+
+        cloudflared tunnel create bunnyforge-mcp
+
+   Prints a UUID and writes `~/.cloudflared/<UUID>.json`. The tunnel
+   exists at this point but routes nothing and runs nowhere.
+
+3. **Point a hostname at it.**
+
+        cloudflared tunnel route dns bunnyforge-mcp mcp.example.com
+
+   Creates a proxied `CNAME` to `<UUID>.cfargotunnel.com`. This is the
+   step that needs Cloudflare as your DNS authority, and it is why the
+   hostname is permanent: the record belongs to the tunnel rather than
+   to a session. If the record already exists and points elsewhere, the
+   command refuses rather than clobbering it.
+
+4. **Say where traffic goes** — `~/.cloudflared/config.yml`:
+
+        tunnel: bunnyforge-mcp
+        credentials-file: /Users/you/.cloudflared/<UUID>.json
+
+        ingress:
+          - hostname: mcp.example.com
+            service: http://127.0.0.1:8765
+          - service: http_status:404
+
+   `8765` is `serve-mcp`'s default port; move one and move the other.
+   The trailing `http_status:404` is the catch-all rule, and it is
+   required — cloudflared refuses to start without one. Give
+   `credentials-file` an absolute path: the launch agent in step 6 does
+   not expand `~`.
+
+5. **Run it by hand once,** and prove the whole path before trusting it:
+
+        cloudflared tunnel run bunnyforge-mcp
+        bunnyforge serve-mcp --public-host mcp.example.com
+        bunnyforge serve-mcp --check https://mcp.example.com
+
+6. **Make the tunnel start on its own.**
+
+        cloudflared service install
+
+   On macOS this is a *user launch agent* and takes no `sudo`; it reads
+   the `config.yml` from step 4. On Linux the same command installs a
+   system service and does need `sudo`. Note what a launch agent does
+   not do: it starts **at login, not at boot**, so a machine that
+   reboots with nobody logging in comes back without a tunnel.
+
+Two things this deliberately does not do.
+
+**Starting the tunnel does not start `serve-mcp`.** The tunnel is the
+route; the server is still yours to run. Until it is up the hostname
+answers `502`, which is the correct answer rather than a fault.
+
+**Do not put Cloudflare Access in front of the hostname.** The instinct
+is a good one — everything served is GM-only — but the mechanism is
+wrong: claude.ai has to complete this server's own OAuth flow against
+that URL, and it cannot log through an Access challenge to get there.
+The authentication is already present in the GM key and the OAuth
+grant, without which the server refuses to start.
 
 ## Check it before adding the connector
 
@@ -179,6 +256,9 @@ but not already-issued tokens — delete the state file for that.
 ## Troubleshooting
 
 - **401 from `/mcp`:** no or expired token — reconnect from claude.ai.
+- **502 from the public hostname:** the tunnel is up and the server is
+  not, or the server is on a port the `ingress` rule does not name. Start
+  `serve-mcp`; check the port in `~/.cloudflared/config.yml` matches.
 - **421 Invalid Host header through a tunnel:** DNS-rebinding protection
   does not know your public hostname. Pass `--public-host <hostname>` —
   the same hostname the tunnel serves, with no scheme and no port. The


### PR DESCRIPTION
Closes #83.

`docs/serve-mcp.md` recommended a named tunnel, explained why it is the right choice, and then showed `cloudflared tunnel run <name>` — a command that only works once the tunnel exists. Nothing in the document said how to get one. The quick-tunnel alternative was fully specified in a single line, so the *less* recommended option was the only one the document actually enabled.

Docs only. No code, no config, no packaged data.

## Files changed

- `docs/serve-mcp.md` *(modified)* — a new "Set up a named tunnel (once)" section between "Run behind a tunnel" and the pre-flight check; a forward pointer from the existing recommendation; one new troubleshooting entry.

## Work breakdown

**The six steps**, in the order they have to happen: `tunnel login` (writes the cert that authorises the next two commands), `tunnel create` (UUID plus credentials), `route dns` (the proxied CNAME — the step that actually needs Cloudflare as DNS authority, and the reason the hostname is permanent), `config.yml`, a by-hand run that ends in `serve-mcp --check`, and `cloudflared service install`.

**Four traps are called out**, each because it is either silent or presents as a different fault than it is:

- **The trailing `service: http_status:404` is mandatory.** cloudflared refuses to start without a catch-all ingress rule, and the failure does not obviously name the cause.
- **`credentials-file` must be an absolute path** — the launch agent does not expand `~`.
- **`cloudflared service install` is a *user launch agent* on macOS and takes no `sudo`.** This one I had wrong from memory and corrected against the installed CLI's own help, which describes itself as managing "the cloudflared launch agent". The consequence is the part worth documenting: a launch agent starts **at login, not at boot**, so a machine that reboots unattended comes back with no tunnel. Anyone reading "permanent" as "survives reboot headless" is owed that sentence. Linux is noted as differing — system service, needs `sudo`.
- **Starting the tunnel does not start `serve-mcp`.** Until the server is up the hostname answers `502`, which is correct rather than broken, and reads exactly like a misconfigured tunnel. `502` also joins the troubleshooting list, where it was missing.

**One anti-recommendation.** Do not put Cloudflare Access in front of the hostname. It is the natural instinct once a zone is on Cloudflare — everything served here is GM-only, so wanting another gate is sound — but it breaks the connector: claude.ai must complete this server's own OAuth flow against that URL and cannot log through an Access challenge to reach it. The section says so, and says what stands in its place: the GM key and the OAuth grant, without which the server refuses to start.

Written in the document's existing register — four-space code blocks, reason-first prose, ~70 column wrap — rather than pasted in from another format.

## Test expectations

None — documentation only. The suite is unchanged at `Ran 935 tests … OK (skipped=58)`, which is a regression check on the tree, not evidence about the changed lines.

The commands themselves were verified two ways. The `cloudflared` surface (`tunnel login` / `create` / `route dns` / `run`, and `service install`) was checked against the CLI installed on this machine, version 2026.8.2, including the launch-agent wording that corrected my initial assumption. The bunnyforge side (`--public-host`, `--check`, the `8765` default port, `BUNNYFORGE_MCP_KEY`) was checked against `serve_mcp.py`'s argument parser.

**Not verified by execution:** no tunnel was created on any Cloudflare account, so steps 1–4 and 6 are verified against the CLI's documented interface rather than by running them end to end. Worth a real run before anyone treats the section as proven.

## Operational impact

None on the package. Reader-facing: the document now enables the option it recommends, and the two behaviours most likely to be misread as breakage — `502` before the server starts, and a tunnel that is absent after an unattended reboot — are stated rather than discovered.

## Provenance

- **Agent:** Claude Code (VS Code extension), inline execution.
- **Model / version:** session `/model` directive: Opus 5 (1M context).
