### PR TITLE
docs+test: the papercuts found restarting serve-mcp after #88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ starts a fresh one.
   `~/Library/Logs/bunnyforge/mcp.log` on macOS,
   `$XDG_STATE_HOME/bunnyforge/mcp.log` elsewhere. (#87)
 
+### Fixed
+
+- `docs/serve-mcp.md` now says which variable names the workspace for
+  `serve-mcp` itself: `--workspace`, else `$BUNNYFORGE_WORKSPACE`, else
+  the nearest `campaign.toml`. `$BUNNYFORGE_MCP_WORKSPACE` — the only
+  one the page previously mentioned — belongs to
+  `scripts/mcp-session.py` alone, so setting it and running `serve-mcp`
+  directly refused to start with no hint why. (#89)
+- `docs/serve-mcp.md`'s named-tunnel recipe now has a step for checking
+  that the launch agent it just installed actually runs, and the repair
+  when it does not. `cloudflared service install` has been seen writing
+  a plist whose `ProgramArguments` is the bare binary with no
+  subcommand: it exits 1, retries every five seconds forever, and the
+  only symptom is a hostname that starts 502ing whenever the tunnel you
+  were really relying on goes away. (#90)
+- `test_help_works_without_the_extra` no longer dumps `serve-mcp
+  --help` into the test suite's output — which since #87 included the
+  running machine's home directory, by way of the `--log-file` default
+  path. (#92)
+
 ### Changed
 
 - `docs/serve-mcp.md` now walks through creating the named tunnel it

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -30,6 +30,14 @@ it anchors the OAuth issuer, and it declares the hostname to the
 server's DNS-rebinding protection. Omit it and every tunnelled request
 is refused with `421` before it reaches authentication.
 
+Note what the command above does *not* say: which campaign to serve.
+`serve-mcp` takes `--workspace`, else `$BUNNYFORGE_WORKSPACE`, else the
+nearest `campaign.toml` at or above the current directory — so run from
+inside the campaign, or name it. **`$BUNNYFORGE_MCP_WORKSPACE` is a
+different variable**, read only by `scripts/mcp-session.py` (below);
+setting it does nothing for `serve-mcp` itself, which then refuses to
+start unless you happen to be standing in a campaign folder.
+
 A **named tunnel** (free with a Cloudflare-managed domain) is the
 recommended recipe: the hostname — and therefore the connector URL in
 claude.ai and the OAuth trust it anchors — survives restarts. Creating
@@ -103,6 +111,43 @@ free, and once it is done the hostname is permanent.
    system service and does need `sudo`. Note what a launch agent does
    not do: it starts **at login, not at boot**, so a machine that
    reboots with nobody logging in comes back without a tunnel.
+
+7. **Check that it actually starts.** Do not skip this — the way it
+   fails is silent.
+
+        launchctl list | grep cloudflared
+        cloudflared tunnel list
+
+   You want a real PID in the first column and a populated CONNECTIONS
+   column. A `-` with status `1` means the agent is failing: cloudflared
+   2026.8.2 has been seen generating a plist whose `ProgramArguments`
+   is the bare binary with no subcommand, which prints usage, exits 1,
+   and — with the `KeepAlive` the same command generates — retries
+   every five seconds forever.
+   `~/Library/Logs/com.cloudflare.cloudflared.err.log` says so:
+   ``use `cloudflared tunnel run` to start tunnel <name>``.
+
+   The repair is to supply the arguments yourself, in
+   `~/Library/LaunchAgents/com.cloudflare.cloudflared.plist`:
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>/usr/local/bin/cloudflared</string>
+            <string>--config</string>
+            <string>/absolute/path/to/.cloudflared/config.yml</string>
+            <string>--no-autoupdate</string>
+            <string>tunnel</string>
+            <string>run</string>
+            <string>bunnyforge-mcp</string>
+        </array>
+
+   Then `launchctl unload` the plist and `launchctl load` it again, and
+   re-run the two checks. Two traps on the way: `unload` can report
+   `Input/output error` having nonetheless succeeded — confirm with
+   `launchctl print gui/$(id -u)/com.cloudflare.cloudflared`, which
+   should then say the service is not found — and `sudo` is wrong here,
+   because it addresses the system domain and cannot see a user launch
+   agent.
 
 Two things this deliberately does not do.
 
@@ -309,7 +354,11 @@ Export `BUNNYFORGE_MCP_WORKSPACE` from your shell profile and it needs no
 arguments at all — the workspace comes from `--workspace`, else that
 variable, else the `DEFAULT_WORKSPACE` constant near the top of the
 script. Prefer the variable: it survives `git pull` without leaving a
-local edit in `git status` forever. Other flags: `--fresh` (drop every registered client and
+local edit in `git status` forever. This variable belongs to *this
+script only*; `bunnyforge serve-mcp` run directly does not read it and
+wants `$BUNNYFORGE_WORKSPACE` instead. Setting both, to the same
+path, is the arrangement that behaves the way you expect from either
+entry point. Other flags: `--fresh` (drop every registered client and
 token first), `--status`, `--down`, `--port`, `--bunnyforge` (the console
 script that has the `[mcp]` extra, if it is not on your PATH).
 

--- a/docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md
+++ b/docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md
@@ -16,6 +16,19 @@ The traffic is benign — claude.ai's own MCP connector, OAuth-authenticated —
 but the lines clutter the terminal. They should leave the terminal yet still
 be recorded to a file, and the file must prune itself.
 
+> **Errata (post-implementation, 2026-08-21).** "Every request lands on
+> stderr" names the wrong stream, here and at "uvicorn installs its stderr
+> default" below. uvicorn's stock `LOGGING_CONFIG` routes the `access`
+> handler to `ext://sys.stdout` and only the `default` handler to
+> `ext://sys.stderr` (checked against uvicorn 0.52.4). The argument below
+> is unaffected and is left as written: the clutter is real on either
+> stream; per-logger routing remains the only option that separates access
+> from errors at all, since `scripts/mcp-session.py` captures both streams
+> into one `server.log` regardless; and the constraint that made the flag
+> opt-in — don't hollow out that `server.log` — rests on that same
+> both-streams redirect. The shipped code was always correct; the prose in
+> `docs/serve-mcp.md` and the flag's help string were corrected in #88.
+
 ## Decision: Python-side rotation (option B)
 
 Three options were surveyed:

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -45,8 +45,9 @@ class TestMainGuards(unittest.TestCase):
         return root
 
     def test_help_works_without_the_extra(self):
-        with self.assertRaises(SystemExit) as ctx:
-            serve_mcp.main(["--help"])
+        with contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(SystemExit) as ctx:
+                serve_mcp.main(["--help"])
         self.assertEqual(ctx.exception.code, 0)
 
     def test_bad_workspace_is_one_error_line_not_a_traceback(self):


### PR DESCRIPTION
Closes #89
Closes #90
Closes #91
Closes #92

Four small fixes with one shared origin: restarting `serve-mcp` after #88 merged turned into a much longer outage than it should have been, and each wrong turn was a signpost pointing somewhere unhelpful. Docs and one test only — no behavior change.

## Files changed

- `docs/serve-mcp.md` (modified) — workspace-variable note, and a verification step for the tunnel's launch agent
- `docs/superpowers/specs/2026-08-21-serve-mcp-log-file-design.md` (modified) — errata block under **Problem**
- `tests/test_serve_mcp.py` (modified) — one `redirect_stdout`
- `CHANGELOG.md` (modified) — new `### Fixed` section under `[Unreleased]`

## Work breakdown

**#89 — the page taught the wrong variable.** `docs/serve-mcp.md` mentioned only `$BUNNYFORGE_MCP_WORKSPACE`, which is read by `scripts/mcp-session.py` alone. Run `bunnyforge serve-mcp` directly with that set and it refuses to start, because it wants `--workspace`, else `$BUNNYFORGE_WORKSPACE`, else the nearest `campaign.toml`. The refusal is correct and its one line scrolls past in the launching terminal; what you notice is the hostname 502ing minutes later. Now stated where the bare `serve-mcp` invocation is first shown, and the `mcp-session.py` paragraph marks its variable as belonging to that script.

**#90 — a launch agent that could never start.** Step 6 said `cloudflared service install` and stopped. On cloudflared 2026.8.2 that wrote a plist whose `ProgramArguments` was the bare binary with no subcommand — so it printed usage, exited 1, and with the `KeepAlive` the same command generates, retried every five seconds indefinitely. Nothing surfaces: the doc's promise quietly doesn't hold, and you only find out when whatever manually-started tunnel you were actually relying on goes away. Added step 7: what to check, what a failure looks like, the `ProgramArguments` repair, and two traps — `launchctl unload` reporting `Input/output error` having nonetheless succeeded, and `sudo` being wrong for a user launch agent.

**#91 — errata, not a rewrite.** The `--log-file` design spec opens with "every request lands on stderr". uvicorn's stock `LOGGING_CONFIG` puts the `access` handler on `ext://sys.stdout` and only `default` on `ext://sys.stderr` (checked against 0.52.4). #88 corrected the same wording in the docs and the flag's help string but deliberately left the spec alone — amending an approved design record is a decision, not a side effect. So this adds a dated errata block and leaves the original argument standing, with the reasoning for why the conclusion survives the corrected premise: the clutter is real on either stream; per-logger routing is still the only option that separates access from errors, since `scripts/mcp-session.py` captures both streams into one `server.log`; and the constraint that made the flag opt-in rests on that same both-streams redirect.

**#92 — pristine test output.** `test_help_works_without_the_extra` drove `main(["--help"])` without redirecting stdout, so argparse's help text printed into every suite run — and since #87 that included the running machine's home directory, via `%(const)s` in the `--log-file` help. Wrapped in `redirect_stdout`, matching what `test_cli.py:76` already does. I checked the three sibling `--help` call sites: `test_cli.py:76` already redirects, and the other two capture through `subprocess`.

**Verification.** Suite green in both shapes CI runs: bare Python `Ran 950 tests … OK (skipped=60)`, and with the `[mcp]` extra `Ran 950 tests … OK`. Confirmed the fix does what it claims by grepping the suite's own output for the help text — several lines before, zero after.

## Operational impact

None — documentation and one test.

The one thing this PR deliberately does **not** fix is the asymmetry it documents: the tunnel now starts on its own and the server still doesn't, so closing its terminal takes the MCP endpoint down. That is #93, which needs a design conversation (chiefly: the GM key cannot live in a plist the way a config path can) rather than a patch.

No changelog entry for #91 — it amends an internal design record with no user-visible effect. The other three are recorded under `### Fixed`.

## Provenance

- **Agent:** Claude Code (Claude Agent SDK)
- **Model / version:** Opus 5 (`claude-opus-5`) requested for this session. Requested, not observed — the running model cannot be verified from inside the session.
