### PR TITLE
docs: a launch agent so serve-mcp survives closing its terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ starts a fresh one.
   private file (refused unless it is mode 600-tight), so launchers
   that run no shell — launchd above all — never hold the key
   themselves. (#93)
+- `docs/serve-mcp.md`: "Make the server start on its own (macOS)" — a
+  launch agent recipe with a key file and a mandatory verification
+  step, closing the tunnel-starts-but-server-doesn't asymmetry. (#93)
 
 ### Fixed
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -19,7 +19,7 @@ command; see "One command" at the end.
 Keep it out of git. You will type it exactly once per grant, on the
 consent page in your own browser — it is never stored by claude.ai.
 For unattended starts, `--auth-key-file` reads it from a private
-file instead.
+file — the launch agent recipe below leans on that.
 
 ## Run behind a tunnel
 
@@ -155,7 +155,8 @@ Two things this deliberately does not do.
 
 **Starting the tunnel does not start `serve-mcp`.** The tunnel is the
 route; the server is still yours to run. Until it is up the hostname
-answers `502`, which is the correct answer rather than a fault.
+answers `502`, which is the correct answer rather than a fault. The
+next section closes the asymmetry.
 
 **Do not put Cloudflare Access in front of the hostname.** The instinct
 is a good one — everything served is GM-only — but the mechanism is
@@ -163,6 +164,114 @@ wrong: claude.ai has to complete this server's own OAuth flow against
 that URL, and it cannot log through an Access challenge to get there.
 The authentication is already present in the GM key and the OAuth
 grant, without which the server refuses to start.
+
+## Make the server start on its own (macOS)
+
+Step 6 got the tunnel a launch agent; this section gives `serve-mcp`
+one of its own, so neither end of the route depends on a terminal
+window staying open. The same trap applies: a launch agent starts **at
+login, not at boot**.
+
+One decision shapes the recipe: the GM key. A plist is not a secrets
+store — it is readable by every process running as you, echoed by
+`launchctl print`, and the first file you paste somewhere when
+debugging — so the key goes in a private file and the plist carries
+only its path, the same trust class as the `config.yml` path in the
+tunnel's plist. `--auth-key-file` reads it, strips a trailing newline,
+and refuses an empty or group/other-readable file.
+
+1. **Put the key in a file.** Any path works; this one sits beside the
+   OAuth state file that "Resetting access" already covers:
+
+        mkdir -p ~/.local/state/bunnyforge
+        printf '%s\n' '<your key>' > ~/.local/state/bunnyforge/mcp-key
+        chmod 600 ~/.local/state/bunnyforge/mcp-key
+
+2. **Create the log directory** — launchd does not create the parents
+   of its log paths:
+
+        mkdir -p ~/Library/Logs/bunnyforge
+
+3. **Write `~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist`.**
+   Every path must be absolute: launchd expands no `~` and reads no
+   shell profile — which is also why the workspace travels as
+   `--workspace` rather than `$BUNNYFORGE_WORKSPACE`, and why there is
+   no `EnvironmentVariables` block at all. The first string is the
+   `bunnyforge` that has the `[mcp]` extra: `which bunnyforge` from
+   the shell where `serve-mcp` already runs by hand.
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+          "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>com.bunnyforge.serve-mcp</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>/absolute/path/to/bunnyforge</string>
+                <string>serve-mcp</string>
+                <string>--workspace</string>
+                <string>/absolute/path/to/campaign</string>
+                <string>--public-host</string>
+                <string>mcp.example.com</string>
+                <string>--auth-key-file</string>
+                <string>/Users/you/.local/state/bunnyforge/mcp-key</string>
+                <string>--log-file</string>
+            </array>
+            <key>RunAtLoad</key>
+            <true/>
+            <key>KeepAlive</key>
+            <dict>
+                <key>SuccessfulExit</key>
+                <false/>
+            </dict>
+            <key>ThrottleInterval</key>
+            <integer>60</integer>
+            <key>StandardOutPath</key>
+            <string>/Users/you/Library/Logs/bunnyforge/serve-mcp.launchd.log</string>
+            <key>StandardErrorPath</key>
+            <string>/Users/you/Library/Logs/bunnyforge/serve-mcp.launchd.log</string>
+        </dict>
+        </plist>
+
+   Two log destinations on purpose, doing different work. Bare
+   `--log-file` carries the request volume to
+   `~/Library/Logs/bunnyforge/mcp.log`, rotated at midnight, 14 days
+   kept. The launchd log carries only what that file structurally
+   cannot: the startup banner, the one-line refusals printed before
+   any logging exists, and crash tracebacks. It is unrotated, but it
+   receives no access lines, so it stays small.
+
+4. **Load it:**
+
+        launchctl load ~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist
+
+5. **Check that it actually starts** — step 7's discipline, unchanged:
+
+        launchctl list | grep com.bunnyforge.serve-mcp
+        bunnyforge serve-mcp --check https://mcp.example.com
+
+   A real PID in the first column and a passing check means done. A
+   `-` with `78` beside it is a **refusal**: the configuration is
+   wrong, restarting will not help, and the last line of
+   `~/Library/Logs/bunnyforge/serve-mcp.launchd.log` names the fix — a
+   bad workspace path, a key file that is missing or too open, a
+   `bunnyforge` without the `[mcp]` extra. Any other nonzero status is
+   a crash. `KeepAlive` restarts crashes within a minute; refusals it
+   retries at most once a minute (`ThrottleInterval`), so a broken
+   config surfaces here and in the log instead of spinning every five
+   seconds — the loop step 7 warns about.
+
+   After editing the plist, `launchctl unload` then `load` again.
+   Step 7's two traps apply verbatim: `unload` can report
+   `Input/output error` having succeeded, and `sudo` addresses the
+   wrong domain entirely.
+
+One conflict worth knowing: the agent and `scripts/mcp-session.py`
+both want port 8765. While the agent is loaded, an mcp-session's
+server cannot bind — `launchctl unload` the agent first when you want
+the interactive route back.
 
 ## Check it before adding the connector
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -181,10 +181,14 @@ tunnel's plist. `--auth-key-file` reads it, strips a trailing newline,
 and refuses an empty or group/other-readable file.
 
 1. **Put the key in a file.** Any path works; this one sits beside the
-   OAuth state file that "Resetting access" already covers:
+   OAuth state file that "Resetting access" already covers. The
+   `umask` matters here: a bare redirect creates the file under your
+   shell's default mode (often `644`) and it sits world-readable until
+   `chmod` runs a line later — exactly the condition `--auth-key-file`
+   refuses.
 
         mkdir -p ~/.local/state/bunnyforge
-        printf '%s\n' '<your key>' > ~/.local/state/bunnyforge/mcp-key
+        (umask 077; printf '%s\n' '<your key>' > ~/.local/state/bunnyforge/mcp-key)
         chmod 600 ~/.local/state/bunnyforge/mcp-key
 
 2. **Create the log directory** — launchd does not create the parents
@@ -239,11 +243,23 @@ and refuses an empty or group/other-readable file.
    `--log-file` carries the request volume to
    `~/Library/Logs/bunnyforge/mcp.log`, rotated at midnight, 14 days
    kept. The launchd log carries only what that file structurally
-   cannot: the startup banner, the one-line refusals printed before
-   any logging exists, and crash tracebacks. It is unrotated, but it
-   receives no access lines, so it stays small.
+   cannot: the one-line refusals printed before any logging exists,
+   and crash tracebacks. It is unrotated, but it receives no access
+   lines, so it stays small. The startup banner itself is not among
+   these — it is a plain `print()` to stdout, launchd redirects
+   stdout to this same file, and a file (unlike a terminal) makes
+   Python block-buffer it; the process then blocks inside
+   `uvicorn.run()` indefinitely, so that buffer never flushes and the
+   banner never lands here at all. Uvicorn's own `Uvicorn running
+   on …` line does — it goes to stderr, which is line-buffered — and
+   is the signal a healthy start actually leaves behind.
 
-4. **Load it:**
+4. **Quit any by-hand `serve-mcp` first, then load it.** The agent
+   binds the same port 8765; while a hand-run server — from "Run
+   behind a tunnel," or from proving the path by hand when setting up
+   the tunnel — still holds it, the agent's own start fails, and the
+   next step's `--check` still *passes*, because the hand-run server
+   is the one answering it.
 
         launchctl load ~/Library/LaunchAgents/com.bunnyforge.serve-mcp.plist
 
@@ -254,13 +270,16 @@ and refuses an empty or group/other-readable file.
 
    A real PID in the first column and a passing check means done. A
    `-` with `78` beside it is a **refusal**: the configuration is
-   wrong, restarting will not help, and the last line of
+   wrong, restarting will not help, and
    `~/Library/Logs/bunnyforge/serve-mcp.launchd.log` names the fix — a
    bad workspace path, a key file that is missing or too open, a
    `bunnyforge` without the `[mcp]` extra. Any other nonzero status is
-   a crash. `KeepAlive` restarts crashes within a minute; refusals it
-   retries at most once a minute (`ThrottleInterval`), so a broken
-   config surfaces here and in the log instead of spinning every five
+   usually a crash, but the likeliest one here is not: something else
+   — most often a hand-run `serve-mcp` you forgot to quit — already
+   holds port 8765, and the agent exits 1 trying to bind it.
+   `KeepAlive` restarts crashes within a minute; refusals it retries
+   at most once a minute (`ThrottleInterval`), so a broken config
+   surfaces here and in the log instead of spinning every five
    seconds — the loop step 7 warns about.
 
    After editing the plist, `launchctl unload` then `load` again.
@@ -400,7 +419,9 @@ players even by accident.
 
 ## Resetting access
 
-Delete the token state file and restart the server:
+Delete the token state file and restart the server (as a launch agent:
+`launchctl kickstart -k gui/$(id -u)/com.bunnyforge.serve-mcp`, or
+unload then load):
 
     rm ~/.local/state/bunnyforge/mcp-oauth-state.json
 
@@ -440,6 +461,9 @@ to its own `server.log`; it needs no flag and is unchanged.
 - **502 from the public hostname:** the tunnel is up and the server is
   not, or the server is on a port the `ingress` rule does not name. Start
   `serve-mcp`; check the port in `~/.cloudflared/config.yml` matches.
+  Running it as a launch agent instead? Don't start it by hand — see
+  "Make the server start on its own" above: `launchctl list`, a `78`
+  exit, and the launchd log are the first three things to check.
 - **421 Invalid Host header through a tunnel:** DNS-rebinding protection
   does not know your public hostname. Pass `--public-host <hostname>` —
   the same hostname the tunnel serves, with no scheme and no port. The


### PR DESCRIPTION
Closes #93

The docs half of #93, and the second of its two PRs. #96 shipped the code — `--auth-key-file` and refusals exiting 78 — and was deliberately `Refs`, not `Closes`, because this recipe was gated on #94 rewriting the passages it anchors to. #94 has merged, so this lands on top of it.

Base is `main`, not stacked.

## Files changed

- `docs/serve-mcp.md` (modified) — the new `## Make the server start on its own (macOS)` section, plus four pointers and corrections elsewhere on the page
- `CHANGELOG.md` (modified) — the one `### Added` bullet #96 held back, because the section it describes did not exist yet

## Work breakdown

**The recipe.** Step 6 of the tunnel section already gets *cloudflared* a launch agent; the server it routes to was still a foreground process, so closing that terminal took the endpoint down and left the hostname answering 502 behind a healthy tunnel. This adds the matching agent: put the key in a mode-600 file, create the log directory launchd will not create for you, write the plist, load it, and — the step that matters — verify. The plist deliberately has **no `EnvironmentVariables` key at all**: with the workspace in `--workspace` and the key behind `--auth-key-file`, nothing is left to put there, which removes the one tempting place to paste the GM key. `plutil -lint` passes on the block as printed.

**Four fixes elsewhere on the page**, all found by walking the recipe as an operator rather than reading the diff:

- **The port clash.** Someone following the page in order still has a `serve-mcp` running by hand when they reach `launchctl load`. The agent then cannot bind 8765 and exits 1 — while the verification step's `--check` *passes*, because the hand-run server is the one answering. Step 4 now says to quit it first, and step 5 names the port as the likeliest cause of a nonzero status.
- **The startup banner never reaches the launchd log.** The draft claimed it did, and so does the design spec. It does not: the banner is a `print()` to stdout, which under launchd is a file and therefore block-buffered, and the process then blocks in `uvicorn.run()` indefinitely, so it never flushes. Refusals and tracebacks *do* land, because they go to stderr. Confirmed empirically twice. The prose now points at uvicorn's own start line as the healthy-start signal instead. **The spec is wrong on this point** (`…-design.md`, Decision 4) — flagging it rather than editing a committed design record.
- **The Troubleshooting 502 entry** was the index entry for exactly the failure this section exists to eliminate, and still said "Start `serve-mcp`" with no pointer to `launchctl list` or exit 78.
- **`## Resetting access`**'s "restart the server" had no launch-agent meaning; it now names `launchctl kickstart -k`.

Two smaller corrections: the key file is now written under `(umask 077)` so it is never world-readable even for an instant — the exact condition `--auth-key-file` refuses, in a recipe whose thesis is that the key must not be casually readable — and "the *last line* of the log names the fix" became "the log names the fix", because the bad-workspace refusal is a four-line card ending in a README link.

## Test expectations

None — this changes no code, and the suite is unchanged at `Ran 964 tests` / `OK (skipped=60)`. `plutil -lint` on the plist returns OK. The reviewer also ran the doc's new `umask` sequence against a scratch path under `umask 022` and confirmed the file is 600 at first `stat` with no intermediate 644, then fed the result through the real `_read_key_file` to confirm it is accepted.

**The live `launchctl` behaviour is doc-verified by design, not asserted.** Exercising it means mutating `~/Library/LaunchAgents` on this machine, so the spec's verification story defers the end-to-end to your first run of the recipe — which is exactly why its step 5 is written to be self-verifying.

## Operational impact

No code change, so nothing to deploy or migrate. The recipe is opt-in.

Two things worth knowing if you run it: a launch agent starts **at login, not at boot** (the same trap the tunnel section names), and the agent and `scripts/mcp-session.py` both want port 8765 — `launchctl unload` the agent when you want the interactive route back.

**Follow-up, filed not fixed:** #97 — the `## Logging` section (pre-existing, from #88) still says the startup banner "reaches stderr". Correcting one half of that claim here means the page now contradicts itself until #97 lands; it is out of this PR's scope because the falsehood predates it. #95 remains parked for the systemd half.

## Provenance

- **Agent:** Claude Code (subagent-driven development — a task implementer, an independent task reviewer, a whole-branch reviewer briefed to look where the task review could not, one fix wave, and a scoped re-review of it)
- **Model / version:** the session was asked to run as Claude Opus 5 as controller and reviewer, with Claude Sonnet 5 implementers; commit trailers record the tier each seat was dispatched at. A session cannot observe which model actually served it — these are the tiers requested, not an observation.
