### PR TITLE
CHANGELOG gains the [Unreleased] section its own format prescribes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This file starts at 0.5.0. For anything earlier, see the
 [releases page](https://github.com/dcltdw/bunnyforge/releases) and the git
 history.
 
+Entries land under `[Unreleased]` in the same PR as the change they
+record; the release PR renames that section to the version it ships and
+starts a fresh one.
+
+## [Unreleased]
+
+### Changed
+
+- `docs/serve-mcp.md` now walks through creating the named tunnel it
+  recommends — login, create, route dns, config, launch agent — plus the
+  traps: the ingress catch-all is mandatory, the credentials path must be
+  absolute, a launch agent starts at login rather than boot, and the
+  hostname answers 502 until `serve-mcp` is started. One
+  anti-recommendation: no Cloudflare Access in front of the hostname; the
+  connector must complete the server's own OAuth flow against it. (#84)
+
 ## [0.5.0] — 2026-08-18
 
 The release where retrieval became scoped and ordered, and where the
@@ -100,3 +116,6 @@ See step 5 of the migration recipe.
 **Packaged prose in this release was cleared by deliberate human reads at PR
 time, not by an automated check** — nothing yet screens `src/bunnyforge/data/`
 for campaign-specific terms. That is the basis for the portability claim.
+
+[Unreleased]: https://github.com/dcltdw/bunnyforge/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dcltdw/bunnyforge/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ no API token stored anywhere.
 1. Land the changes on `main` in the usual way (branch, PR, review).
 2. Bump `version` in `pyproject.toml`. **This is a separate step from the
    tag, which is why they drift** — CI refuses a tag that disagrees with it.
+   In the same PR, rename `CHANGELOG.md`'s `[Unreleased]` section to
+   `[X.Y.Z] — <date>`, start a fresh empty `[Unreleased]`, and update the
+   link definitions at the bottom of the file.
 3. Tag and push:
 
        git tag vX.Y.Z && git push origin vX.Y.Z


### PR DESCRIPTION
Closes #85.

`CHANGELOG.md` declares Keep a Changelog 1.1.0 and then omits the convention's accumulation point: `main` has already moved one commit past 0.5.0 (#84) with nowhere to record it. This adds the `## [Unreleased]` section, backfills #84's entry, adds the missing link definitions, and hooks the release procedure so the section gets renamed at each cut rather than re-derived.

Docs only. The companion change — the standing rule that every PR carries its own entry — lands in the `dcltdw:opening-a-pr` skill (separate PR in the agents repo), not in this repository.

## Files changed

- `CHANGELOG.md` *(modified)* — `## [Unreleased]` with #84's entry under Changed; one sentence stating the convention; `[Unreleased]`/`[0.5.0]` compare-link definitions at the bottom (the `[0.5.0]` bracket was a dead reference).
- `README.md` *(modified)* — "Releasing" step 2 gains the changelog half of the release PR: rename `[Unreleased]` to `[X.Y.Z] — date`, start a fresh empty one, update the links.

## Work breakdown

**Entries ride in the PR, not after the merge.** Three reasons, recorded in #85: the never-commit-to-main rule would force every post-merge update into its own PR; the change and its record land atomically; and it is what Keep a Changelog prescribes. Once this lands, "update the changelog" stops being a separate action anyone can forget after a merge — the release PR's rename (as #79 did by hand) is the only remaining changelog ceremony, and README now says so.

**#84 is backfilled** under Changed, per the house precedent that significant docs earn entries (#77 got one in 0.5.0). The meta-change in this PR — adding the section itself — gets no entry; it is scaffolding, not a notable change.

**A CI guard was considered and deliberately declined** (decision 2026-08-19, recorded in #85): prose only, accepting that a forgotten entry is invisible until a human notices. If that starts happening, the `changelog-enforcer` pattern (fail any PR that neither touches `CHANGELOG.md` nor carries a `no-changelog` label) is the ready remedy.

## Test expectations

None — documentation only. Suite unchanged at `Ran 935 tests … OK (skipped=58)` as a regression check; nothing reads `CHANGELOG.md` or the README's Releasing section.

## Operational impact

None on the package. Process-facing: future release PRs carry one more mechanical step (the rename), now written down in the Releasing procedure rather than reconstructed from #79's example.

## Provenance

- **Agent:** Claude Code (VS Code extension), inline execution.
- **Model / version:** session `/model` directive: Fable 5.
