### PR TITLE
chore: ignore .DS_Store in the repo and in the campaign workspace template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 dist/
 build/
 .venv-mcp/
+.DS_Store
+
+# A GM key kept for local testing -- never versioned.
+gm-secret.txt

--- a/src/bunnyforge/data/root/gitignore
+++ b/src/bunnyforge/data/root/gitignore
@@ -14,3 +14,6 @@ __pycache__/
 # it is the committed baseline.
 .bunnyforge/wiki-token
 .bunnyforge/wiki-drift/
+
+# macOS Finder litter, created in any folder it visits.
+.DS_Store


### PR DESCRIPTION
Closes #102

Base is `main`, not stacked.

## Files changed

- `.gitignore` (modified) — `.DS_Store`, plus a `gm-secret.txt` rule that had been sitting uncommitted
- `src/bunnyforge/data/root/gitignore` (modified) — `.DS_Store` in the campaign workspace template

**No changelog entry**, deliberately: this is ignore-file hygiene. The one product-visible edge — `bunnyforge init` writing one extra ignore line — is additive and changes nothing about an existing workspace, so it does not warrant a `[Unreleased]` entry. Stating the omission rather than leaving it silent.

## Work breakdown

**Two `.gitignore` files were relevant, not one.** The obvious one is the repo's own, which had four stray `.DS_Store` files sitting untracked. The one easy to miss is `src/bunnyforge/data/root/gitignore` — the template `bunnyforge init` installs as `.gitignore` in every new campaign workspace (`init.py:84`). A campaign folder is one its owner browses in Finder constantly, so it collects `.DS_Store` at least as fast as the repo does. A bare pattern with no slash matches at every depth, so it's one line in each file.

**The `gm-secret.txt` rule was already in the working tree, uncommitted.** The file it names exists in the repo root, so until now the only thing stopping it from being staged was a line that a `git checkout .gitignore`, a reset, or a fresh clone would remove. Committing it makes the protection durable. This was raised and confirmed before including it.

Worth stating plainly, and it's in the commit message too: **this does nothing for existing campaign workspaces.** Their `.gitignore` was copied at `init` time and is now a normal file in that repo — the line has to be added by hand.

## Test expectations

None — suite unchanged at `Ran 964 tests` / `OK (skipped=60)`, confirming no test pins the template's contents.

Both halves were verified rather than assumed:

- `git check-ignore -v` confirms the repo rule matches at every depth that had a stray file (`.DS_Store`, `docs/.DS_Store`, `docs/superpowers/.DS_Store`, `samples/.DS_Store`) and that `gm-secret.txt` matches.
- End-to-end: ran `bunnyforge init` into a throwaway directory, confirmed the generated campaign `.gitignore` carries the new section, and `git check-ignore` inside that fresh campaign confirms `.DS_Store` is ignored there.

## Operational impact

None for the repo side. On the product side, `bunnyforge init` writes one extra ignore line — additive, and it changes nothing about an existing workspace.

## Provenance

- **Agent:** Claude Code
- **Model / version:** the session was asked to run as Claude Opus 5; the commit trailers record that. A session cannot observe which model actually served it — this is the tier requested, not an observation.
