### PR TITLE
docs: the startup banner goes to stdout, not stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ starts a fresh one.
   --help` into the test suite's output — which since #87 included the
   running machine's home directory, by way of the `--log-file` default
   path. (#92)
+- `docs/serve-mcp.md`'s Logging section no longer lists the startup
+  banner among the things that reach stderr. It goes to stdout, which
+  under a launch agent is a block-buffered file the server never gets
+  to flush — so the one line naming the resolved log path was
+  invisible for exactly the readers most likely to go looking. (#97)
 
 ### Changed
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -447,10 +447,13 @@ prunes its own logs, nothing else to configure. If the file can't be
 written, `serve-mcp` refuses with one line and exits 78 (`EX_CONFIG`)
 rather than starting up and failing later.
 
-Access lines go only to the file. Errors — the startup banner, bind
-failures, tracebacks — still reach stderr as well, so a crashed server
-says why in the terminal and the file keeps the same errors alongside
-the access lines.
+Access lines go only to the file. Errors — bind failures, tracebacks —
+still reach stderr as well, so a crashed server says why in the
+terminal and the file keeps the same errors alongside the access
+lines. The startup banner is not one of them: it goes to stdout, which
+under a launch agent is a block-buffered file the server never gets to
+flush, so it appears only once the process stops. Uvicorn's own
+`Uvicorn running on` line is the healthy-start signal to read there.
 
 `scripts/mcp-session.py` already captures the whole stdout/stderr stream
 to its own `server.log`; it needs no flag and is unchanged.


### PR DESCRIPTION
Closes #97

A one-paragraph correction: `docs/serve-mcp.md`'s Logging section listed the startup banner among the things that reach stderr. It does not.

Base is `main`, not stacked.

## Files changed

- `docs/serve-mcp.md` (modified) — the Logging section's stderr sentence
- `CHANGELOG.md` (modified) — one `### Fixed` entry under `[Unreleased]`

## Work breakdown

Both banner lines — `serving <name> at http://…` and `access log: <path> (rotated at midnight, 14 kept)` — are plain `print()` calls with no `file=`, so they go to **stdout**. Under a launch agent stdout is a redirected file, hence block-buffered, and the server then blocks in `uvicorn.run()` until it stops. The banner therefore never flushes while the server is alive.

That matters more than a pedantic correction, because the `access log:` line is the *only* place the resolved log path is printed — so it was invisible to precisely the readers most likely to go looking for it.

Bind failures and tracebacks are unaffected and genuinely do reach stderr: `uvicorn` and `uvicorn.error` are wired to both the `file` and `stderr` handlers, and an uncaught traceback goes to stderr directly. The corrected sentence keeps that claim and drops only the banner, then names uvicorn's own `Uvicorn running on` line as the healthy-start signal to read instead.

The launch agent section added in #93 already stated the corrected behaviour, so until now the page contradicted itself. This closes that.

## Test expectations

None — no code changed; the suite is unchanged at `Ran 964 tests` / `OK (skipped=60)`. The buffering behaviour was reproduced directly (a `print()` to a redirected stdout plus a sleep: the file stays empty until the process exits), and confirmed live on a running launch agent, whose log carries uvicorn's start line and no banner.

## Operational impact

None. Documentation only.

## Provenance

- **Agent:** Claude Code
- **Model / version:** the session was asked to run as Claude Opus 5; the commit trailer records that. A session cannot observe which model actually served it — this is the tier requested, not an observation.
