### PR TITLE
serve-mcp: --log-file routes the access log to a rotated file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ starts a fresh one.
 
 ## [Unreleased]
 
+### Added
+
+- `bunnyforge serve-mcp --log-file [PATH]` routes uvicorn's logs to a
+  self-pruning file (rotated at midnight, 14 days kept) instead of
+  cluttering the terminal with access lines; errors still reach stderr
+  too. Bare `--log-file` picks a platform default:
+  `~/Library/Logs/bunnyforge/mcp.log` on macOS,
+  `$XDG_STATE_HOME/bunnyforge/mcp.log` elsewhere. (#87)
+
 ### Changed
 
 - `docs/serve-mcp.md` now walks through creating the named tunnel it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ starts a fresh one.
 ### Added
 
 - `bunnyforge serve-mcp --log-file [PATH]` routes uvicorn's logs to a
-  self-pruning file (rotated at midnight, 14 days kept) instead of
-  cluttering the terminal with access lines; errors still reach stderr
-  too. Bare `--log-file` picks a platform default:
+  self-pruning file (rotated at midnight, 14 rotated days kept
+  alongside the live one) instead of cluttering the terminal with
+  access lines; errors still reach stderr too. Bare `--log-file` picks
+  a platform default:
   `~/Library/Logs/bunnyforge/mcp.log` on macOS,
   `$XDG_STATE_HOME/bunnyforge/mcp.log` elsewhere. (#87)
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -253,6 +253,28 @@ Delete the token state file and restart the server:
 the consent flow again. Changing the GM key invalidates future grants
 but not already-issued tokens — delete the state file for that.
 
+## Logging
+
+By default uvicorn writes every request to stderr — run in a background
+terminal, that clutters it with access lines. `--log-file` moves them to
+a self-pruning file instead:
+
+    bunnyforge serve-mcp --public-host mcp.example.com --log-file
+
+With no value the log goes to `~/Library/Logs/bunnyforge/mcp.log` on
+macOS and `$XDG_STATE_HOME/bunnyforge/mcp.log` (default
+`~/.local/state/bunnyforge/mcp.log`) elsewhere; pass a path to choose.
+The file rotates at midnight and 14 days are kept — the server prunes
+its own logs, nothing else to configure.
+
+Access lines go only to the file. Errors — the startup banner, bind
+failures, tracebacks — still reach stderr as well, so a crashed server
+says why in the terminal while the file stays a complete record of the
+run.
+
+`scripts/mcp-session.py` already captures the whole stdout/stderr stream
+to its own `server.log`; it needs no flag and is unchanged.
+
 ## Troubleshooting
 
 - **401 from `/mcp`:** no or expired token — reconnect from claude.ai.

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -264,13 +264,16 @@ moves them to a self-pruning file instead:
 With no value the log goes to `~/Library/Logs/bunnyforge/mcp.log` on
 macOS and `$XDG_STATE_HOME/bunnyforge/mcp.log` (default
 `~/.local/state/bunnyforge/mcp.log`) elsewhere; pass a path to choose.
-The file rotates at midnight and 14 days are kept — the server prunes
-its own logs, nothing else to configure.
+The resolved path is printed at startup. The file rotates at midnight
+and 14 rotated days are kept alongside the live one — the server
+prunes its own logs, nothing else to configure. If the file can't be
+written, `serve-mcp` refuses with one line and exits 1 rather than
+starting up and failing later.
 
 Access lines go only to the file. Errors — the startup banner, bind
 failures, tracebacks — still reach stderr as well, so a crashed server
-says why in the terminal while the file stays a complete record of the
-run.
+says why in the terminal and the file keeps the same errors alongside
+the access lines.
 
 `scripts/mcp-session.py` already captures the whole stdout/stderr stream
 to its own `server.log`; it needs no flag and is unchanged.

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -255,9 +255,9 @@ but not already-issued tokens — delete the state file for that.
 
 ## Logging
 
-By default uvicorn writes every request to stderr — run in a background
-terminal, that clutters it with access lines. `--log-file` moves them to
-a self-pruning file instead:
+By default uvicorn writes every request to the terminal — run in a
+background terminal, that clutters it with access lines. `--log-file`
+moves them to a self-pruning file instead:
 
     bunnyforge serve-mcp --public-host mcp.example.com --log-file
 

--- a/docs/superpowers/plans/2026-08-21-serve-mcp-log-file.md
+++ b/docs/superpowers/plans/2026-08-21-serve-mcp-log-file.md
@@ -1,0 +1,465 @@
+# serve-mcp `--log-file` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An opt-in `--log-file [PATH]` flag on `bunnyforge serve-mcp` that routes uvicorn's access log to a self-rotating file (midnight, 14 kept) while errors still reach stderr; without the flag, behavior is unchanged byte-for-byte.
+
+**Architecture:** Two pure helpers in `serve_mcp.py` — `_default_log_path()` (platform default location) and `_log_config(path)` (a `dictConfig` dict for uvicorn with ONE shared `TimedRotatingFileHandler`) — plus a small `main()` integration: create the log directory, refuse with one stderr line on `OSError`, pass `log_config=` to `uvicorn.run` only when the flag is present. No new modules, no new dependencies.
+
+**Tech Stack:** Python stdlib (`argparse`, `logging.handlers`, `pathlib`), uvicorn's `log_config=` parameter, `unittest` (this repo does not use pytest).
+
+**Spec:** `docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md` — read it first; the plan argues from it.
+
+## Global Constraints
+
+- Issue: dcltdw/bunnyforge#87. Every commit message body carries `Refs #87` (the PR will carry `Closes #87`).
+- Work happens on branch `worktree-serve-mcp-log-file` in the worktree at `.claude/worktrees/serve-mcp-log-file` (already created; the spec is already committed there).
+- Test runner: `python3 -m unittest <module> -v` for one module, `python3 -m unittest discover -s tests` for the suite. Baseline is green: 935 tests, OK (skipped=58).
+- The `mcp` SDK (and uvicorn, which ships with the `[mcp]` extra) is optional: `serve_mcp.py` must stay importable on bare Python, so never import uvicorn at module top level. Tests needing it are guarded with `@unittest.skipUnless(HAVE_MCP, ...)` (the `HAVE_MCP` constant already exists in `tests/test_serve_mcp.py`).
+- No test opens a socket or reaches a real `uvicorn.run` — the run is mocked where needed.
+- With `--log-file` absent, `uvicorn.run` must be called WITHOUT a `log_config` kwarg at all (not `log_config=None`), so today's default logging is untouched.
+- Rotation values are fixed: `when="midnight"`, `backupCount=14`. No tuning flags.
+- Exactly ONE file handler shared by all uvicorn loggers (two rotating handlers on one file collide on the rollover rename).
+- `scripts/mcp-session.py` is NOT modified.
+- Code style: follow the file's existing look — 4-space indent, lowercase one-line error messages to stderr, comments only for non-obvious constraints.
+- Commit trailer: `Co-Authored-By:` the current AI model, per repo convention.
+
+---
+
+### Task 1: `_default_log_path()` and the `--log-file` parser flag
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (imports at ~line 29; new helper just above `def build_parser()` at ~line 250; new argument inside `build_parser()` after the `--no-auth` argument)
+- Test: `tests/test_serve_mcp.py` (new test class after `TestMainGuards`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `_default_log_path() -> pathlib.Path` (module-level, underscore-private), and `build_parser()` gaining `--log-file` with `nargs="?"`; parsed value `args.log_file` is `None` when absent, `str(_default_log_path())` when bare, or the given string. Task 3 consumes `args.log_file`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_serve_mcp.py`, directly after the `TestMainGuards` class, add:
+
+```python
+class TestLogFileFlag(unittest.TestCase):
+    """--log-file parsing and the platform default path — bare Python."""
+
+    def parse(self, argv):
+        return serve_mcp.build_parser().parse_args(argv)
+
+    def test_absent_means_none(self):
+        self.assertIsNone(self.parse([]).log_file)
+
+    def test_bare_flag_uses_platform_default(self):
+        self.assertEqual(self.parse(["--log-file"]).log_file,
+                         str(serve_mcp._default_log_path()))
+
+    def test_explicit_path_wins(self):
+        self.assertEqual(self.parse(["--log-file", "/tmp/x.log"]).log_file,
+                         "/tmp/x.log")
+
+    def test_default_path_on_macos(self):
+        with mock.patch("sys.platform", "darwin"):
+            self.assertEqual(
+                serve_mcp._default_log_path(),
+                Path.home() / "Library" / "Logs" / "bunnyforge" / "mcp.log")
+
+    def test_default_path_honors_xdg_state_home(self):
+        with mock.patch("sys.platform", "linux"), \
+             mock.patch.dict(os.environ, {"XDG_STATE_HOME": "/var/state"}):
+            self.assertEqual(serve_mcp._default_log_path(),
+                             Path("/var/state/bunnyforge/mcp.log"))
+
+    def test_default_path_falls_back_without_xdg(self):
+        with mock.patch("sys.platform", "linux"), \
+             mock.patch.dict(os.environ, {"XDG_STATE_HOME": ""}):
+            self.assertEqual(
+                serve_mcp._default_log_path(),
+                Path.home() / ".local" / "state" / "bunnyforge" / "mcp.log")
+```
+
+(`unittest`, `mock`, `os`, and `Path` are already imported at the top of the test file.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_serve_mcp.TestLogFileFlag -v`
+Expected: errors — `AttributeError: module 'bunnyforge.serve_mcp' has no attribute '_default_log_path'` and `'Namespace' object has no attribute 'log_file'`.
+
+- [ ] **Step 3: Implement**
+
+In `src/bunnyforge/serve_mcp.py`:
+
+(a) Add to the stdlib imports (after `import sys`):
+
+```python
+from pathlib import Path
+```
+
+(b) Immediately above `def build_parser()`, add:
+
+```python
+def _default_log_path() -> Path:
+    """Where --log-file logs when given no value.
+
+    macOS gets ~/Library/Logs (where log viewers look); everywhere else
+    follows the XDG state convention, matching scripts/mcp-session.py's
+    own state directory.
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Logs" / "bunnyforge" / "mcp.log"
+    state = os.environ.get("XDG_STATE_HOME", "").strip()
+    base = Path(state) if state else Path.home() / ".local" / "state"
+    return base / "bunnyforge" / "mcp.log"
+```
+
+(c) Inside `build_parser()`, after the `--no-auth` `add_argument` call (before `--allow-direct-edits`), add:
+
+```python
+    parser.add_argument("--log-file", nargs="?", metavar="PATH",
+                        const=str(_default_log_path()),
+                        help="write uvicorn's logs to PATH instead of "
+                             "cluttering stderr with access lines; rotated "
+                             "at midnight, 14 days kept. Bare --log-file "
+                             "uses %(const)s")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_serve_mcp.TestLogFileFlag -v`
+Expected: 6 tests, OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: --log-file flag and its platform default path
+
+Refs #87"
+```
+
+(Plus the model `Co-Authored-By:` trailer.)
+
+---
+
+### Task 2: `_log_config()` — the uvicorn logging dict
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (new function directly below `_default_log_path()`)
+- Test: `tests/test_serve_mcp.py` (new test class after `TestLogFileFlag`)
+
+**Interfaces:**
+- Consumes: nothing from other tasks (pure function).
+- Produces: `_log_config(path: Path) -> dict`, a `logging.config.dictConfig`-shaped dict for `uvicorn.run(log_config=...)`. Task 3 consumes it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_serve_mcp.py`, after `TestLogFileFlag`, add:
+
+```python
+class TestLogConfig(unittest.TestCase):
+    """The dict handed to uvicorn: access to file only, errors to both."""
+
+    def setUp(self):
+        self.cfg = serve_mcp._log_config(Path("/tmp/mcp.log"))
+
+    def test_access_goes_to_file_only(self):
+        self.assertEqual(self.cfg["loggers"]["uvicorn.access"]["handlers"],
+                         ["file"])
+
+    def test_errors_go_to_file_and_stderr(self):
+        self.assertEqual(self.cfg["loggers"]["uvicorn.error"]["handlers"],
+                         ["file", "stderr"])
+        self.assertEqual(self.cfg["loggers"]["uvicorn"]["handlers"],
+                         ["file", "stderr"])
+
+    def test_one_rotating_file_handler_midnight_keep_14(self):
+        # ONE file handler on purpose: two rotating handlers on the same
+        # file would both attempt the rollover rename and collide.
+        handlers = self.cfg["handlers"]
+        file_handlers = [h for h in handlers.values()
+                         if "filename" in h]
+        self.assertEqual(len(file_handlers), 1)
+        h = handlers["file"]
+        self.assertEqual(
+            h["class"], "logging.handlers.TimedRotatingFileHandler")
+        self.assertEqual(h["when"], "midnight")
+        self.assertEqual(h["backupCount"], 14)
+        self.assertEqual(h["filename"], "/tmp/mcp.log")
+
+    def test_dict_is_valid_dictconfig(self):
+        # A wiring assertion can pass on a malformed dict; only
+        # dictConfig itself proves the schema. Built against a tmpdir
+        # because the rotating handler opens its file eagerly.
+        import logging
+        import logging.config
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        logging.config.dictConfig(serve_mcp._log_config(root / "mcp.log"))
+        try:
+            self.assertTrue(logging.getLogger("uvicorn.access").handlers)
+            self.assertTrue((root / "mcp.log").exists())
+        finally:
+            for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+                logger = logging.getLogger(name)
+                for handler in list(logger.handlers):
+                    handler.close()
+                    logger.removeHandler(handler)
+                logger.propagate = True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_serve_mcp.TestLogConfig -v`
+Expected: 4 errors — `AttributeError: module 'bunnyforge.serve_mcp' has no attribute '_log_config'`.
+
+- [ ] **Step 3: Implement**
+
+In `src/bunnyforge/serve_mcp.py`, directly below `_default_log_path()`, add:
+
+```python
+def _log_config(path: Path) -> dict:
+    """uvicorn log_config: access lines to a rotated file, errors to both.
+
+    One TimedRotatingFileHandler shared by every uvicorn logger — two
+    rotating handlers on the same file would both attempt the rollover
+    rename and collide. The formatter adds timestamps, which uvicorn's
+    stderr default lacks; access lines render fine through it because
+    the request line lives in the record's message/args.
+    """
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "timestamped": {
+                "format": "%(asctime)s %(levelname)s %(message)s"}},
+        "handlers": {
+            "file": {
+                "class": "logging.handlers.TimedRotatingFileHandler",
+                "filename": str(path),
+                "when": "midnight",
+                "backupCount": 14,
+                "formatter": "timestamped"},
+            "stderr": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+                "formatter": "timestamped"}},
+        "loggers": {
+            "uvicorn": {"handlers": ["file", "stderr"],
+                        "level": "INFO", "propagate": False},
+            "uvicorn.error": {"handlers": ["file", "stderr"],
+                              "level": "INFO", "propagate": False},
+            "uvicorn.access": {"handlers": ["file"],
+                               "level": "INFO", "propagate": False}},
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_serve_mcp.TestLogConfig -v`
+Expected: 4 tests, OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: the log_config dict that splits access from errors
+
+Refs #87"
+```
+
+---
+
+### Task 3: `main()` integration — mkdir, refusal, and the uvicorn.run wiring
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (two spots inside `main()`: after the auth checks, and the `uvicorn.run` call at the end)
+- Test: `tests/test_serve_mcp.py` (one test added to `TestStartupContract`; one new class after `TestLogConfig`)
+
+**Interfaces:**
+- Consumes: `args.log_file` (Task 1), `_log_config(path)` (Task 2).
+- Produces: the user-visible behavior; nothing downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+(a) Inside the existing `TestStartupContract` class (it already has the `_main` helper and clears `BUNNYFORGE_MCP_KEY`), add:
+
+```python
+    def test_log_file_refuses_uncreatable_directory(self):
+        # A file where a directory is needed: mkdir(parents=True) fails
+        # with NotADirectoryError, an OSError — deterministically, on
+        # bare Python, before any uvicorn import. uvicorn is stubbed so
+        # that a MISSING refusal fails fast (rc 0 from the mock) rather
+        # than falling through to a real uvicorn.run and serving.
+        blocker = self.enterContext(tempfile.NamedTemporaryFile())
+        target = Path(blocker.name) / "sub" / "mcp.log"
+        with mock.patch.dict("sys.modules",
+                             {"uvicorn": mock.MagicMock()}):
+            rc, err = self._main(["--no-auth", "--log-file", str(target)])
+        self.assertEqual(rc, 1)
+        self.assertIn("log directory", err)
+        self.assertNotIn("Traceback", err)
+```
+
+(b) After `TestLogConfig`, add a new class:
+
+```python
+@unittest.skipUnless(HAVE_MCP, "needs the mcp extra")
+class TestLogFileWiring(unittest.TestCase):
+    """main() hands uvicorn the log_config — run mocked, no socket."""
+
+    def _main(self, extra):
+        store = scaffold(self)
+        import uvicorn
+        with mock.patch.object(uvicorn, "run") as run, \
+             mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": ""}), \
+             contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()):
+            rc = serve_mcp.main(["--workspace", str(store.ws.root),
+                                 "--no-auth"] + extra)
+        return rc, run, out.getvalue()
+
+    def test_flag_passes_log_config_and_creates_directory(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        target = root / "logs" / "mcp.log"
+        rc, run, out = self._main(["--log-file", str(target)])
+        self.assertEqual(rc, 0)
+        self.assertTrue(target.parent.is_dir())
+        cfg = run.call_args.kwargs["log_config"]
+        self.assertEqual(cfg["handlers"]["file"]["filename"], str(target))
+        self.assertIn(str(target), out)   # startup line names the path
+
+    def test_no_flag_passes_no_log_config_kwarg(self):
+        rc, run, _ = self._main([])
+        self.assertEqual(rc, 0)
+        self.assertNotIn("log_config", run.call_args.kwargs)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_serve_mcp.TestStartupContract.test_log_file_refuses_uncreatable_directory tests.test_serve_mcp.TestLogFileWiring -v`
+Expected: the refusal test FAILS — today `main` ignores the flag, sails past the missing mkdir guard, and hits the stubbed `uvicorn.run`, so rc is 0, not 1 (on a bare Python without `mcp` it instead returns 1 with the install hint and fails on the missing "log directory" message — either way a fast, deterministic failure, no server started). `test_flag_passes_log_config_and_creates_directory` FAILS with `KeyError: 'log_config'`; `test_no_flag_passes_no_log_config_kwarg` PASSES already (that is fine — it pins today's behavior against regression).
+
+- [ ] **Step 3: Implement**
+
+In `main()` in `src/bunnyforge/serve_mcp.py`:
+
+(a) After the auth-check block (the one ending `return 1` under `refusing to start without auth`), and BEFORE the `# --public-host does double duty` comment, insert:
+
+```python
+    log_path = None
+    if args.log_file is not None:
+        log_path = Path(args.log_file).expanduser()
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            print(f"cannot create log directory {log_path.parent}: {exc}",
+                  file=sys.stderr)
+            return 1
+```
+
+(This sits before the `import uvicorn` block on purpose: the refusal must fire on bare Python.)
+
+(b) Replace the final run call:
+
+```python
+    uvicorn.run(app, host=args.host, port=args.port)
+```
+
+with:
+
+```python
+    if log_path:
+        print(f"access log: {log_path} (rotated at midnight, 14 kept)")
+        uvicorn.run(app, host=args.host, port=args.port,
+                    log_config=_log_config(log_path))
+    else:
+        uvicorn.run(app, host=args.host, port=args.port)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python3 -m unittest tests.test_serve_mcp -v 2>&1 | tail -5`
+Expected: whole module OK (the new tests plus every pre-existing one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "feat: serve-mcp --log-file routes access noise to a rotated file
+
+Refs #87"
+```
+
+---
+
+### Task 4: Documentation, changelog, full-suite verification
+
+**Files:**
+- Modify: `docs/serve-mcp.md` (new `## Logging` section immediately before `## Troubleshooting`, ~line 256)
+- Modify: `CHANGELOG.md` (new `### Added` subsection at the top of `[Unreleased]`, before the existing `### Changed`)
+
+**Interfaces:**
+- Consumes: the flag's final behavior from Tasks 1–3 (doc text below matches it exactly).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Add the Logging section to docs/serve-mcp.md**
+
+Insert immediately before the `## Troubleshooting` heading:
+
+```markdown
+## Logging
+
+By default uvicorn writes every request to stderr — run in a background
+terminal, that clutters it with access lines. `--log-file` moves them to
+a self-pruning file instead:
+
+    bunnyforge serve-mcp --public-host mcp.example.com --log-file
+
+With no value the log goes to `~/Library/Logs/bunnyforge/mcp.log` on
+macOS and `$XDG_STATE_HOME/bunnyforge/mcp.log` (default
+`~/.local/state/bunnyforge/mcp.log`) elsewhere; pass a path to choose.
+The file rotates at midnight and 14 days are kept — the server prunes
+its own logs, nothing else to configure.
+
+Access lines go only to the file. Errors — the startup banner, bind
+failures, tracebacks — still reach stderr as well, so a crashed server
+says why in the terminal while the file stays a complete record of the
+run.
+
+`scripts/mcp-session.py` already captures the whole stdout/stderr stream
+to its own `server.log`; it needs no flag and is unchanged.
+```
+
+- [ ] **Step 2: Add the changelog entry**
+
+In `CHANGELOG.md`, directly under the `## [Unreleased]` heading and before the existing `### Changed`, insert:
+
+```markdown
+### Added
+
+- `bunnyforge serve-mcp --log-file [PATH]` routes uvicorn's logs to a
+  self-pruning file (rotated at midnight, 14 days kept) instead of
+  cluttering the terminal with access lines; errors still reach stderr
+  too. Bare `--log-file` picks a platform default:
+  `~/Library/Logs/bunnyforge/mcp.log` on macOS,
+  `$XDG_STATE_HOME/bunnyforge/mcp.log` elsewhere. (#87)
+```
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `python3 -m unittest discover -s tests 2>&1 | grep -E "^(OK|FAILED|Ran )"`
+Expected: `Ran 948 tests` (935 baseline + 13 new; trust the OK line over the exact count if other PRs landed meanwhile), `OK (skipped=58)` — skips rise if the `mcp` extra is absent.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/serve-mcp.md CHANGELOG.md
+git commit -m "docs: the Logging section and changelog entry for --log-file
+
+Refs #87"
+```
+
+---
+
+## After the tasks
+
+Use `superpowers:finishing-a-development-branch`. The PR closes #87 (`Closes #87` in the body), is opened with the `dcltdw:opening-a-pr` skill, and waits for review — no self-merge. The board card for #87 moves per the PR skills.

--- a/docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md
+++ b/docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md
@@ -1,0 +1,142 @@
+# serve-mcp `--log-file`: access log out of the terminal, into a rotated file
+
+**Issue:** dcltdw/bunnyforge#87
+**Date:** 2026-08-21
+**Status:** approved in brainstorm; this document is the validated design
+
+## Problem
+
+`bunnyforge serve-mcp --public-host mcp.stardragonenterprises.com` runs in a
+background terminal. uvicorn installs its default logging config (nothing in
+`serve_mcp.py` configures logging), so every request lands on stderr:
+
+    INFO:     160.79.106.179:0 - "POST /mcp HTTP/1.1" 200 OK
+
+The traffic is benign — claude.ai's own MCP connector, OAuth-authenticated —
+but the lines clutter the terminal. They should leave the terminal yet still
+be recorded to a file, and the file must prune itself.
+
+## Decision: Python-side rotation (option B)
+
+Three options were surveyed:
+
+- **A. launchd + newsyslog(8):** native to macOS, but `/etc/newsyslog.d/`
+  needs sudo, and newsyslog rotates by rename — a process holding the fd
+  keeps writing to the renamed inode unless signalled to reopen. Rejected.
+- **B. uvicorn `log_config` with a rotating file handler:** no sudo, no
+  rename trap (the handler itself does the rollover and reopens), identical
+  behavior however the process is launched, cross-platform. **Chosen.**
+- **C. logrotate:** Linux-native, Homebrew-only on macOS. Rejected.
+
+A constraint the survey missed, found during brainstorm:
+`scripts/mcp-session.py` already redirects the server's stdout+stderr to
+`$XDG_STATE_HOME/bunnyforge/server.log` and tails that file in its failure
+diagnostics. Any design that silences stderr by default would hollow out that
+script's log. This drove two choices below: the flag is **opt-in**, and the
+error stream **stays on stderr** even when the flag is active.
+
+## CLI surface
+
+One new flag on `build_parser()`:
+
+    --log-file [PATH]
+
+- **Omitted** (default): behavior is today's, byte-for-byte. No `log_config`
+  is passed to `uvicorn.run`; uvicorn installs its stderr default.
+  `scripts/mcp-session.py` is unaffected and is not modified.
+- **Bare `--log-file`** (`nargs="?"`, `const` = the default path): logs to
+  the platform default —
+  - macOS (`sys.platform == "darwin"`): `~/Library/Logs/bunnyforge/mcp.log`
+  - elsewhere: `$XDG_STATE_HOME/bunnyforge/mcp.log`, falling back to
+    `~/.local/state/bunnyforge/mcp.log` when the variable is unset or empty.
+- **`--log-file PATH`**: exactly that path.
+
+The default path is computed by a helper (`_default_log_path()`) so the
+parser test can assert it without duplicating platform logic. The flag has
+no interaction with `--auth-key` / `--no-auth` / `--public-host`; logging is
+orthogonal to auth.
+
+When the flag is active, `main()` prints one startup line naming the
+resolved path (alongside the existing "serving …" line) so the operator
+knows where the access lines went.
+
+## Log routing
+
+A new pure function in `serve_mcp.py`:
+
+    _log_config(path: Path) -> dict
+
+returns a `logging.config.dictConfig`-shaped dict (`version: 1`,
+`disable_existing_loggers: False`) passed to `uvicorn.run(...,
+log_config=...)`. Shape:
+
+- **Handlers:**
+  - `file`: `logging.handlers.TimedRotatingFileHandler`, `filename=path`,
+    `when="midnight"`, `backupCount=14`. **Exactly one file handler,
+    shared** — two rotating handlers on the same file would both attempt
+    the rollover rename and collide.
+  - `stderr`: `logging.StreamHandler` on `ext://sys.stderr`.
+- **Formatter** (on both handlers): `%(asctime)s %(levelname)s %(message)s`.
+  Timestamps are an improvement over uvicorn's timestamp-less default, and
+  the format renders access records correctly because uvicorn's access line
+  is carried in the record's message/args, not in formatter-specific fields.
+- **Loggers:**
+  - `uvicorn.access` → `[file]` only, level INFO, `propagate: False`.
+  - `uvicorn.error` and `uvicorn` → `[file, stderr]`, level INFO,
+    `propagate: False`.
+
+Net effect: access noise goes only to the file; the startup banner, bind
+failures, and tracebacks reach both the terminal and the file, so the file
+is a complete record of the run and a crashed server still says why in the
+terminal.
+
+## Rotation and retention
+
+`when="midnight"`, `backupCount=14`: one file per day, ~two weeks of
+history, pruning done by the handler itself. At this server's traffic level
+each daily file is tiny. Age-bounded retention was chosen over size-bounded
+(`RotatingFileHandler`) for predictability; no tuning flags — the defaults
+are the policy until a real need appears.
+
+## Directory creation and errors
+
+Before `uvicorn.run`, `main()` resolves the path and runs
+`path.parent.mkdir(parents=True, exist_ok=True)`. Any `OSError` (unwritable
+parent, a file where a directory should be, …) becomes the module's existing
+error style: one line to stderr, `return 1`, no traceback.
+
+## Testing
+
+Everything tests at the existing seam — no test opens a socket or reaches a
+real `uvicorn.run`:
+
+- **Parser:** flag absent → `None`; bare flag → `_default_log_path()`;
+  explicit path → that path.
+- **`_log_config` wiring:** `uvicorn.access` routes to the file handler
+  only; `uvicorn.error` routes to both; rotation params are
+  `midnight`/`backupCount=14`.
+- **Schema validity:** feed the dict to `logging.config.dictConfig` against
+  a tmpdir path — proves the dict is well-formed where a wiring assertion
+  alone would not — then close/detach the created handlers so the tmpdir
+  can be removed.
+- **Refusal path:** `--log-file` pointing into an uncreatable directory
+  returns 1 with a one-line stderr message.
+- Existing tests in `test_serve_mcp.py`, `test_mcp_auth.py`, `test_cli.py`
+  are untouched.
+
+## Documentation and changelog
+
+- `docs/serve-mcp.md`: a short **Logging** section — the flag, the default
+  path per platform, midnight/14-day rotation, and a note that
+  `scripts/mcp-session.py` keeps its own `server.log` redirect and needs no
+  change.
+- `CHANGELOG.md`: an `Added` entry under `[Unreleased]`.
+
+## Out of scope
+
+- launchd / newsyslog / logrotate integration.
+- A `--no-access-log` (discard entirely) escape hatch.
+- Retention/rotation tuning flags.
+- Any change to `scripts/mcp-session.py`.
+- A config-file key: logging is an operator concern, not a campaign
+  concern, so it does not belong in `campaign.toml`.

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from pathlib import Path
 from typing import NamedTuple
 
 from bunnyforge import _config
@@ -247,6 +248,20 @@ def build_server(store: WorkspaceStore, *, allow_direct_edits: bool = False,
     return server
 
 
+def _default_log_path() -> Path:
+    """Where --log-file logs when given no value.
+
+    macOS gets ~/Library/Logs (where log viewers look); everywhere else
+    follows the XDG state convention, matching scripts/mcp-session.py's
+    own state directory.
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Logs" / "bunnyforge" / "mcp.log"
+    state = os.environ.get("XDG_STATE_HOME", "").strip()
+    base = Path(state) if state else Path.home() / ".local" / "state"
+    return base / "bunnyforge" / "mcp.log"
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="bunnyforge serve-mcp",
@@ -269,6 +284,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-auth", action="store_true",
                         help="serve with no authentication — local testing "
                              "only; everything served is GM-only material")
+    parser.add_argument("--log-file", nargs="?", metavar="PATH",
+                        const=str(_default_log_path()),
+                        help="write uvicorn's logs to PATH instead of "
+                             "cluttering stderr with access lines; rotated "
+                             "at midnight, 14 days kept. Bare --log-file "
+                             "uses %(const)s")
     parser.add_argument("--allow-direct-edits", action="store_true",
                         help="also expose write_entity, which edits "
                              "canonical files in place and commits each edit")

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -262,6 +262,42 @@ def _default_log_path() -> Path:
     return base / "bunnyforge" / "mcp.log"
 
 
+def _log_config(path: Path) -> dict:
+    """uvicorn log_config: access lines to a rotated file, errors to both.
+
+    One TimedRotatingFileHandler shared by every uvicorn logger — two
+    rotating handlers on the same file would both attempt the rollover
+    rename and collide. The formatter adds timestamps, which uvicorn's
+    stderr default lacks; access lines render fine through it because
+    the request line lives in the record's message/args.
+    """
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "timestamped": {
+                "format": "%(asctime)s %(levelname)s %(message)s"}},
+        "handlers": {
+            "file": {
+                "class": "logging.handlers.TimedRotatingFileHandler",
+                "filename": str(path),
+                "when": "midnight",
+                "backupCount": 14,
+                "formatter": "timestamped"},
+            "stderr": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+                "formatter": "timestamped"}},
+        "loggers": {
+            "uvicorn": {"handlers": ["file", "stderr"],
+                        "level": "INFO", "propagate": False},
+            "uvicorn.error": {"handlers": ["file", "stderr"],
+                              "level": "INFO", "propagate": False},
+            "uvicorn.access": {"handlers": ["file"],
+                               "level": "INFO", "propagate": False}},
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="bunnyforge serve-mcp",

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -269,7 +269,11 @@ def _log_config(path: Path) -> dict:
     rotating handlers on the same file would both attempt the rollover
     rename and collide. The formatter adds timestamps, which uvicorn's
     stderr default lacks; access lines render fine through it because
-    the request line lives in the record's message/args.
+    the request line lives in the record's message/args. Named
+    `timestamped` rather than uvicorn's own `default`/`access` formatter
+    names, so passing `use_colors=` to `uvicorn.run` would raise
+    `KeyError: 'default'` in uvicorn's `Config.configure_logging` —
+    unreachable today since serve_mcp never passes it.
     """
     return {
         "version": 1,
@@ -555,9 +559,9 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
         log_path = Path(args.log_file).expanduser()
         try:
             log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.open("a").close()
         except OSError as exc:
-            print(f"cannot create log directory {log_path.parent}: {exc}",
-                  file=sys.stderr)
+            print(f"cannot write log file {log_path}: {exc}", file=sys.stderr)
             return 1
 
     # --public-host does double duty: it names the OAuth issuer, and it
@@ -589,7 +593,7 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
     print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp "
           f"(OAuth issuer: {issuer})" if key else
           f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp")
-    if log_path:
+    if log_path is not None:
         print(f"access log: {log_path} (rotated at midnight, 14 kept)")
         uvicorn.run(app, host=args.host, port=args.port,
                     log_config=_log_config(log_path))

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -550,6 +550,16 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
               file=sys.stderr)
         return 1
 
+    log_path = None
+    if args.log_file is not None:
+        log_path = Path(args.log_file).expanduser()
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            print(f"cannot create log directory {log_path.parent}: {exc}",
+                  file=sys.stderr)
+            return 1
+
     # --public-host does double duty: it names the OAuth issuer, and it
     # declares the hostname to DNS-rebinding protection in build_app (#46).
     issuer = (f"https://{args.public_host}" if args.public_host
@@ -579,7 +589,12 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
     print(f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp "
           f"(OAuth issuer: {issuer})" if key else
           f"serving {ws.config.name} at http://{args.host}:{args.port}/mcp")
-    uvicorn.run(app, host=args.host, port=args.port)
+    if log_path:
+        print(f"access log: {log_path} (rotated at midnight, 14 kept)")
+        uvicorn.run(app, host=args.host, port=args.port,
+                    log_config=_log_config(log_path))
+    else:
+        uvicorn.run(app, host=args.host, port=args.port)
     return 0
 
 

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -323,9 +323,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--log-file", nargs="?", metavar="PATH",
                         const=str(_default_log_path()),
                         help="write uvicorn's logs to PATH instead of "
-                             "cluttering stderr with access lines; rotated "
-                             "at midnight, 14 days kept. Bare --log-file "
-                             "uses %(const)s")
+                             "cluttering the terminal with access lines; "
+                             "rotated at midnight, 14 days kept. Bare "
+                             "--log-file uses %(const)s")
     parser.add_argument("--allow-direct-edits", action="store_true",
                         help="also expose write_entity, which edits "
                              "canonical files in place and commits each edit")

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -139,6 +139,37 @@ class TestLogConfig(unittest.TestCase):
                 logger.propagate = True
 
 
+@unittest.skipUnless(HAVE_MCP, "needs the mcp extra")
+class TestLogFileWiring(unittest.TestCase):
+    """main() hands uvicorn the log_config — run mocked, no socket."""
+
+    def _main(self, extra):
+        store = scaffold(self)
+        import uvicorn
+        with mock.patch.object(uvicorn, "run") as run, \
+             mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": ""}), \
+             contextlib.redirect_stdout(io.StringIO()) as out, \
+             contextlib.redirect_stderr(io.StringIO()):
+            rc = serve_mcp.main(["--workspace", str(store.ws.root),
+                                 "--no-auth"] + extra)
+        return rc, run, out.getvalue()
+
+    def test_flag_passes_log_config_and_creates_directory(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        target = root / "logs" / "mcp.log"
+        rc, run, out = self._main(["--log-file", str(target)])
+        self.assertEqual(rc, 0)
+        self.assertTrue(target.parent.is_dir())
+        cfg = run.call_args.kwargs["log_config"]
+        self.assertEqual(cfg["handlers"]["file"]["filename"], str(target))
+        self.assertIn(str(target), out)   # startup line names the path
+
+    def test_no_flag_passes_no_log_config_kwarg(self):
+        rc, run, _ = self._main([])
+        self.assertEqual(rc, 0)
+        self.assertNotIn("log_config", run.call_args.kwargs)
+
+
 class TestStartupContract(unittest.TestCase):
     """Default-deny: the spec's startup matrix, refusal rows.
 
@@ -179,6 +210,21 @@ class TestStartupContract(unittest.TestCase):
         with self.assertRaises(SystemExit):
             with contextlib.redirect_stderr(io.StringIO()):
                 serve_mcp.build_parser().parse_args(["--token", "t"])
+
+    def test_log_file_refuses_uncreatable_directory(self):
+        # A file where a directory is needed: mkdir(parents=True) fails
+        # with NotADirectoryError, an OSError — deterministically, on
+        # bare Python, before any uvicorn import. uvicorn is stubbed so
+        # that a MISSING refusal fails fast (rc 0 from the mock) rather
+        # than falling through to a real uvicorn.run and serving.
+        blocker = self.enterContext(tempfile.NamedTemporaryFile())
+        target = Path(blocker.name) / "sub" / "mcp.log"
+        with mock.patch.dict("sys.modules",
+                             {"uvicorn": mock.MagicMock()}):
+            rc, err = self._main(["--no-auth", "--log-file", str(target)])
+        self.assertEqual(rc, 1)
+        self.assertIn("log directory", err)
+        self.assertNotIn("Traceback", err)
 
 
 @unittest.skipUnless(HAVE_MCP, "mcp extra not installed")

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -52,6 +52,43 @@ class TestMainGuards(unittest.TestCase):
         self.assertEqual(serve_mcp.main(["--workspace", str(empty)]), 1)
 
 
+class TestLogFileFlag(unittest.TestCase):
+    """--log-file parsing and the platform default path — bare Python."""
+
+    def parse(self, argv):
+        return serve_mcp.build_parser().parse_args(argv)
+
+    def test_absent_means_none(self):
+        self.assertIsNone(self.parse([]).log_file)
+
+    def test_bare_flag_uses_platform_default(self):
+        self.assertEqual(self.parse(["--log-file"]).log_file,
+                         str(serve_mcp._default_log_path()))
+
+    def test_explicit_path_wins(self):
+        self.assertEqual(self.parse(["--log-file", "/tmp/x.log"]).log_file,
+                         "/tmp/x.log")
+
+    def test_default_path_on_macos(self):
+        with mock.patch("sys.platform", "darwin"):
+            self.assertEqual(
+                serve_mcp._default_log_path(),
+                Path.home() / "Library" / "Logs" / "bunnyforge" / "mcp.log")
+
+    def test_default_path_honors_xdg_state_home(self):
+        with mock.patch("sys.platform", "linux"), \
+             mock.patch.dict(os.environ, {"XDG_STATE_HOME": "/var/state"}):
+            self.assertEqual(serve_mcp._default_log_path(),
+                             Path("/var/state/bunnyforge/mcp.log"))
+
+    def test_default_path_falls_back_without_xdg(self):
+        with mock.patch("sys.platform", "linux"), \
+             mock.patch.dict(os.environ, {"XDG_STATE_HOME": ""}):
+            self.assertEqual(
+                serve_mcp._default_log_path(),
+                Path.home() / ".local" / "state" / "bunnyforge" / "mcp.log")
+
+
 class TestStartupContract(unittest.TestCase):
     """Default-deny: the spec's startup matrix, refusal rows.
 

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -89,6 +89,56 @@ class TestLogFileFlag(unittest.TestCase):
                 Path.home() / ".local" / "state" / "bunnyforge" / "mcp.log")
 
 
+class TestLogConfig(unittest.TestCase):
+    """The dict handed to uvicorn: access to file only, errors to both."""
+
+    def setUp(self):
+        self.cfg = serve_mcp._log_config(Path("/tmp/mcp.log"))
+
+    def test_access_goes_to_file_only(self):
+        self.assertEqual(self.cfg["loggers"]["uvicorn.access"]["handlers"],
+                         ["file"])
+
+    def test_errors_go_to_file_and_stderr(self):
+        self.assertEqual(self.cfg["loggers"]["uvicorn.error"]["handlers"],
+                         ["file", "stderr"])
+        self.assertEqual(self.cfg["loggers"]["uvicorn"]["handlers"],
+                         ["file", "stderr"])
+
+    def test_one_rotating_file_handler_midnight_keep_14(self):
+        # ONE file handler on purpose: two rotating handlers on the same
+        # file would both attempt the rollover rename and collide.
+        handlers = self.cfg["handlers"]
+        file_handlers = [h for h in handlers.values()
+                         if "filename" in h]
+        self.assertEqual(len(file_handlers), 1)
+        h = handlers["file"]
+        self.assertEqual(
+            h["class"], "logging.handlers.TimedRotatingFileHandler")
+        self.assertEqual(h["when"], "midnight")
+        self.assertEqual(h["backupCount"], 14)
+        self.assertEqual(h["filename"], "/tmp/mcp.log")
+
+    def test_dict_is_valid_dictconfig(self):
+        # A wiring assertion can pass on a malformed dict; only
+        # dictConfig itself proves the schema. Built against a tmpdir
+        # because the rotating handler opens its file eagerly.
+        import logging
+        import logging.config
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        logging.config.dictConfig(serve_mcp._log_config(root / "mcp.log"))
+        try:
+            self.assertTrue(logging.getLogger("uvicorn.access").handlers)
+            self.assertTrue((root / "mcp.log").exists())
+        finally:
+            for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+                logger = logging.getLogger(name)
+                for handler in list(logger.handlers):
+                    handler.close()
+                    logger.removeHandler(handler)
+                logger.propagate = True
+
+
 class TestStartupContract(unittest.TestCase):
     """Default-deny: the spec's startup matrix, refusal rows.
 

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -1,6 +1,8 @@
 import contextlib
 import importlib.util
 import io
+import logging
+import logging.config
 import os
 import tempfile
 import unittest
@@ -119,24 +121,56 @@ class TestLogConfig(unittest.TestCase):
         self.assertEqual(h["backupCount"], 14)
         self.assertEqual(h["filename"], "/tmp/mcp.log")
 
+    def _detach_uvicorn_loggers(self):
+        for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+            logger = logging.getLogger(name)
+            for handler in list(logger.handlers):
+                handler.close()
+                logger.removeHandler(handler)
+            logger.propagate = True
+            logger.setLevel(logging.NOTSET)
+
     def test_dict_is_valid_dictconfig(self):
         # A wiring assertion can pass on a malformed dict; only
         # dictConfig itself proves the schema. Built against a tmpdir
         # because the rotating handler opens its file eagerly.
-        import logging
-        import logging.config
         root = Path(self.enterContext(tempfile.TemporaryDirectory()))
-        logging.config.dictConfig(serve_mcp._log_config(root / "mcp.log"))
         try:
+            logging.config.dictConfig(
+                serve_mcp._log_config(root / "mcp.log"))
             self.assertTrue(logging.getLogger("uvicorn.access").handlers)
             self.assertTrue((root / "mcp.log").exists())
         finally:
-            for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
-                logger = logging.getLogger(name)
-                for handler in list(logger.handlers):
-                    handler.close()
-                    logger.removeHandler(handler)
-                logger.propagate = True
+            self._detach_uvicorn_loggers()
+
+    def test_access_lines_reach_the_file_and_not_the_terminal(self):
+        # The behavioral guarantee, not just the wiring: delete
+        # "propagate": False from the uvicorn.access entry and access
+        # lines propagate up to uvicorn's [file, stderr] handlers, so
+        # they land in the terminal and are written to the file twice
+        # -- while every handler-list assertion above still passes.
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        log = root / "mcp.log"
+        err = io.StringIO()
+        try:
+            # redirect_stderr wraps dictConfig, not the other way round:
+            # ext://sys.stderr resolves to whatever sys.stderr IS at
+            # configure time, so the handler must be configured while
+            # already redirected or it binds to the real terminal stream
+            # forever, silently uncaptured (confirmed empirically).
+            with contextlib.redirect_stderr(err):
+                logging.config.dictConfig(serve_mcp._log_config(log))
+                logging.getLogger("uvicorn.access").info(
+                    '%s - "%s %s HTTP/%s" %d', "1.2.3.4:0", "POST", "/mcp",
+                    "1.1", 200)
+                logging.getLogger("uvicorn.error").info("bind failed")
+            for handler in logging.getLogger("uvicorn.access").handlers:
+                handler.flush()
+        finally:
+            self._detach_uvicorn_loggers()
+        self.assertIn('"POST /mcp HTTP/1.1" 200', log.read_text())
+        self.assertNotIn("POST /mcp", err.getvalue())
+        self.assertIn("bind failed", err.getvalue())
 
 
 @unittest.skipUnless(HAVE_MCP, "needs the mcp extra")
@@ -223,7 +257,19 @@ class TestStartupContract(unittest.TestCase):
                              {"uvicorn": mock.MagicMock()}):
             rc, err = self._main(["--no-auth", "--log-file", str(target)])
         self.assertEqual(rc, 1)
-        self.assertIn("log directory", err)
+        self.assertIn("cannot write log file", err)
+        self.assertNotIn("Traceback", err)
+
+    def test_log_file_refuses_a_directory_as_the_target(self):
+        # mkdir(exist_ok=True) sails past a target that is itself a
+        # directory; only opening the file catches it, and it must be a
+        # refusal line rather than a traceback out of dictConfig.
+        target = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        with mock.patch.dict("sys.modules",
+                             {"uvicorn": mock.MagicMock()}):
+            rc, err = self._main(["--no-auth", "--log-file", str(target)])
+        self.assertEqual(rc, 1)
+        self.assertIn("cannot write log file", err)
         self.assertNotIn("Traceback", err)
 
 


### PR DESCRIPTION
Closes #87

An opt-in `--log-file [PATH]` flag on `bunnyforge serve-mcp` that routes uvicorn's access log to a self-pruning file (`TimedRotatingFileHandler`, midnight, 14 rotated days kept) while errors still reach stderr. Without the flag, behavior is unchanged — `uvicorn.run` is called with no `log_config` kwarg at all.

## Files changed

- `src/bunnyforge/serve_mcp.py` (modified) — `_default_log_path()`, `_log_config()`, and the `main()` integration
- `tests/test_serve_mcp.py` (modified) — three new test classes and two new methods on `TestStartupContract`
- `docs/serve-mcp.md` (modified) — new `## Logging` section
- `CHANGELOG.md` (modified) — `### Added` entry under `[Unreleased]`
- `docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md` (new) — approved design spec
- `docs/superpowers/plans/2026-08-21-serve-mcp-log-file.md` (new) — implementation plan

## Work breakdown

**`_default_log_path()`** — bare `--log-file` needs a platform default, and the parser test needs to assert it without duplicating platform logic. macOS gets `~/Library/Logs/bunnyforge/mcp.log`, where log viewers look; everywhere else follows XDG state, matching `scripts/mcp-session.py`'s own state directory.

**`_log_config(path)`** — a `dictConfig` dict with exactly **one** `TimedRotatingFileHandler` shared by every uvicorn logger. Two rotating handlers on one file would both attempt the rollover rename and collide. `uvicorn.access` routes to the file only; `uvicorn` and `uvicorn.error` route to both, so the file is a complete record of what uvicorn logged while a crashed server still says why in the terminal. `propagate: False` throughout is load-bearing: uvicorn's stock config gives `uvicorn.error` no handlers and lets it propagate, so without it every error line would be written twice.

**`main()` integration** — resolve the path, create the parent, and refuse with one stderr line on `OSError`. The guard sits **before** the in-function `import uvicorn` on purpose, so the refusal fires on bare Python without the `[mcp]` extra. `log_config=` is passed only when the flag is present.

Two corrections came out of review rather than the plan, and both are worth reading:

- **uvicorn's default access stream is stdout, not stderr.** Its stock `LOGGING_CONFIG` puts the `access` handler on `ext://sys.stdout` and only `default` on `ext://sys.stderr` (checked against uvicorn 0.52.4). The docs and the flag's own help string both said "stderr"; `d846f8b` corrects them to "the terminal", which is true of either stream. **The spec still carries the original error** at its lines 11 and 45 — I left an approved design record alone rather than editing it unilaterally. Worth a decision: the design's *conclusion* survives the corrected premise (per-logger routing is still the only approach that separates access from errors, and `scripts/mcp-session.py` captures both streams into `server.log` either way), so an errata line under **Problem** would be enough.
- **`mkdir(parents=True, exist_ok=True)` was not the guard the spec asked for.** `exist_ok=True` short-circuits on an existing directory whatever its mode, so the spec's own named case — an unwritable parent — sailed past and surfaced later as an uncaught `ValueError` out of `dictConfig`, *after* both startup lines printed. `de001c9` probes the file itself (`open("a").close()`, not `Path.touch()`, which succeeds on a directory via `os.utime`) inside the same `try`.

**Verification.** Suite green in both shapes CI runs, checked at `de001c9`: bare Python `Ran 950 tests … OK (skipped=60)`, and with the `[mcp]` extra installed `Ran 950 tests … OK`. The mcp-extra run matters here — the two tests that pin the `uvicorn.run` wiring are `@skipUnless(HAVE_MCP)`-gated and merely *skip* without it.

One test is worth calling out: `test_access_lines_reach_the_file_and_not_the_terminal` asserts on real logging output rather than handler wiring. Before it existed, deleting `"propagate": False` from the `uvicorn.access` entry inverted the whole feature — access lines back on the terminal *and* double-written to the file — with all 948 tests still green.

## Operational impact

None. The flag is opt-in; with it absent `uvicorn.run` receives no `log_config` kwarg, so today's logging is untouched. `scripts/mcp-session.py` is not modified and needs no flag — it already redirects the server's whole stdout+stderr stream to its own `server.log`.

One follow-up worth its own issue, pre-existing and deliberately not fixed here: `tests/test_serve_mcp.py`'s `test_help_works_without_the_extra` never redirects stdout, so the full `--help` text dumps into the suite's output. This branch makes that dump longer and gives it a machine-specific home directory via `%(const)s`.

## Provenance

- **Agent:** Claude Code (Claude Agent SDK), subagent-driven development — a fresh implementer per task, an independent reviewer between tasks, then a whole-branch review and one fix wave.
- **Model / version:** controller and all reviewer seats requested Opus 5 (`claude-opus-5`); all implementer seats requested Sonnet 5 (`claude-sonnet-5`). Requested, not observed — the running model cannot be verified from inside the session.
