### PR TITLE
docs: an mcp-session stops the launch agent, it does not fail to bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ starts a fresh one.
   --help` into the test suite's output — which since #87 included the
   running machine's home directory, by way of the `--log-file` default
   path. (#92)
+- `docs/serve-mcp.md` no longer claims an mcp-session "cannot bind"
+  while the launch agent holds port 8765. It stops the agent's server
+  instead — and because that is a SIGTERM, the exit is clean and
+  `KeepAlive` leaves it down, silently. The page now says so, offers
+  `--port` as the conflict-free route, and names `launchctl kickstart`
+  as the way back. (#99)
 
 ### Changed
 

--- a/docs/serve-mcp.md
+++ b/docs/serve-mcp.md
@@ -287,10 +287,25 @@ and refuses an empty or group/other-readable file.
    `Input/output error` having succeeded, and `sudo` addresses the
    wrong domain entirely.
 
-One conflict worth knowing: the agent and `scripts/mcp-session.py`
-both want port 8765. While the agent is loaded, an mcp-session's
-server cannot bind — `launchctl unload` the agent first when you want
-the interactive route back.
+One conflict worth knowing, and it is sharper than it looks: the
+agent and `scripts/mcp-session.py` both default to port 8765. The
+mcp-session does not politely fail to bind — it stops whatever
+`serve-mcp` is holding the port, which is your agent's server, and
+says so in one line. Worse, that stop is a SIGTERM, so the exit is a
+clean `0`, and `KeepAlive` is `{SuccessfulExit: false}` precisely so
+clean exits stay down. Your agent is then off with nothing in the
+launchd log to say why — a graceful shutdown is not a refusal.
+
+Give the mcp-session its own port instead, which `--port` passes to
+both the quick tunnel and the server:
+
+    scripts/mcp-session.py --port 8766 --verify
+
+That leaves the agent untouched. If you would rather have the port
+back, `launchctl unload` the agent first — deliberate, and equally
+fine. To restore an agent an mcp-session already stopped:
+
+    launchctl kickstart -k gui/$(id -u)/com.bunnyforge.serve-mcp
 
 ## Check it before adding the connector
 


### PR DESCRIPTION
Closes #99

The launch agent recipe's closing paragraph described the wrong failure. Found while commissioning the #93 agent on a real machine.

Base is `main`, not stacked.

## Files changed

- `docs/serve-mcp.md` (modified) — the port-conflict paragraph at the end of "Make the server start on its own (macOS)"
- `CHANGELOG.md` (modified) — one `### Fixed` entry under `[Unreleased]`

## Work breakdown

The paragraph said that while the agent holds 8765, an mcp-session's server "cannot bind". It binds fine. `clear_port()` in `scripts/mcp-session.py` looks up whatever is LISTENing on the port and, if the command matches `serve-mcp`, SIGTERMs it — and the launch agent's child qualifies. So the mcp-session does not politely lose the race; it stops your agent and prints one line saying so.

The second half is the part that actually bites. SIGTERM gives uvicorn a graceful shutdown, so the process exits **0** — and the recipe's `KeepAlive` is `{SuccessfulExit: false}` *by design*, so launchd does not restart a clean exit. The agent is left down, with nothing in the launchd log to explain it, because a graceful shutdown is not a refusal. The two mechanisms are individually correct and compose into a silent disable.

The paragraph now says that, and offers the escape the old text didn't mention: `--port` reaches **both** the quick tunnel and the server (`start_tunnel(args.port)` and `start_server(…, args.port, …)`), so `--port 8766` gives a fully independent stack alongside the running agent — nothing killed, nothing to restore. `launchctl unload` first remains valid as the deliberate choice, and `launchctl kickstart -k` is named as the way back for an agent an mcp-session already stopped.

Worth noting `clear_port` is not reckless: it refuses outright, rather than killing, when the port holder is not a `serve-mcp`. The hazard is specific to the agent-versus-mcp-session case this paragraph exists to cover.

## Test expectations

None — no code changed; the suite is unchanged at `Ran 964 tests` / `OK (skipped=60)`. The behaviour was read off `scripts/mcp-session.py` (`clear_port`, `port_holder`, and `--port`'s two call sites) rather than inferred, and the `KeepAlive` half is what the recipe's own plist already specifies.

## Operational impact

Documentation only — but it corrects guidance an operator with a live launch agent could act on and lose their agent to.

## Provenance

- **Agent:** Claude Code
- **Model / version:** the session was asked to run as Claude Opus 5; the commit trailer records that. A session cannot observe which model actually served it — this is the tier requested, not an observation.
