### PR TITLE
serve-mcp: --auth-key-file and exit-78 refusals, the code half of the launch agent design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,18 @@ starts a fresh one.
   a platform default:
   `~/Library/Logs/bunnyforge/mcp.log` on macOS,
   `$XDG_STATE_HOME/bunnyforge/mcp.log` elsewhere. (#87)
+- `bunnyforge serve-mcp --auth-key-file PATH` reads the GM key from a
+  private file (refused unless it is mode 600-tight), so launchers
+  that run no shell — launchd above all — never hold the key
+  themselves. (#93)
 
 ### Changed
 
+- `serve-mcp` startup refusals (no auth, bad workspace, unwritable log
+  file, missing `[mcp]` extra) exit `78` (sysexits `EX_CONFIG`) rather
+  than `1`, so `launchctl list` — and any service manager that can
+  branch on exit codes — can tell "fix the configuration" from a
+  crash. `--check` still exits `1` on a failing report. (#93)
 - `docs/serve-mcp.md` now walks through creating the named tunnel it
   recommends — login, create, route dns, config, launch agent — plus the
   traps: the ingress catch-all is mandatory, the credentials path must be

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -18,6 +18,8 @@ command; see "One command" at the end.
 
 Keep it out of git. You will type it exactly once per grant, on the
 consent page in your own browser — it is never stored by claude.ai.
+For unattended starts, `--auth-key-file` reads it from a private
+file instead.
 
 ## Run behind a tunnel
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -267,8 +267,8 @@ macOS and `$XDG_STATE_HOME/bunnyforge/mcp.log` (default
 The resolved path is printed at startup. The file rotates at midnight
 and 14 rotated days are kept alongside the live one — the server
 prunes its own logs, nothing else to configure. If the file can't be
-written, `serve-mcp` refuses with one line and exits 1 rather than
-starting up and failing later.
+written, `serve-mcp` refuses with one line and exits 78 (`EX_CONFIG`)
+rather than starting up and failing later.
 
 Access lines go only to the file. Errors — the startup banner, bind
 failures, tracebacks — still reach stderr as well, so a crashed server

--- a/docs/superpowers/plans/2026-08-21-serve-mcp-launch-agent.md
+++ b/docs/superpowers/plans/2026-08-21-serve-mcp-launch-agent.md
@@ -1,0 +1,688 @@
+# serve-mcp Launch Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `bunnyforge serve-mcp` survives closing its terminal: a
+`--auth-key-file` flag so the GM key never sits in a plist, refusals that
+exit 78 so a service manager can tell configuration from crash, and a
+documented macOS launch agent recipe with mandatory verification.
+
+**Architecture:** All code lands in `src/bunnyforge/serve_mcp.py` — a new
+key-resolution helper pair (`_read_key_file`, `_resolve_key`), one parser
+flag, and an `EXIT_CONFIG = 78` constant applied to every startup refusal.
+The launch agent itself is delivered as a doc recipe in
+`docs/serve-mcp.md` mirroring the cloudflared section, not as generated
+code. Design rationale: the spec (below) — read it first.
+
+**Tech Stack:** Python stdlib only (argparse, stat, pathlib); unittest;
+macOS launchd (documented, not executed).
+
+**Spec:** `docs/superpowers/specs/2026-08-21-serve-mcp-launch-agent-design.md`
+(committed on this branch). Issue: dcltdw/bunnyforge#93.
+
+## Global Constraints
+
+- **Workspace:** the branch `serve-mcp-launch-agent` in the worktree
+  `/Users/dcltdw/Github/bunnyforge/.claude/worktrees/serve-mcp-launch-agent`
+  already exists with the spec committed. Work there. Never commit to
+  `main`, never touch the other worktrees.
+- **Test command (bare shape):** the shared `.venv` python is an editable
+  install pointing at the MAIN checkout, so from the worktree always run:
+  `export PYTHONPATH=/Users/dcltdw/Github/bunnyforge/.claude/worktrees/serve-mcp-launch-agent/src`
+  then `/Users/dcltdw/Github/bunnyforge/.venv/bin/python3 -m unittest discover -s tests`.
+  Expected shape: `Ran 950 tests … OK (skipped=60)` (counts grow as tasks
+  add tests). Neither `mcp` nor `uvicorn` is installed there; the
+  `@skipUnless(HAVE_MCP)` tests only skip — that is normal, not a failure.
+- **Full shape (`[mcp]` extra):** only Task 5 needs it; it builds a
+  throwaway venv (instructions there), matching CI's `mcp-suite` job.
+- **No new dependencies.** Everything added is stdlib.
+- **Every new refusal must fire before any SDK import** so it runs (and
+  is tested) on bare Python — the existing `main()` ordering already
+  guarantees this; keep the new code above the `import uvicorn` line.
+- **Style:** match `serve_mcp.py` as it is — 4-space indent, ~75-column
+  wrap, double quotes, comments that state constraints rather than
+  narrate. Doc code blocks in `docs/serve-mcp.md` are indented (4 spaces,
+  8 inside list items), not fenced.
+- **Exit codes are the contract:** startup refusals exit
+  `EXIT_CONFIG = 78` (sysexits `EX_CONFIG`); `--check` keeps its
+  documented `0` / `1`. Do not "clean up" the check path to 78.
+- **Commits:** confirm `git branch --show-current` says
+  `serve-mcp-launch-agent` before each commit. Trailer every commit with
+  the model line the session's harness specifies
+  (`Co-Authored-By: Claude <model> <noreply@anthropic.com>`).
+
+---
+
+### Task 1: Prerequisite gate and baseline
+
+PR #94 (open at plan time) rewrites the exact `docs/serve-mcp.md`
+passages Task 4 anchors to (the tunnel's step 7 verification, the
+workspace-variables note). The code tasks don't need it; the doc task
+does.
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a rebased branch whose `docs/serve-mcp.md` contains
+  `7. **Check that it actually starts.**` — the anchor Task 4 inserts
+  after.
+
+- [ ] **Step 1: Check #94's state**
+
+Run: `gh pr view 94 --repo dcltdw/bunnyforge --json state --jq .state`
+
+- `MERGED`: continue to Step 2.
+- Anything else: do Tasks 2 and 3 now, then **stop before Task 4 and
+  report** that the doc task is waiting on #94 — do not hand-merge #94's
+  text yourself.
+
+- [ ] **Step 2: Rebase onto current main**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Expected: clean rebase (the spec commit touches only a new file). Verify
+the anchor exists: `grep -n "Check that it actually starts" docs/serve-mcp.md`
+→ one hit.
+
+- [ ] **Step 3: Baseline suite**
+
+Run the bare-shape test command from Global Constraints.
+Expected: `OK (skipped=60)`. If not green, stop and report — do not build
+on a red baseline.
+
+---
+
+### Task 2: Refusals exit 78 (`EXIT_CONFIG`)
+
+Every pre-serve refusal in `main()` — bad workspace, auth contradictions,
+missing auth, unwritable log file, missing `[mcp]` extra — currently
+returns 1, indistinguishable in `launchctl list` from a crash. They
+become 78 (`EX_CONFIG`). `--check`'s report stays 0/1.
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (constant near `KEY_ENV`; five
+  `return 1` sites in `main()`)
+- Test: `tests/test_serve_mcp.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `serve_mcp.EXIT_CONFIG: int = 78`, used by Task 3's tests and
+  named in Task 4's docs and Task 5's changelog. Refusal `return` sites
+  in `main()` all use it.
+
+- [ ] **Step 1: Update the refusal assertions to fail first (TDD)**
+
+In `tests/test_serve_mcp.py`, change the expected exit code from `1` to
+`serve_mcp.EXIT_CONFIG` in exactly these six tests (find them by name,
+not line number):
+
+- `TestMainGuards.test_bad_workspace_is_one_error_line_not_a_traceback`
+- `TestStartupContract.test_refuses_without_key_or_no_auth`
+- `TestStartupContract.test_refuses_key_and_no_auth_together`
+- `TestStartupContract.test_env_key_counts_as_key_for_the_contradiction`
+- `TestStartupContract.test_log_file_refuses_uncreatable_directory`
+- `TestStartupContract.test_log_file_refuses_a_directory_as_the_target`
+
+e.g. the first becomes:
+
+```python
+    def test_bad_workspace_is_one_error_line_not_a_traceback(self):
+        empty = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.assertEqual(serve_mcp.main(["--workspace", str(empty)]),
+                         serve_mcp.EXIT_CONFIG)
+```
+
+Add one new test to `TestStartupContract` pinning the number itself (78
+is an external contract — a future systemd unit's
+`RestartPreventExitStatus=78` depends on it):
+
+```python
+    def test_refusal_exit_code_is_ex_config(self):
+        # sysexits(3) EX_CONFIG; a service manager keys on the number.
+        self.assertEqual(serve_mcp.EXIT_CONFIG, 78)
+```
+
+Leave every `--check`/`report` test alone — `TestCheck`-side assertions
+of `rc == 1` are the documented contract for a failing report.
+
+- [ ] **Step 2: Run to verify the seven fail**
+
+Run (with the Global Constraints PYTHONPATH exported):
+`/Users/dcltdw/Github/bunnyforge/.venv/bin/python3 -m unittest tests.test_serve_mcp -v 2>&1 | tail -20`
+Expected: 6 failures (`1 != 78`-shaped... actually `AttributeError:
+EXIT_CONFIG` until the constant exists) plus the new pin test erroring
+the same way. Either failure mode is the "red" this step wants.
+
+- [ ] **Step 3: Implement**
+
+In `src/bunnyforge/serve_mcp.py`, directly under the `KEY_ENV` line:
+
+```python
+KEY_ENV = "BUNNYFORGE_MCP_KEY"
+
+# sysexits(3) EX_CONFIG: a startup refusal. The configuration is wrong
+# and restarting cannot fix it, so a service manager (or a human reading
+# `launchctl list`) can tell it from a crash, which stays exit 1 (#93).
+EXIT_CONFIG = 78
+```
+
+Then in `main()`, change these five refusal returns from `return 1` to
+`return EXIT_CONFIG` (and no others — in particular NOT
+`return report(preflight(...))`):
+
+1. the `except (ConfigError, WorkspaceError)` workspace block
+2. the `--no-auth contradicts` block
+3. the `refusing to start without auth` block
+4. the `cannot write log file` block
+5. the `except ModuleNotFoundError` install-hint block
+
+- [ ] **Step 4: Run to verify green**
+
+Same command as Step 2. Expected: `OK (skipped=…)`, zero failures. Then
+the full bare suite: `… -m unittest discover -s tests` → `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "serve-mcp: startup refusals exit 78 (EX_CONFIG), not 1 (#93)"
+```
+
+---
+
+### Task 3: The `--auth-key-file` flag
+
+The plist carries a path, not the key. `--auth-key-file PATH` reads the
+key from a private file: stripped, refused when missing/empty/too open.
+Precedence: `--auth-key` and `--auth-key-file` together are ambiguous
+(refused); either flag outranks `$BUNNYFORGE_MCP_KEY`.
+
+**Files:**
+- Modify: `src/bunnyforge/serve_mcp.py` (imports; two helpers before
+  `build_parser`; one `add_argument`; the key-resolution block in
+  `main()`)
+- Test: `tests/test_serve_mcp.py` (new `TestAuthKeyFile` class)
+
+**Interfaces:**
+- Consumes: `EXIT_CONFIG` from Task 2.
+- Produces:
+  - `_read_key_file(path_str: str) -> str` — returns the stripped key;
+    raises `ValueError` (message is the refusal line) on unreadable,
+    group/other-accessible (POSIX only), or empty file.
+  - `_resolve_key(args: argparse.Namespace) -> str` — full precedence;
+    raises `ValueError` on flag conflict or via `_read_key_file`; returns
+    `""` when no key anywhere (the existing no-auth refusal handles
+    that case downstream, unchanged).
+  - Parser accepts `--auth-key-file PATH` (`args.auth_key_file`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_serve_mcp.py` (after `TestStartupContract`):
+
+```python
+class TestAuthKeyFile(unittest.TestCase):
+    """--auth-key-file: the key a plist can point at (#93).
+
+    Bare Python throughout: resolution and every refusal fire before
+    any SDK import.
+    """
+
+    def setUp(self):
+        self.enterContext(mock.patch.dict(
+            os.environ, {"BUNNYFORGE_MCP_KEY": ""}))
+
+    def _keyfile(self, content="sekrit\n", mode=0o600) -> Path:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        path = root / "mcp-key"
+        path.write_text(content, encoding="utf-8")
+        path.chmod(mode)
+        return path
+
+    def _resolve(self, argv):
+        args = serve_mcp.build_parser().parse_args(argv)
+        return serve_mcp._resolve_key(args)
+
+    def _ws(self) -> Path:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "campaign.toml").write_text(MINIMAL, encoding="utf-8")
+        return root
+
+    def test_reads_and_strips_the_key(self):
+        path = self._keyfile("  sekrit\n")
+        self.assertEqual(
+            self._resolve(["--auth-key-file", str(path)]), "sekrit")
+
+    def test_missing_file_is_a_refusal(self):
+        with self.assertRaisesRegex(ValueError, "cannot read"):
+            self._resolve(["--auth-key-file", "/nonexistent/mcp-key"])
+
+    def test_empty_file_is_a_refusal(self):
+        path = self._keyfile("   \n")
+        with self.assertRaisesRegex(ValueError, "empty"):
+            self._resolve(["--auth-key-file", str(path)])
+
+    @unittest.skipUnless(os.name == "posix", "POSIX file modes")
+    def test_group_or_other_readable_is_a_refusal(self):
+        path = self._keyfile(mode=0o644)
+        with self.assertRaisesRegex(ValueError, "chmod 600"):
+            self._resolve(["--auth-key-file", str(path)])
+
+    def test_both_key_flags_together_are_ambiguous(self):
+        path = self._keyfile()
+        with self.assertRaisesRegex(ValueError, "contradicts"):
+            self._resolve(["--auth-key", "k", "--auth-key-file", str(path)])
+
+    def test_auth_key_flag_wins_without_reading_the_file(self):
+        self.assertEqual(self._resolve(["--auth-key", "k"]), "k")
+
+    def test_file_outranks_the_environment(self):
+        path = self._keyfile("filekey\n")
+        with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "envkey"}):
+            self.assertEqual(
+                self._resolve(["--auth-key-file", str(path)]), "filekey")
+
+    def test_environment_still_answers_when_no_flag(self):
+        with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "envkey"}):
+            self.assertEqual(self._resolve([]), "envkey")
+
+    def test_no_auth_conflict_through_main(self):
+        # Same default-deny contradiction as --auth-key + --no-auth.
+        path = self._keyfile()
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = serve_mcp.main(["--workspace", str(self._ws()),
+                                 "--auth-key-file", str(path), "--no-auth"])
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
+        self.assertIn("contradict", stderr.getvalue())
+
+    def test_bad_key_file_through_main_is_one_line_exit_78(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = serve_mcp.main(["--workspace", str(self._ws()),
+                                 "--auth-key-file", "/nonexistent/mcp-key"])
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
+        self.assertIn("cannot read auth key file", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `… -m unittest tests.test_serve_mcp.TestAuthKeyFile -v`
+Expected: every test errors — `unrecognized arguments: --auth-key-file`
+(SystemExit from argparse) or `AttributeError: _resolve_key`.
+
+- [ ] **Step 3: Implement**
+
+In `src/bunnyforge/serve_mcp.py`:
+
+(a) Add `import stat` to the stdlib imports (alphabetical: between `os`
+and `sys`).
+
+(b) Immediately before `def build_parser()`:
+
+```python
+def _read_key_file(path_str: str) -> str:
+    """The GM key from a file a plist can safely point at (#93).
+
+    Stripped, so a trailing newline from echo is harmless. Refused when
+    unreadable, empty, or -- on POSIX -- accessible to group or other:
+    the file stands in for a secret typed by hand, and a lax mode is a
+    misconfiguration to fix, not to serve through.
+    """
+    path = Path(path_str).expanduser()
+    try:
+        if os.name == "posix":
+            mode = stat.S_IMODE(path.stat().st_mode)
+            if mode & 0o077:
+                raise ValueError(
+                    f"auth key file {path} is group- or other-accessible "
+                    f"(mode {mode:03o}) -- chmod 600 it")
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"cannot read auth key file: {exc}") from None
+    key = raw.strip()
+    if not key:
+        raise ValueError(f"auth key file {path} is empty")
+    return key
+
+
+def _resolve_key(args) -> str:
+    """--auth-key, else --auth-key-file, else $BUNNYFORGE_MCP_KEY.
+
+    The two flags together are refused as ambiguous rather than
+    silently ordered; either flag outranks the environment variable,
+    which is how --auth-key has always behaved. Raises ValueError
+    carrying the one-line refusal; "" means no key anywhere, and the
+    default-deny check in main() owns that refusal.
+    """
+    if args.auth_key and args.auth_key_file:
+        raise ValueError("--auth-key contradicts --auth-key-file; "
+                         "pick one")
+    if args.auth_key:
+        return args.auth_key.strip()
+    if args.auth_key_file:
+        return _read_key_file(args.auth_key_file)
+    return os.environ.get(KEY_ENV, "").strip()
+```
+
+(c) In `build_parser()`, directly after the `--auth-key` argument:
+
+```python
+    parser.add_argument("--auth-key-file", metavar="PATH",
+                        help="read the GM key from PATH -- for launchers "
+                             "that run no shell (a launchd agent); the "
+                             "file must not be group- or other-readable")
+```
+
+(d) In `main()`, replace the single line
+`key = (args.auth_key or os.environ.get(KEY_ENV, "")).strip()` with:
+
+```python
+    try:
+        key = _resolve_key(args)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return EXIT_CONFIG
+```
+
+(e) Widen the contradiction message on the next block so it names the
+new flag (its `"contradict"` substring, which tests assert, is
+unchanged):
+
+```python
+    if key and args.no_auth:
+        print(f"--no-auth contradicts --auth-key/--auth-key-file/"
+              f"{KEY_ENV}; pick one", file=sys.stderr)
+        return EXIT_CONFIG
+```
+
+- [ ] **Step 4: Run to verify green**
+
+`… -m unittest tests.test_serve_mcp.TestAuthKeyFile -v` → OK, then the
+full bare suite → `OK (skipped=60)` with the test count up by 11.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bunnyforge/serve_mcp.py tests/test_serve_mcp.py
+git commit -m "serve-mcp: --auth-key-file reads the GM key from a private file (#93)"
+```
+
+---
+
+### Task 4: The launch agent recipe in `docs/serve-mcp.md`
+
+Requires Task 1's #94 gate passed. Three edits, one file.
+
+**Files:**
+- Modify: `docs/serve-mcp.md`
+
+**Interfaces:**
+- Consumes: flag and exit-code behavior exactly as Tasks 2–3 shipped
+  them (`--auth-key-file`, refusal exit 78, bare `--log-file` default
+  `~/Library/Logs/bunnyforge/mcp.log`).
+- Produces: the section heading `## Make the server start on its own
+  (macOS)`, referenced by Task 5's changelog entry.
+
+- [ ] **Step 1: Add the key-file pointer where the key is introduced**
+
+In the `## Generate a GM key (once)` section, after "…it is never stored
+by claude.ai.", append to the same paragraph:
+
+```
+For unattended starts, `--auth-key-file` reads it from a private file —
+the launch agent recipe below leans on that.
+```
+
+- [ ] **Step 2: Point the asymmetry paragraph at the fix**
+
+The paragraph beginning `**Starting the tunnel does not start
+`serve-mcp`.**` ends with "…the correct answer rather than a fault."
+Append one sentence:
+
+```
+The next section closes the asymmetry.
+```
+
+- [ ] **Step 3: Insert the new section**
+
+Between the end of the `## Set up a named tunnel (once)` section (after
+the "Do not put Cloudflare Access…" paragraph) and `## Check it before
+adding the connector`, insert:
+
+````markdown
+## Make the server start on its own (macOS)
+
+Step 6 got the tunnel a launch agent; this section gives `serve-mcp`
+one of its own, so neither end of the route depends on a terminal
+window staying open. The same trap applies: a launch agent starts **at
+login, not at boot**.
+
+One decision shapes the recipe: the GM key. A plist is not a secrets
+store — it is readable by every process running as you, echoed by
+`launchctl print`, and the first file you paste somewhere when
+debugging — so the key goes in a private file and the plist carries
+only its path, the same trust class as the `config.yml` path in the
+tunnel's plist. `--auth-key-file` reads it, strips a trailing newline,
+and refuses an empty or group/other-readable file.
+
+1. **Put the key in a file.** Any path works; this one sits beside the
+   OAuth state file that "Resetting access" already covers:
+
+        mkdir -p ~/.local/state/bunnyforge
+        printf '%s\n' '<your key>' > ~/.local/state/bunnyforge/mcp-key
+        chmod 600 ~/.local/state/bunnyforge/mcp-key
+
+2. **Create the log directory** — launchd does not create the parents
+   of its log paths:
+
+        mkdir -p ~/Library/Logs/bunnyforge
+
+3. **Write `~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist`.**
+   Every path must be absolute: launchd expands no `~` and reads no
+   shell profile — which is also why the workspace travels as
+   `--workspace` rather than `$BUNNYFORGE_WORKSPACE`, and why there is
+   no `EnvironmentVariables` block at all. The first string is the
+   `bunnyforge` that has the `[mcp]` extra: `which bunnyforge` from
+   the shell where `serve-mcp` already runs by hand.
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+          "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>com.bunnyforge.serve-mcp</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>/absolute/path/to/bunnyforge</string>
+                <string>serve-mcp</string>
+                <string>--workspace</string>
+                <string>/absolute/path/to/campaign</string>
+                <string>--public-host</string>
+                <string>mcp.example.com</string>
+                <string>--auth-key-file</string>
+                <string>/Users/you/.local/state/bunnyforge/mcp-key</string>
+                <string>--log-file</string>
+            </array>
+            <key>RunAtLoad</key>
+            <true/>
+            <key>KeepAlive</key>
+            <dict>
+                <key>SuccessfulExit</key>
+                <false/>
+            </dict>
+            <key>ThrottleInterval</key>
+            <integer>60</integer>
+            <key>StandardOutPath</key>
+            <string>/Users/you/Library/Logs/bunnyforge/serve-mcp.launchd.log</string>
+            <key>StandardErrorPath</key>
+            <string>/Users/you/Library/Logs/bunnyforge/serve-mcp.launchd.log</string>
+        </dict>
+        </plist>
+
+   Two log destinations on purpose, doing different work. Bare
+   `--log-file` carries the request volume to
+   `~/Library/Logs/bunnyforge/mcp.log`, rotated at midnight, 14 days
+   kept. The launchd log carries only what that file structurally
+   cannot: the startup banner, the one-line refusals printed before
+   any logging exists, and crash tracebacks. It is unrotated, but it
+   receives no access lines, so it stays small.
+
+4. **Load it:**
+
+        launchctl load ~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist
+
+5. **Check that it actually starts** — step 7's discipline, unchanged:
+
+        launchctl list | grep com.bunnyforge.serve-mcp
+        bunnyforge serve-mcp --check https://mcp.example.com
+
+   A real PID in the first column and a passing check means done. A
+   `-` with `78` beside it is a **refusal**: the configuration is
+   wrong, restarting will not help, and the last line of
+   `~/Library/Logs/bunnyforge/serve-mcp.launchd.log` names the fix — a
+   bad workspace path, a key file that is missing or too open, a
+   `bunnyforge` without the `[mcp]` extra. Any other nonzero status is
+   a crash. `KeepAlive` restarts crashes within a minute; refusals it
+   retries at most once a minute (`ThrottleInterval`), so a broken
+   config surfaces here and in the log instead of spinning every five
+   seconds — the loop step 7 warns about.
+
+   After editing the plist, `launchctl unload` then `load` again.
+   Step 7's two traps apply verbatim: `unload` can report
+   `Input/output error` having succeeded, and `sudo` addresses the
+   wrong domain entirely.
+
+One conflict worth knowing: the agent and `scripts/mcp-session.py`
+both want port 8765. While the agent is loaded, an mcp-session's
+server cannot bind — `launchctl unload` the agent first when you want
+the interactive route back.
+````
+
+(Convert the ```` ```` fence content as-is; the inner code blocks are
+already in the doc's indented style.)
+
+- [ ] **Step 4: Lint the plist**
+
+Extract exactly the XML block (from `<?xml` through `</plist>`) into
+the session scratchpad as `serve-mcp.plist`, unindented, and run:
+
+```bash
+plutil -lint <scratchpad>/serve-mcp.plist
+```
+
+Expected: `serve-mcp.plist: OK`. If plutil objects, fix the doc's block
+to match what lints.
+
+- [ ] **Step 5: Read the section once in place**
+
+Re-read the full `docs/serve-mcp.md` from "Set up a named tunnel" to
+"Check it before adding the connector" and confirm: numbering is
+consistent, the step-7 references point at an existing step 7, and no
+paragraph contradicts the flag semantics Tasks 2–3 shipped.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/serve-mcp.md
+git commit -m "docs: launch agent recipe -- serve-mcp survives closing its terminal (#93)"
+```
+
+---
+
+### Task 5: Changelog, full-suite verification, deferred systemd issue
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: everything shipped above.
+- Produces: the branch ready for `dcltdw:opening-a-pr`.
+
+- [ ] **Step 1: Changelog entries**
+
+Under `## [Unreleased]`, append to the existing `### Added` list:
+
+```markdown
+- `bunnyforge serve-mcp --auth-key-file PATH` reads the GM key from a
+  private file (refused unless it is mode 600-tight), so launchers
+  that run no shell — launchd above all — never hold the key
+  themselves. (#93)
+- `docs/serve-mcp.md`: "Make the server start on its own (macOS)" — a
+  launch agent recipe with a key file and a mandatory verification
+  step, closing the tunnel-starts-but-server-doesn't asymmetry. (#93)
+```
+
+and to the existing `### Changed` list:
+
+```markdown
+- `serve-mcp` startup refusals (no auth, bad workspace, unwritable log
+  file, missing `[mcp]` extra) exit `78` (sysexits `EX_CONFIG`) rather
+  than `1`, so `launchctl list` — and any service manager that can
+  branch on exit codes — can tell "fix the configuration" from a
+  crash. `--check` still exits `1` on a failing report. (#93)
+```
+
+- [ ] **Step 2: Bare-shape suite**
+
+Run the Global Constraints test command.
+Expected: `OK (skipped=60)`, total 962 (950 baseline + 1 from Task 2 +
+11 from Task 3; trust the OK line over this arithmetic if #94 or a
+rebase moved the count).
+
+- [ ] **Step 3: Full shape, throwaway venv (CI's mcp-suite job locally)**
+
+```bash
+cd /Users/dcltdw/Github/bunnyforge/.claude/worktrees/serve-mcp-launch-agent
+python3 -m venv "$SCRATCHPAD/venv-mcp"
+"$SCRATCHPAD/venv-mcp/bin/pip" install -q -e '.[mcp]'
+unset PYTHONPATH
+"$SCRATCHPAD/venv-mcp/bin/python3" -m unittest discover -s tests
+```
+
+(`$SCRATCHPAD` = the session's scratchpad directory; the editable
+install targets THIS worktree, so no PYTHONPATH.)
+Expected: `OK` with zero skips of the mcp variety (`skipped=0` or only
+non-mcp skips). Both shapes green is the done-bar; report the two
+summary lines verbatim.
+
+- [ ] **Step 4: File the deferred systemd follow-up**
+
+First confirm the label exists:
+`gh label list --repo dcltdw/bunnyforge --search deferred`
+(if missing, create it first:
+`gh label create deferred --repo dcltdw/bunnyforge --description "Real work, deliberately parked — revisit when the need is live (not wontfix)"`).
+
+```bash
+gh issue create --repo dcltdw/bunnyforge \
+  --title "serve-mcp: systemd unit recipe, the Linux half of the launch agent design" \
+  --label deferred --label mcp --label documentation \
+  --body "The #93 design (docs/superpowers/specs/2026-08-21-serve-mcp-launch-agent-design.md, Decision 6) shipped macOS/launchd only, because no Linux deployment exists to verify a unit against — but it made the portable choices on purpose: \`--auth-key-file\` maps onto a systemd credential or a root-owned file, and startup refusals exit 78 precisely so a unit can say \`RestartPreventExitStatus=78\` and get the refusal-vs-crash branching launchd cannot express.
+
+Parked until there is a Linux deployment to verify on (\"verify, don't assert\"). When picked up: a \`[Service]\` recipe in docs/serve-mcp.md beside the macOS one — \`Restart=on-failure\`, \`RestartPreventExitStatus=78\`, \`RestartSec=60\`, the key via \`LoadCredential\` or an 0600 file, \`--workspace\` explicit in \`ExecStart\`.
+
+Refs #93."
+```
+
+Add the new issue to the board (project 7, "bunnyforge split") if
+`gh issue view <n> --json projectItems` shows it was not auto-added.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for the launch agent recipe and its two flags (#93)"
+```
+
+- [ ] **Step 6: Open the PR**
+
+Use the `dcltdw:opening-a-pr` skill (mandatory per AGENTS.md). Body
+must carry `Closes #93`, the verification evidence from Steps 2–3, and
+note that the launchd behavior itself is doc-verified by design — the
+spec's "Verification story" section says why, and the operator's first
+run of the recipe (its step 5) is the live end-to-end.

--- a/docs/superpowers/specs/2026-08-21-serve-mcp-launch-agent-design.md
+++ b/docs/superpowers/specs/2026-08-21-serve-mcp-launch-agent-design.md
@@ -1,0 +1,265 @@
+# serve-mcp launch agent: the server survives closing its terminal
+
+**Issue:** dcltdw/bunnyforge#93
+**Date:** 2026-08-21
+**Status:** designed autonomously per the #93 brief; this document is the
+validated design pending dcltdw's review
+
+## Problem
+
+`docs/serve-mcp.md` step 6 gets the *tunnel* starting on its own, but the
+server it routes to is still a foreground process in whatever terminal
+launched it. Closing that window silently takes the MCP endpoint down and
+leaves the hostname answering 502 with a healthy tunnel in front of it —
+exactly how the outage after #88 started. The doc even names the asymmetry:
+"Starting the tunnel does not start `serve-mcp`."
+
+The design question the issue poses is not "how do I write a plist" but six
+coupled decisions: where the GM key lives, how the workspace is named, how
+the recipe is delivered, how launchd's logging interacts with `--log-file`
+(#87), what `KeepAlive` should be given that `main()` legitimately exits
+nonzero on refusals, and whether the scope is launchd only or launchd plus
+systemd. The secret decision shapes the rest, so it comes first.
+
+## Decision 1 — the GM key: a new `--auth-key-file` flag
+
+`BUNNYFORGE_MCP_KEY` is the pre-shared GM key; everything served is GM-only
+campaign material, and `~/Library/LaunchAgents` is not a secrets store.
+Four options were surveyed:
+
+- **A. `EnvironmentVariables` in the plist, with a caveat.** The key would
+  sit in plaintext in a plist that is casually readable, shows up in
+  `launchctl print`, and is the first file anyone pastes into a bug report
+  when the agent misbehaves (#90's diagnosis flow is exactly "open the
+  plist"). Rejected.
+- **B. A mode-0600 env file the agent sources.** launchd runs no shell, so
+  "sourcing" means `ProgramArguments` becomes
+  `/bin/sh -c '. file && exec …'` — a quoting-sensitive shell layer inside
+  a plist, which is the same class of silent argument bug #90 documents.
+  Rejected.
+- **C. macOS Keychain.** Sound storage, but reading it non-interactively
+  means either a shell wrapper around `security(1)` (option B's problem
+  again) or bunnyforge shelling out to a macOS-only tool. It also makes the
+  launchd and any future systemd recipes diverge at the most
+  security-sensitive step. Rejected for now; nothing below precludes
+  layering it later.
+- **D. A first-party `--auth-key-file PATH` flag.** The plist then carries
+  only a path — the same trust class as the cloudflared config path the
+  tunnel's plist already carries — and bunnyforge itself owns the safety
+  checks. Shell-free `ProgramArguments`, identical semantics on any init
+  system, refusals surface through `main()`'s existing one-line-and-exit
+  discipline, and it is testable without launchd. **Chosen.**
+
+(The issue sketches the name as `--auth-key-from-file`; `--auth-key-file`
+says the same thing shorter and reads as the sibling of `--auth-key`.)
+
+### Flag semantics
+
+`--auth-key-file PATH` reads the key from `PATH` (`~` expanded), strips
+surrounding whitespace (so a trailing newline from `echo` is harmless), and
+then behaves exactly as if that key had been passed to `--auth-key`.
+Refusals, each one line on stderr then exit (see Decision 5 for the code):
+
+- the file is missing or unreadable;
+- the file is empty after stripping;
+- on POSIX, the file is group- or other-accessible
+  (`stat.S_IMODE(mode) & 0o077`) — the message names the fix,
+  `chmod 600`. The check is skipped on non-POSIX platforms, where those
+  mode bits are fiction.
+
+Precedence and conflicts keep today's shape (explicit flag beats
+environment):
+
+- `--auth-key` > `--auth-key-file` > `$BUNNYFORGE_MCP_KEY` — except that
+  passing **both flags** is refused as ambiguous rather than silently
+  ordered.
+- `--auth-key-file` with `--no-auth` is refused, exactly like
+  `--auth-key` with `--no-auth` today. A key file that exists but loses to
+  a set `$BUNNYFORGE_MCP_KEY`? It doesn't — the file, being an explicit
+  flag, wins, matching how `--auth-key` already outranks the variable.
+
+The recommended location in the docs is
+`~/.local/state/bunnyforge/mcp-key`, alongside `mcp-oauth-state.json` —
+serve-mcp's secrets then live in one directory that "Resetting access"
+already teaches. Any path works; the flag does not special-case it.
+
+## Decision 2 — the workspace: `--workspace` in `ProgramArguments`
+
+A launchd job inherits no shell profile, which is the #89 class of
+surprise (`BUNNYFORGE_WORKSPACE` vs `BUNNYFORGE_MCP_WORKSPACE`). The plist
+therefore names the workspace as an explicit absolute `--workspace`
+argument, and the recipe's plist has **no `EnvironmentVariables` key at
+all** — with both the key and the workspace in argv there is nothing left
+to put there, and its absence removes the one tempting place to paste the
+GM key. Everything the job needs is visible in `launchctl print`'s argv,
+none of it secret.
+
+## Decision 3 — delivery: a doc recipe with the full plist inline
+
+- **A doc recipe** mirroring the tunnel section: complete plist inline,
+  followed by a mandatory verification step. **Chosen.**
+- **A template plist committed to the repo:** still needs the same five
+  hand edits (bunnyforge path, workspace, hostname, key path, log dir),
+  and a copy in `docs/examples/` drifts from the prose that explains it.
+  Rejected.
+- **A `serve-mcp --install-service` subcommand:** #90 is the cautionary
+  tale about *generated* services being silently wrong — first-party
+  generation could be done right, but it would need flags for all five
+  machine-specific values anyway (it can discover none of them), so it
+  saves only the XML syntax while adding a platform-detection and
+  idempotency surface to own. Disproportionate for a one-operator project.
+  Rejected; revisit only if the recipe demonstrably keeps going wrong.
+
+The recipe is one new section in `docs/serve-mcp.md`, "Make the server
+start on its own (macOS)", placed after "Set up a named tunnel (once)" so
+the two autostart recipes sit together. The existing "Starting the tunnel
+does not start `serve-mcp`" paragraph gains a pointer to it. #90's lesson
+is encoded the same way step 7 encodes it for the tunnel: install is not
+done until `launchctl list` shows a real PID **and**
+`bunnyforge serve-mcp --check https://<public-host>` passes.
+
+## Decision 4 — logging: `--log-file` and `Standard*Path` split the work
+
+They are complementary, not rivals, because they capture different streams:
+
+- `--log-file` (bare, so it resolves to
+  `~/Library/Logs/bunnyforge/mcp.log`) carries the request volume —
+  rotated at midnight, 14 days kept, self-pruning. This is what would
+  otherwise bloat an unrotated launchd log.
+- `StandardOutPath` and `StandardErrorPath`, both pointed at
+  `~/Library/Logs/bunnyforge/serve-mcp.launchd.log`, carry what
+  `--log-file` structurally cannot: `main()`'s refusal lines and the
+  startup banner are `print()`s emitted before uvicorn's logging exists,
+  and a crash traceback bypasses logging entirely. Without these keys a
+  refusing agent is invisible — precisely #90's failure shape.
+
+The launchd file is unrotated but effectively bounded: it receives no
+access lines, only startup banners, refusals, tracebacks, and uvicorn's
+error stream (which `_log_config` sends to stderr as well as the file, by
+design). launchd does not create parent directories for `Standard*Path`,
+so the recipe includes the `mkdir -p`.
+
+`--log-file` appears bare and last in `ProgramArguments`; with
+`nargs="?"` a following `--flag` would not be consumed either way, but
+last means nobody has to know that.
+
+## Decision 5 — restart policy: `KeepAlive` on failure, refusals exit 78
+
+The tension: a crashed server should restart itself (an unattended
+endpoint is the whole point), but `main()` legitimately exits nonzero on
+refusals — no auth, unresolvable workspace, unwritable log file, missing
+`[mcp]` extra — and restarting a refusal forever is the #90 loop. launchd
+cannot branch on exit codes, so the design makes the loop *slow, cheap,
+and diagnosable* instead of pretending it away:
+
+- `KeepAlive` = `{SuccessfulExit: false}` with `ThrottleInterval` = `60`.
+  A crash restarts within a minute; a clean shutdown (SIGTERM →
+  uvicorn's graceful exit 0, or `launchctl unload`) stays down; a refusal
+  retries at most once a minute, each attempt one line in the launchd log.
+- **Refusals now exit 78** (`EX_CONFIG` from sysexits(3), a new
+  `EXIT_CONFIG = 78` constant in `serve_mcp.py`) instead of 1. Every
+  pre-serve refusal path in `main()` changes: workspace resolution, the
+  auth conflicts and the no-auth refusal, the new key-file refusals, the
+  unwritable log file, and the `[mcp]` install hint. `launchctl list`
+  shows the last exit status, so `78` in that column says "fix the
+  configuration, restarting won't help" while `1` still means a crash.
+  `--check` keeps its documented 0-or-nonzero contract and continues to
+  exit 1: it reports on a remote server, it does not refuse to start this
+  one.
+
+Nothing couples to the old value: `scripts/mcp-session.py` tests only
+zero/nonzero, and the handful of `assertEqual(rc, 1)`-shaped tests are
+updated to 78 as part of the change. The alternative — `KeepAlive: false`,
+no restart ever — was rejected because it re-creates the outage class this
+issue exists to close, just with "crash" substituted for "closed
+terminal". Install-time verification (Decision 3) means a refusal loop can
+only arise later, from config rot, and then it is visible in two places
+and bounded to one process a minute.
+
+## Decision 6 — scope: macOS/launchd now, systemd deferred deliberately
+
+The tunnel doc's Linux coverage is one sentence; every verified deployment
+of serve-mcp is the macOS one, and a systemd unit written here could not
+be verified against a real system ("verify, don't assert"). launchd-only
+now — but the portable decisions are made portable on purpose:
+`--auth-key-file` maps directly onto a systemd credential or root-owned
+file, and exit 78 is chosen so a future unit can say
+`RestartPreventExitStatus=78` and get the refusal/crash branching launchd
+cannot express. A follow-up issue (labelled `deferred`) records the
+systemd recipe as real work parked until there is a Linux deployment to
+verify it on.
+
+## The recipe itself (shape, not final prose)
+
+1. Put the key in a file: `mkdir -p`, write the key, `chmod 600` —
+   recommended path `~/.local/state/bunnyforge/mcp-key`. Note that
+   serve-mcp refuses a group/other-readable key file.
+2. `mkdir -p ~/Library/Logs/bunnyforge` (launchd will not create it).
+3. Write `~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist`:
+
+   - `Label`: `com.bunnyforge.serve-mcp`
+   - `ProgramArguments`: absolute path to the `bunnyforge` console script
+     **from the environment that has the `[mcp]` extra** (`which
+     bunnyforge` in the shell where serve-mcp already runs), then
+     `serve-mcp`, `--workspace /abs/path`, `--public-host mcp.example.com`,
+     `--auth-key-file /abs/path/mcp-key`, `--log-file`
+   - `RunAtLoad`: true; `KeepAlive`: `{SuccessfulExit: false}`;
+     `ThrottleInterval`: 60
+   - `StandardOutPath` / `StandardErrorPath`: both
+     `~/Library/Logs/bunnyforge/serve-mcp.launchd.log` (absolute — launchd
+     does not expand `~`)
+4. `launchctl load ~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist`
+   (matching the tunnel section's load/unload vocabulary).
+5. **Verify — do not skip** (the tunnel section's step-7 discipline):
+   `launchctl list | grep bunnyforge` wants a real PID; then
+   `bunnyforge serve-mcp --check https://<public-host>` from anywhere. A
+   `-` with `78` means a refusal — read
+   `~/Library/Logs/bunnyforge/serve-mcp.launchd.log`, which names the
+   fix; `1` means a crash. After editing the plist:
+   `launchctl unload` + `load` again (the existing "unload reports
+   Input/output error but succeeded" trap is cross-referenced, not
+   repeated).
+
+Prose notes the recipe carries: a launch agent starts **at login, not at
+boot** (same trap the tunnel section names); the plist deliberately has no
+`EnvironmentVariables` (launchd inherits no shell profile — the #89 note
+covers why explicitness wins); and the agent and `scripts/mcp-session.py`
+both want port 8765, so unload the agent before running an mcp-session, or
+the session's server will fail to bind.
+
+## Code changes, in one place
+
+- `serve_mcp.py`: `--auth-key-file` in `build_parser()`; a small
+  `_read_key_file()` helper enforcing the semantics above; `EXIT_CONFIG =
+  78` and every refusal path in `main()` switched to it. No behavior
+  change for any invocation that exists today except the exit code of a
+  refusal.
+- `tests/test_serve_mcp.py`: new tests for the key-file flag (reads and
+  strips, missing, empty, lax permissions, both-flags conflict,
+  `--no-auth` conflict, flag-beats-env precedence) and the updated
+  refusal-code assertions. All of these run bare — refusals happen before
+  the SDK import, so no `[mcp]` extra is needed.
+- `docs/serve-mcp.md`: the new section, the asymmetry-paragraph pointer,
+  and a `--auth-key-file` mention where `--auth-key`/`$BUNNYFORGE_MCP_KEY`
+  are introduced.
+- `CHANGELOG.md`: `### Added` (the flag, the recipe) and `### Changed`
+  (refusals exit 78) under `[Unreleased]`.
+
+## Out of scope
+
+- A systemd unit (deferred issue, Decision 6).
+- Keychain integration (Decision 1C; nothing here precludes it).
+- `--install-service` generation (Decision 3; revisit on recurrence).
+- Any change to `scripts/mcp-session.py` — it remains the interactive,
+  by-hand alternative and reads only zero/nonzero from the server.
+
+## Verification story
+
+Unit tests cover every new refusal and the precedence rules; `plutil
+-lint` proves the doc's plist parses; the full suite runs in both CI
+shapes (bare, and with the `[mcp]` extra in a throwaway venv). The live
+`launchctl` behavior cannot be exercised from a worktree without mutating
+`~/Library/LaunchAgents` on the working machine, so — like the tunnel
+recipe in #84/#90 — the end-to-end pass happens when dcltdw runs the
+recipe once, with step 5 existing precisely to make that run
+self-verifying.

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -38,6 +38,11 @@ from bunnyforge._store import StoreError, WorkspaceStore
 
 KEY_ENV = "BUNNYFORGE_MCP_KEY"
 
+# sysexits(3) EX_CONFIG: a startup refusal. The configuration is wrong
+# and restarting cannot fix it, so a service manager (or a human reading
+# `launchctl list`) can tell it from a crash, which stays exit 1 (#93).
+EXIT_CONFIG = 78
+
 # Workspace doctrine, offered as MCP resources so a fresh conversation can
 # load the house rules before it writes anything. Absent files are simply
 # not listed -- which is also what makes campaign-doctrine.md safe to add
@@ -541,18 +546,18 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
         ws = _config.resolve_workspace(args.workspace)
     except (ConfigError, WorkspaceError) as exc:
         print(exc, file=sys.stderr)
-        return 1
+        return EXIT_CONFIG
 
     key = (args.auth_key or os.environ.get(KEY_ENV, "")).strip()
     if key and args.no_auth:
         print(f"--no-auth contradicts --auth-key/{KEY_ENV}; pick one",
               file=sys.stderr)
-        return 1
+        return EXIT_CONFIG
     if not key and not args.no_auth:
         print("refusing to start without auth: pass --auth-key, set "
               f"{KEY_ENV}, or (local testing only) pass --no-auth",
               file=sys.stderr)
-        return 1
+        return EXIT_CONFIG
 
     log_path = None
     if args.log_file is not None:
@@ -562,7 +567,7 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
             log_path.open("a").close()
         except OSError as exc:
             print(f"cannot write log file {log_path}: {exc}", file=sys.stderr)
-            return 1
+            return EXIT_CONFIG
 
     # --public-host does double duty: it names the OAuth issuer, and it
     # declares the hostname to DNS-rebinding protection in build_app (#46).
@@ -584,7 +589,7 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
                               oauth=oauth)
     except ModuleNotFoundError:
         print(_INSTALL_HINT, file=sys.stderr)
-        return 1
+        return EXIT_CONFIG
 
     app = build_app(server, public_host=args.public_host)
     if not key:

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -318,22 +318,28 @@ def _read_key_file(path_str: str) -> str:
     """
     path = Path(path_str).expanduser()
     try:
-        if os.name == "posix":
-            mode = stat.S_IMODE(path.stat().st_mode)
-            if mode & 0o077:
-                raise ValueError(
-                    f"auth key file {path} is group- or other-accessible "
-                    f"(mode {mode:03o}) -- chmod 600 it")
+        # I/O first, so a directory lands on IsADirectoryError rather
+        # than the mode check, whose chmod 600 advice would break it.
         raw = path.read_text(encoding="utf-8")
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except UnicodeDecodeError:
+        # Never interpolate the codec error: it quotes a byte of the key.
+        raise ValueError(
+            f"auth key file {path} is not valid UTF-8") from None
     except OSError as exc:
         raise ValueError(f"cannot read auth key file: {exc}") from None
+    # POSIX only; the group/other bits are fiction elsewhere.
+    if os.name == "posix" and mode & 0o077:
+        raise ValueError(
+            f"auth key file {path} is group- or other-accessible "
+            f"(mode {mode:03o}) -- chmod 600 it")
     key = raw.strip()
     if not key:
         raise ValueError(f"auth key file {path} is empty")
     return key
 
 
-def _resolve_key(args) -> str:
+def _resolve_key(args: argparse.Namespace) -> str:
     """--auth-key, else --auth-key-file, else $BUNNYFORGE_MCP_KEY.
 
     The two flags together are refused as ambiguous rather than
@@ -607,9 +613,9 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
               f"{KEY_ENV}; pick one", file=sys.stderr)
         return EXIT_CONFIG
     if not key and not args.no_auth:
-        print("refusing to start without auth: pass --auth-key, set "
-              f"{KEY_ENV}, or (local testing only) pass --no-auth",
-              file=sys.stderr)
+        print("refusing to start without auth: pass --auth-key or "
+              f"--auth-key-file, set {KEY_ENV}, or (local testing "
+              "only) pass --no-auth", file=sys.stderr)
         return EXIT_CONFIG
 
     log_path = None

--- a/src/bunnyforge/serve_mcp.py
+++ b/src/bunnyforge/serve_mcp.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import stat
 import sys
 from pathlib import Path
 from typing import NamedTuple
@@ -307,6 +308,50 @@ def _log_config(path: Path) -> dict:
     }
 
 
+def _read_key_file(path_str: str) -> str:
+    """The GM key from a file a plist can safely point at (#93).
+
+    Stripped, so a trailing newline from echo is harmless. Refused when
+    unreadable, empty, or -- on POSIX -- accessible to group or other:
+    the file stands in for a secret typed by hand, and a lax mode is a
+    misconfiguration to fix, not to serve through.
+    """
+    path = Path(path_str).expanduser()
+    try:
+        if os.name == "posix":
+            mode = stat.S_IMODE(path.stat().st_mode)
+            if mode & 0o077:
+                raise ValueError(
+                    f"auth key file {path} is group- or other-accessible "
+                    f"(mode {mode:03o}) -- chmod 600 it")
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"cannot read auth key file: {exc}") from None
+    key = raw.strip()
+    if not key:
+        raise ValueError(f"auth key file {path} is empty")
+    return key
+
+
+def _resolve_key(args) -> str:
+    """--auth-key, else --auth-key-file, else $BUNNYFORGE_MCP_KEY.
+
+    The two flags together are refused as ambiguous rather than
+    silently ordered; either flag outranks the environment variable,
+    which is how --auth-key has always behaved. Raises ValueError
+    carrying the one-line refusal; "" means no key anywhere, and the
+    default-deny check in main() owns that refusal.
+    """
+    if args.auth_key and args.auth_key_file:
+        raise ValueError("--auth-key contradicts --auth-key-file; "
+                         "pick one")
+    if args.auth_key:
+        return args.auth_key.strip()
+    if args.auth_key_file:
+        return _read_key_file(args.auth_key_file)
+    return os.environ.get(KEY_ENV, "").strip()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="bunnyforge serve-mcp",
@@ -322,6 +367,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help="pre-shared GM key typed on the OAuth consent "
                              f"page, or set {KEY_ENV}; required unless "
                              "--no-auth")
+    parser.add_argument("--auth-key-file", metavar="PATH",
+                        help="read the GM key from PATH -- for launchers "
+                             "that run no shell (a launchd agent); the "
+                             "file must not be group- or other-readable")
     parser.add_argument("--public-host",
                         help="public hostname the tunnel serves this host "
                              "as; the OAuth issuer becomes https://HOST "
@@ -548,10 +597,14 @@ def main(argv: list[str] | None = None, probe=_probe) -> int:
         print(exc, file=sys.stderr)
         return EXIT_CONFIG
 
-    key = (args.auth_key or os.environ.get(KEY_ENV, "")).strip()
+    try:
+        key = _resolve_key(args)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return EXIT_CONFIG
     if key and args.no_auth:
-        print(f"--no-auth contradicts --auth-key/{KEY_ENV}; pick one",
-              file=sys.stderr)
+        print(f"--no-auth contradicts --auth-key/--auth-key-file/"
+              f"{KEY_ENV}; pick one", file=sys.stderr)
         return EXIT_CONFIG
     if not key and not args.no_auth:
         print("refusing to start without auth: pass --auth-key, set "

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -325,12 +325,41 @@ class TestAuthKeyFile(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "chmod 600"):
             self._resolve(["--auth-key-file", str(path)])
 
+    @unittest.skipUnless(os.name == "posix", "POSIX file modes")
+    def test_directory_is_a_refusal_without_chmod_advice(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        root.chmod(0o755)
+        with self.assertRaisesRegex(ValueError,
+                                    "cannot read auth key file") as ctx:
+            self._resolve(["--auth-key-file", str(root)])
+        self.assertNotIn("chmod 600", str(ctx.exception))
+
+    def test_non_utf8_file_is_a_refusal(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        path = root / "mcp-key"
+        path.write_bytes(b"\xff\xfe")
+        path.chmod(0o600)
+        with self.assertRaisesRegex(ValueError, "not valid UTF-8") as ctx:
+            self._resolve(["--auth-key-file", str(path)])
+        self.assertIn(str(path), str(ctx.exception))
+
+    @unittest.skipUnless(os.name == "posix", "POSIX home expansion")
+    def test_expands_a_leading_tilde(self):
+        home = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        path = home / "mcp-key"
+        path.write_text("tildekey\n", encoding="utf-8")
+        path.chmod(0o600)
+        with mock.patch.dict(os.environ, {"HOME": str(home)}):
+            self.assertEqual(
+                self._resolve(["--auth-key-file", "~/mcp-key"]),
+                "tildekey")
+
     def test_both_key_flags_together_are_ambiguous(self):
         path = self._keyfile()
         with self.assertRaisesRegex(ValueError, "contradicts"):
             self._resolve(["--auth-key", "k", "--auth-key-file", str(path)])
 
-    def test_auth_key_flag_wins_without_reading_the_file(self):
+    def test_auth_key_resolves(self):
         self.assertEqual(self._resolve(["--auth-key", "k"]), "k")
 
     def test_file_outranks_the_environment(self):

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -51,7 +51,8 @@ class TestMainGuards(unittest.TestCase):
 
     def test_bad_workspace_is_one_error_line_not_a_traceback(self):
         empty = Path(self.enterContext(tempfile.TemporaryDirectory()))
-        self.assertEqual(serve_mcp.main(["--workspace", str(empty)]), 1)
+        self.assertEqual(serve_mcp.main(["--workspace", str(empty)]),
+                         serve_mcp.EXIT_CONFIG)
 
 
 class TestLogFileFlag(unittest.TestCase):
@@ -224,20 +225,20 @@ class TestStartupContract(unittest.TestCase):
 
     def test_refuses_without_key_or_no_auth(self):
         rc, err = self._main([])
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
         self.assertIn("--auth-key", err)
         self.assertIn("BUNNYFORGE_MCP_KEY", err)
         self.assertIn("--no-auth", err)
 
     def test_refuses_key_and_no_auth_together(self):
         rc, err = self._main(["--auth-key", "k", "--no-auth"])
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
         self.assertIn("contradict", err)
 
     def test_env_key_counts_as_key_for_the_contradiction(self):
         with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "k"}):
             rc, err = self._main(["--no-auth"])
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
         self.assertIn("contradict", err)
 
     def test_token_flag_is_gone(self):
@@ -256,7 +257,7 @@ class TestStartupContract(unittest.TestCase):
         with mock.patch.dict("sys.modules",
                              {"uvicorn": mock.MagicMock()}):
             rc, err = self._main(["--no-auth", "--log-file", str(target)])
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
         self.assertIn("cannot write log file", err)
         self.assertNotIn("Traceback", err)
 
@@ -268,9 +269,13 @@ class TestStartupContract(unittest.TestCase):
         with mock.patch.dict("sys.modules",
                              {"uvicorn": mock.MagicMock()}):
             rc, err = self._main(["--no-auth", "--log-file", str(target)])
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
         self.assertIn("cannot write log file", err)
         self.assertNotIn("Traceback", err)
+
+    def test_refusal_exit_code_is_ex_config(self):
+        # sysexits(3) EX_CONFIG; a service manager keys on the number.
+        self.assertEqual(serve_mcp.EXIT_CONFIG, 78)
 
 
 @unittest.skipUnless(HAVE_MCP, "mcp extra not installed")

--- a/tests/test_serve_mcp.py
+++ b/tests/test_serve_mcp.py
@@ -278,6 +278,91 @@ class TestStartupContract(unittest.TestCase):
         self.assertEqual(serve_mcp.EXIT_CONFIG, 78)
 
 
+class TestAuthKeyFile(unittest.TestCase):
+    """--auth-key-file: the key a plist can point at (#93).
+
+    Bare Python throughout: resolution and every refusal fire before
+    any SDK import.
+    """
+
+    def setUp(self):
+        self.enterContext(mock.patch.dict(
+            os.environ, {"BUNNYFORGE_MCP_KEY": ""}))
+
+    def _keyfile(self, content="sekrit\n", mode=0o600) -> Path:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        path = root / "mcp-key"
+        path.write_text(content, encoding="utf-8")
+        path.chmod(mode)
+        return path
+
+    def _resolve(self, argv):
+        args = serve_mcp.build_parser().parse_args(argv)
+        return serve_mcp._resolve_key(args)
+
+    def _ws(self) -> Path:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        (root / "campaign.toml").write_text(MINIMAL, encoding="utf-8")
+        return root
+
+    def test_reads_and_strips_the_key(self):
+        path = self._keyfile("  sekrit\n")
+        self.assertEqual(
+            self._resolve(["--auth-key-file", str(path)]), "sekrit")
+
+    def test_missing_file_is_a_refusal(self):
+        with self.assertRaisesRegex(ValueError, "cannot read"):
+            self._resolve(["--auth-key-file", "/nonexistent/mcp-key"])
+
+    def test_empty_file_is_a_refusal(self):
+        path = self._keyfile("   \n")
+        with self.assertRaisesRegex(ValueError, "empty"):
+            self._resolve(["--auth-key-file", str(path)])
+
+    @unittest.skipUnless(os.name == "posix", "POSIX file modes")
+    def test_group_or_other_readable_is_a_refusal(self):
+        path = self._keyfile(mode=0o644)
+        with self.assertRaisesRegex(ValueError, "chmod 600"):
+            self._resolve(["--auth-key-file", str(path)])
+
+    def test_both_key_flags_together_are_ambiguous(self):
+        path = self._keyfile()
+        with self.assertRaisesRegex(ValueError, "contradicts"):
+            self._resolve(["--auth-key", "k", "--auth-key-file", str(path)])
+
+    def test_auth_key_flag_wins_without_reading_the_file(self):
+        self.assertEqual(self._resolve(["--auth-key", "k"]), "k")
+
+    def test_file_outranks_the_environment(self):
+        path = self._keyfile("filekey\n")
+        with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "envkey"}):
+            self.assertEqual(
+                self._resolve(["--auth-key-file", str(path)]), "filekey")
+
+    def test_environment_still_answers_when_no_flag(self):
+        with mock.patch.dict(os.environ, {"BUNNYFORGE_MCP_KEY": "envkey"}):
+            self.assertEqual(self._resolve([]), "envkey")
+
+    def test_no_auth_conflict_through_main(self):
+        # Same default-deny contradiction as --auth-key + --no-auth.
+        path = self._keyfile()
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = serve_mcp.main(["--workspace", str(self._ws()),
+                                 "--auth-key-file", str(path), "--no-auth"])
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
+        self.assertIn("contradict", stderr.getvalue())
+
+    def test_bad_key_file_through_main_is_one_line_exit_78(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = serve_mcp.main(["--workspace", str(self._ws()),
+                                 "--auth-key-file", "/nonexistent/mcp-key"])
+        self.assertEqual(rc, serve_mcp.EXIT_CONFIG)
+        self.assertIn("cannot read auth key file", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+
 @unittest.skipUnless(HAVE_MCP, "mcp extra not installed")
 class TestBuildServer(unittest.IsolatedAsyncioTestCase):
 


### PR DESCRIPTION
Refs #93

This is the **code half** of #93. The macOS launch agent recipe — the docs half — is deliberately not here: it anchors to passages that PR #94 rewrites, and #94 is still open. The plan gated on exactly that (`Task 1`), so Tasks 2–3 shipped and Task 4 waits for #94 to merge. Hence `Refs`, not `Closes`.

## Files changed

- `docs/superpowers/specs/2026-08-21-serve-mcp-launch-agent-design.md` (new) — the approved design, six coupled decisions
- `docs/superpowers/plans/2026-08-21-serve-mcp-launch-agent.md` (new) — the implementation plan this branch executed
- `src/bunnyforge/serve_mcp.py` (modified) — `EXIT_CONFIG`, `_read_key_file`, `_resolve_key`, the `--auth-key-file` flag, six refusal sites
- `tests/test_serve_mcp.py` (modified) — new `TestAuthKeyFile` (13 tests), six refusal assertions retargeted, one exit-code pin
- `docs/serve-mcp.md` (modified) — two sentences: the `## Logging` refusal now says 78, and `## Generate a GM key (once)` names the new flag
- `CHANGELOG.md` (modified) — `### Added` and `### Changed` under `[Unreleased]`

## Work breakdown

**Startup refusals exit 78 (`EX_CONFIG`), not 1.** `serve-mcp` legitimately exits nonzero when it refuses to start — no auth, an unresolvable workspace, an unwritable log file, a `bunnyforge` without the `[mcp]` extra. In `launchctl list` those were indistinguishable from a crash, so the operator had no way to know whether restarting would help. All six refusal paths now return `EXIT_CONFIG = 78`. `--check` is untouched and still exits 0/1 — it reports on a *remote* server, it does not refuse to start this one. The number is pinned by its own test, because it is an external contract: a future systemd unit's `RestartPreventExitStatus=78` depends on it (see #95).

**`--auth-key-file PATH`.** A plist is not a secrets store — it is readable by every process running as you, echoed by `launchctl print`, and the first file anyone pastes into a bug report. So the plist carries a *path* and bunnyforge owns the safety checks: the key is read and stripped (a trailing newline from `echo` is harmless), and refused when the file is missing, unreadable, empty, not valid UTF-8, or — on POSIX — group- or other-accessible, where the message names the fix. Precedence keeps today's shape: `--auth-key` > `--auth-key-file` > `$BUNNYFORGE_MCP_KEY`, except that passing both flags is refused as ambiguous rather than silently ordered. Every refusal fires before any SDK import, so the whole surface is testable on bare Python.

**Two refusals made honest during review.** A directory passed as `PATH` used to reach the permission check and be told `chmod 600 it` — destructive advice on a directory, and the likely typo is naming the recommended *parent* `~/.local/state/bunnyforge` (which also holds `mcp-oauth-state.json`) instead of the key file inside it. I/O now runs first, so a directory lands on `cannot read auth key file: [Errno 21] Is a directory`. Separately, a non-UTF-8 file raised `UnicodeDecodeError` — a `ValueError`, not an `OSError` — which escaped the handler and produced a bare codec message naming no path, and quoting a byte of the key. It now gets its own refusal that names the path and no file content.

## Test expectations

None — both CI shapes are green, no expected failures.

- Bare (no `mcp`/`uvicorn`): `Ran 964 tests` / `OK (skipped=60)` — all 60 skips are the `[mcp]` class gates.
- Full `[mcp]` extra, throwaway venv matching CI's `mcp-suite` job: `Ran 964 tests` / `OK`, zero skips.
- `tests/check_portability.py` PASSED; `git status --porcelain` empty afterwards.
- The two reworded refusals were also checked by hand, not just by assertion: `cannot read auth key file: [Errno 21] Is a directory: '/tmp'` and `auth key file <path> is not valid UTF-8`.

## Operational impact

**One behaviour change to be aware of:** a `serve-mcp` startup refusal now exits **78** instead of 1. Anything that branches on `serve-mcp`'s exit status needs to expect it. Nothing in-repo does — `scripts/mcp-session.py` reads only zero/nonzero — and `--check` is unchanged, but a shell wrapper or CI step elsewhere testing `== 1` would silently stop matching.

No migration, no reinstall, no config change. `--auth-key-file` is purely additive; every invocation that works today works unchanged.

**Follow-ups:** #95 files the systemd unit recipe as `deferred` — the design chose 78 and a key *file* precisely so a Linux unit can say `RestartPreventExitStatus=78`, but there is no Linux deployment to verify a unit against yet. The launchd recipe itself lands once #94 merges.

## Provenance

- **Agent:** Claude Code (subagent-driven development — per-task implementers, independent reviewers per task, plus a whole-branch review and one scoped re-review of its fix wave)
- **Model / version:** the session was asked to run as Claude Opus 5 as controller and reviewer, with Claude Sonnet 5 implementers; commit trailers record the tier each seat was dispatched at. Note that a session cannot observe which model actually served it — these are the tiers requested, not an observation.
